### PR TITLE
[fix] Breaking test due to platform-specific directory separator

### DIFF
--- a/test/utils/file_utils_test.dart
+++ b/test/utils/file_utils_test.dart
@@ -18,7 +18,8 @@ void main() {
         // Default windows separator (\) causes issue with
         // hardcoded default with separator for Linux/MacOS (/)
         if (context.separator == '\\') {
-          shortPath = shortPath.replaceAll('\\', '/');
+          expect(shortPath, ".../C\\D.csv");
+          return;
         }
 
         expect(shortPath, ".../C/D.csv");

--- a/test/utils/file_utils_test.dart
+++ b/test/utils/file_utils_test.dart
@@ -1,3 +1,4 @@
+import 'package:path/path.dart';
 import 'package:test/test.dart';
 import 'package:apidash/utils/file_utils.dart';
 
@@ -12,7 +13,15 @@ void main() {
 
       test('Test getShortPath', () {
         String path = "A/B/C/D.csv";
-        expect(getShortPath(path), ".../C/D.csv");
+        String shortPath = getShortPath(path);
+
+        // Default windows separator (\) causes issue with
+        // hardcoded default with separator for Linux/MacOS (/)
+        if (context.separator == '\\') {
+          shortPath = shortPath.replaceAll('\\', '/');
+        }
+
+        expect(shortPath, ".../C/D.csv");
       });
 
       test('Test getTempFileName', () {


### PR DESCRIPTION
## PR Description

This PR addresses the issue #219 . 
The test failure is observed when running flutter test, where the `getFileExtension` test case is failing due to a discrepancy in the file path format on Windows systems.

Recognized that the discrepancy is due to differences in escape characters, particularly on Windows platforms.
Implemented a fix to ensure consistent file path formatting across different platforms, as MacOS and Linux share common separator being `/`.

## Related Issues

- Related Issue #219 
- Closes #219 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Awaiting confirmation if tests are required for breaking tests fixes.
- [ ] I need help with writing tests
