### PR TITLE
textfield alignment

### DIFF
--- a/lib/widgets/textfields.dart
+++ b/lib/widgets/textfields.dart
@@ -95,7 +95,6 @@ class JsonSearchField extends StatelessWidget {
       controller: controller,
       onChanged: onChanged,
       style: kCodeStyle,
-      cursorHeight: 18,
       decoration: const InputDecoration(
         isDense: true,
         border: InputBorder.none,


### PR DESCRIPTION
There was an alignment issue in response screen search text field
before it looked like this 
![Screenshot 2024-02-26 040239](https://github.com/foss42/apidash/assets/85278795/92294440-5055-4ed0-9c02-3c3e42ef2653)

now it looks like this 
![Screenshot 2024-02-26 041106](https://github.com/foss42/apidash/assets/85278795/17b490f5-f011-4867-a071-0913cb58c3ad)

is this fine ?
