### PR TITLE
Added arrow keys navigation

### DIFF
--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_headers.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_headers.dart
@@ -19,6 +19,7 @@ class EditRequestHeadersState extends ConsumerState<EditRequestHeaders> {
   late List<NameValueModel> rows;
   late List<bool> isRowEnabledList;
   late int seed;
+  final FocusNode headerValueFocus = FocusNode();
 
   @override
   void initState() {
@@ -76,15 +77,23 @@ class EditRequestHeadersState extends ConsumerState<EditRequestHeaders> {
           grow: 1,
           cellBuilder: (_, row) {
             int idx = row.index;
-            return HeaderField(
-              keyId: "$selectedId-$idx-headers-k-$seed",
-              initialValue: rows[idx].name,
-              hintText: "Add Header Name",
-              onChanged: (value) {
-                rows[idx] = rows[idx].copyWith(name: value);
-                _onFieldChange(selectedId!);
+            return KeyboardListener(
+              focusNode: FocusNode(),
+              onKeyEvent: (KeyEvent event) {
+                if (event.logicalKey.keyId == 4294967309) {
+                  headerValueFocus.requestFocus();
+                }
               },
-              colorScheme: Theme.of(context).colorScheme,
+              child: HeaderField(
+                keyId: "$selectedId-$idx-headers-k-$seed",
+                initialValue: rows[idx].name,
+                hintText: "Add Header Name",
+                onChanged: (value) {
+                  rows[idx] = rows[idx].copyWith(name: value);
+                  _onFieldChange(selectedId!);
+                },
+                colorScheme: Theme.of(context).colorScheme,
+              ),
             );
           },
           sortable: false,
@@ -107,6 +116,7 @@ class EditRequestHeadersState extends ConsumerState<EditRequestHeaders> {
               keyId: "$selectedId-$idx-headers-v-$seed",
               initialValue: rows[idx].value,
               hintText: " Add Header Value",
+              focusNode: headerValueFocus,
               onChanged: (value) {
                 rows[idx] = rows[idx].copyWith(value: value);
                 _onFieldChange(selectedId!);

--- a/lib/widgets/headerfield.dart
+++ b/lib/widgets/headerfield.dart
@@ -1,7 +1,9 @@
 import 'package:apidash/utils/header_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:apidash/consts.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';
+import 'package:provider/provider.dart';
 
 class HeaderField extends StatefulWidget {
   const HeaderField({
@@ -24,7 +26,9 @@ class HeaderField extends StatefulWidget {
 
 class _HeaderFieldState extends State<HeaderField> {
   final TextEditingController controller = TextEditingController();
-
+  final SuggestionsController suggestionsController = SuggestionsController();
+  final ScrollController scrollController = ScrollController();
+  final FocusNode focusNode = FocusNode();
   @override
   void initState() {
     super.initState();
@@ -52,66 +56,70 @@ class _HeaderFieldState extends State<HeaderField> {
   Widget build(BuildContext context) {
     var colorScheme = widget.colorScheme ?? Theme.of(context).colorScheme;
     return TypeAheadField(
-      key: Key(widget.keyId),
-      hideOnEmpty: true,
-      minCharsForSuggestions: 1,
-      onSuggestionSelected: (value) {
-        setState(() {
-          controller.text = value;
-        });
-        widget.onChanged!.call(value);
-      },
-      itemBuilder: (context, String suggestion) {
-        return ListTile(
-          dense: true,
-          title: Text(suggestion),
-        );
-      },
-      suggestionsCallback: headerSuggestionCallback,
-      suggestionsBoxDecoration: suggestionBoxDecorations(context),
-      textFieldConfiguration: TextFieldConfiguration(
-        onChanged: widget.onChanged,
         controller: controller,
-        style: kCodeStyle.copyWith(
-          color: colorScheme.onSurface,
-        ),
-        decoration: InputDecoration(
-          hintStyle: kCodeStyle.copyWith(
-            color: colorScheme.outline.withOpacity(
-              kHintOpacity,
+        suggestionsController: suggestionsController,
+        key: Key(widget.keyId),
+        hideOnEmpty: true,
+        onSelected: (value) {
+          setState(() {
+            controller.text = value;
+          });
+          widget.onChanged!.call(value);
+        },
+        itemBuilder: (context, suggestion) {
+          return ListTile(
+            dense: true,
+            title: Text(suggestion),
+          );
+        },
+        suggestionsCallback: headerSuggestionCallback,
+        constraints: const BoxConstraints(maxHeight: 400),
+        decorationBuilder: (context, child) {
+          return Material(
+            elevation: 4,
+            shape: RoundedRectangleBorder(
+              side: BorderSide(
+                color: Theme.of(context).dividerColor,
+                width: 1.2,
+              ),
+              borderRadius:
+                  const BorderRadius.vertical(bottom: Radius.circular(8)),
             ),
-          ),
-          hintText: widget.hintText,
-          focusedBorder: UnderlineInputBorder(
-            borderSide: BorderSide(
-              color: colorScheme.primary.withOpacity(
-                kHintOpacity,
+            clipBehavior: Clip.hardEdge,
+            child: child,
+          );
+        },
+        direction: VerticalDirection.down,
+        builder: (context, controller, focusNode) {
+          return TextField(
+            onChanged: widget.onChanged,
+            controller: controller,
+            focusNode: focusNode,
+            style: kCodeStyle.copyWith(
+              color: colorScheme.onSurface,
+            ),
+            decoration: InputDecoration(
+              hintStyle: kCodeStyle.copyWith(
+                color: colorScheme.outline.withOpacity(
+                  kHintOpacity,
+                ),
+              ),
+              hintText: widget.hintText,
+              focusedBorder: UnderlineInputBorder(
+                borderSide: BorderSide(
+                  color: colorScheme.primary.withOpacity(
+                    kHintOpacity,
+                  ),
+                ),
+              ),
+              enabledBorder: UnderlineInputBorder(
+                borderSide: BorderSide(
+                  color: colorScheme.surfaceVariant,
+                ),
               ),
             ),
-          ),
-          enabledBorder: UnderlineInputBorder(
-            borderSide: BorderSide(
-              color: colorScheme.surfaceVariant,
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  SuggestionsBoxDecoration suggestionBoxDecorations(BuildContext context) {
-    return SuggestionsBoxDecoration(
-      elevation: 4,
-      constraints: const BoxConstraints(maxHeight: 400),
-      shape: RoundedRectangleBorder(
-        side: BorderSide(
-          color: Theme.of(context).dividerColor,
-          width: 1.2,
-        ),
-        borderRadius: const BorderRadius.vertical(bottom: Radius.circular(8)),
-      ),
-      clipBehavior: Clip.hardEdge,
-    );
+          );
+        });
   }
 
   Future<List<String>> headerSuggestionCallback(String pattern) async {

--- a/lib/widgets/textfields.dart
+++ b/lib/widgets/textfields.dart
@@ -41,6 +41,7 @@ class CellField extends StatelessWidget {
     this.hintText,
     this.onChanged,
     this.colorScheme,
+    this.focusNode,
   });
 
   final String keyId;
@@ -48,11 +49,13 @@ class CellField extends StatelessWidget {
   final String? hintText;
   final void Function(String)? onChanged;
   final ColorScheme? colorScheme;
+  final FocusNode? focusNode;
 
   @override
   Widget build(BuildContext context) {
     var clrScheme = colorScheme ?? Theme.of(context).colorScheme;
     return TextFormField(
+      focusNode: focusNode,
       key: Key(keyId),
       initialValue: initialValue,
       style: kCodeStyle.copyWith(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
   json_annotation: ^4.8.1
   printing: ^5.11.1
   package_info_plus: ^4.1.0
-  flutter_typeahead: ^4.8.0
+  flutter_typeahead: ^5.2.0
   provider: ^6.0.5
   json_data_explorer:
     git:


### PR DESCRIPTION
## PR Description

I Upgraded flutter_typeahead package to 5.2.0 as it auto implements arrow keys navigation.
I added focus node to the header value text field to request focus.
I warped the header name textfield with  KeyboardListener widget to listen to user "enter" command

## Related Issues

- Closes #195

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [ ] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
- [x] I need help with writing tests
