### PR TITLE
[feat] show no endpoint screen over error

### DIFF
--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -492,6 +492,9 @@ const kAudioError =
 const kRaiseIssue =
     "\nPlease raise an issue in API Dash GitHub repo so that we can resolve it.";
 
+const kNoAPIEndpoint =
+    "\nOops! It looks like you haven't entered a URL. \n \n Remember, even the best code generators need a little spark of inspiration - and that's your URL!";
+
 const kHintTextUrlCard = "Enter API endpoint like api.foss42.com/country/codes";
 const kLabelPlusNew = "+ New";
 const kLabelSend = "Send";

--- a/lib/screens/home_page/editor_pane/details_card/code_pane.dart
+++ b/lib/screens/home_page/editor_pane/details_card/code_pane.dart
@@ -12,15 +12,26 @@ class CodePane extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final selectedRequestModel = ref.watch(selectedRequestModelProvider);
+
+    if (selectedRequestModel != null || selectedRequestModel!.url == '') {
+      return const ErrorMessage(
+        showIssueButton: false,
+        icon: Icons.info_outline_rounded,
+        message: kNoAPIEndpoint,
+      );
+    }
+
     final CodegenLanguage codegenLanguage =
         ref.watch(codegenLanguageStateProvider);
 
-    final selectedRequestModel = ref.watch(selectedRequestModelProvider);
     final defaultUriScheme =
         ref.watch(settingsProvider.select((value) => value.defaultUriScheme));
-
     final code = codegen.getCode(
-        codegenLanguage, selectedRequestModel!, defaultUriScheme);
+      codegenLanguage,
+      selectedRequestModel,
+      defaultUriScheme,
+    );
     if (code == null) {
       return const ErrorMessage(
         message: "An error was encountered while generating code. $kRaiseIssue",

--- a/lib/widgets/error_message.dart
+++ b/lib/widgets/error_message.dart
@@ -7,11 +7,13 @@ class ErrorMessage extends StatelessWidget {
     super.key,
     required this.message,
     this.showIcon = true,
+    this.icon = Icons.warning_rounded,
     this.showIssueButton = true,
   });
 
   final String? message;
   final bool showIcon;
+  final IconData icon;
   final bool showIssueButton;
 
   @override
@@ -25,7 +27,7 @@ class ErrorMessage extends StatelessWidget {
           children: [
             showIcon
                 ? Icon(
-                    Icons.warning_rounded,
+                    icon,
                     size: 40,
                     color: color,
                   )

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -625,6 +625,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -677,10 +701,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   mime:
     dependency: transitive
     description:


### PR DESCRIPTION
**Description:**

This PR resolves the issue titled  #183 . 

Previously, clicking the "view code" button with an empty URL field would trigger errors in certain code generators. 
With this fix, instead of throwing an error, a placeholder widget will be shown asking user to provide appropriate endpoint.

<details>
<summary>Preview</summary>

![image](https://github.com/foss42/apidash/assets/84124091/704398c4-e2de-4777-ae26-c4e47bfd1f1c)

</details>

**Additional Changes:**

- Tests will be added once all feedbacks are implemented.

This enhancement ensures smoother user experience and better error handling. 

Please review and provide feedback. 
Thank you!