### PR TITLE
Initial Support for Mobile Client

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: use_build_context_synchronously
 
+import 'package:apidash/screens/mobile/home_page/home_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:window_manager/window_manager.dart' hide WindowCaption;
@@ -124,10 +125,7 @@ class DashApp extends ConsumerWidget {
       ),
       themeMode: isDarkMode ? ThemeMode.dark : ThemeMode.light,
       home: kIsMobile
-          ? const MobileDashboard(
-              title: 'Requests',
-              scaffoldBody: CollectionPane(),
-            )
+          ? const MobileHomePage()
           : Stack(
               children: [
                 kIsLinux ? const Dashboard() : const App(),

--- a/lib/providers/ui_providers.dart
+++ b/lib/providers/ui_providers.dart
@@ -24,3 +24,4 @@ final nameTextFieldFocusNodeProvider =
   });
   return focusNode;
 });
+final mobileBottomNavIndexStateProvider = StateProvider<int>((ref) => 0);

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_pane.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_pane.dart
@@ -1,3 +1,4 @@
+import 'package:apidash/consts.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:apidash/providers/providers.dart';
@@ -25,7 +26,7 @@ class EditRequestPane extends ConsumerWidget {
 
     return RequestPane(
       selectedId: selectedId,
-      codePaneVisible: codePaneVisible,
+      codePaneVisible: kIsMobile ? true : codePaneVisible,
       tabIndex: tabIndex,
       onPressedCodeButton: () {
         ref.read(codePaneVisibleStateProvider.notifier).state =

--- a/lib/screens/mobile/drawer.dart
+++ b/lib/screens/mobile/drawer.dart
@@ -1,3 +1,4 @@
+import 'package:apidash/screens/home_page/collection_pane.dart';
 import 'package:apidash/screens/intro_page.dart';
 import 'package:apidash/screens/mobile/home_page/home_page.dart';
 import 'package:apidash/screens/settings_page.dart';
@@ -11,61 +12,68 @@ class MobileAppDrawer extends StatelessWidget {
     return Drawer(
       child: ListView(
         children: [
-          ListTile(
-            title: const Text("Requests"),
-            leading: const Icon(
-              Icons.auto_awesome_mosaic,
-            ),
-            trailing: SizedBox(
-              width: 65,
-              child: Row(
-                children: [
-                  GestureDetector(
-                    child: const Icon(Icons.home_outlined),
-                    onTap: () {
-                      Navigator.of(context).pushAndRemoveUntil(
-                        MaterialPageRoute(
-                          builder: (context) => Scaffold(
-                            appBar: AppBar(
-                              title: const Text("Home"),
-                            ),
-                            drawer: const MobileAppDrawer(),
-                            body: const IntroPage(),
-                          ),
-                        ),
-                        (Route<dynamic> route) => false,
-                      );
-                    },
-                  ),
-                  const SizedBox(width: 5),
-                  GestureDetector(
-                    child: const Icon(Icons.settings_outlined),
-                    onTap: () {
-                      Navigator.of(context).pushAndRemoveUntil(
-                        MaterialPageRoute(
-                          builder: (context) => Scaffold(
-                            appBar: AppBar(
-                              title: const Text("Settings"),
-                            ),
-                            drawer: const MobileAppDrawer(),
-                            body: const SettingsPage(),
-                          ),
-                        ),
-                        (Route<dynamic> route) => false,
-                      );
-                    },
-                  ),
-                ],
+          SizedBox(
+            height: MediaQuery.of(context).size.height * 0.05,
+            child: ListTile(
+              title: const Text("Requests"),
+              leading: const Icon(
+                Icons.auto_awesome_mosaic,
               ),
-            ),
-            onTap: () {
-              Navigator.of(context).pushAndRemoveUntil(
-                MaterialPageRoute(
-                  builder: (context) => const MobileHomePage(),
+              trailing: SizedBox(
+                width: 65,
+                child: Row(
+                  children: [
+                    GestureDetector(
+                      child: const Icon(Icons.home_outlined),
+                      onTap: () {
+                        Navigator.of(context).pushAndRemoveUntil(
+                          MaterialPageRoute(
+                            builder: (context) => Scaffold(
+                              appBar: AppBar(
+                                title: const Text("Home"),
+                              ),
+                              drawer: const MobileAppDrawer(),
+                              body: const IntroPage(),
+                            ),
+                          ),
+                          (Route<dynamic> route) => false,
+                        );
+                      },
+                    ),
+                    const SizedBox(width: 5),
+                    GestureDetector(
+                      child: const Icon(Icons.settings_outlined),
+                      onTap: () {
+                        Navigator.of(context).pushAndRemoveUntil(
+                          MaterialPageRoute(
+                            builder: (context) => Scaffold(
+                              appBar: AppBar(
+                                title: const Text("Settings"),
+                              ),
+                              drawer: const MobileAppDrawer(),
+                              body: const SettingsPage(),
+                            ),
+                          ),
+                          (Route<dynamic> route) => false,
+                        );
+                      },
+                    ),
+                  ],
                 ),
-                (Route<dynamic> route) => false,
-              );
-            },
+              ),
+              onTap: () {
+                Navigator.of(context).pushAndRemoveUntil(
+                  MaterialPageRoute(
+                    builder: (context) => const MobileHomePage(),
+                  ),
+                  (Route<dynamic> route) => false,
+                );
+              },
+            ),
+          ),
+          SizedBox(
+            height: MediaQuery.of(context).size.height * 0.95,
+            child: CollectionPane(),
           )
         ],
       ),

--- a/lib/screens/mobile/drawer.dart
+++ b/lib/screens/mobile/drawer.dart
@@ -1,0 +1,75 @@
+import 'package:apidash/screens/intro_page.dart';
+import 'package:apidash/screens/mobile/home_page/home_page.dart';
+import 'package:apidash/screens/settings_page.dart';
+import 'package:flutter/material.dart';
+
+class MobileAppDrawer extends StatelessWidget {
+  const MobileAppDrawer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      child: ListView(
+        children: [
+          ListTile(
+            title: const Text("Requests"),
+            leading: const Icon(
+              Icons.auto_awesome_mosaic,
+            ),
+            trailing: SizedBox(
+              width: 65,
+              child: Row(
+                children: [
+                  GestureDetector(
+                    child: const Icon(Icons.home_outlined),
+                    onTap: () {
+                      Navigator.of(context).pushAndRemoveUntil(
+                        MaterialPageRoute(
+                          builder: (context) => Scaffold(
+                            appBar: AppBar(
+                              title: const Text("Home"),
+                            ),
+                            drawer: const MobileAppDrawer(),
+                            body: const IntroPage(),
+                          ),
+                        ),
+                        (Route<dynamic> route) => false,
+                      );
+                    },
+                  ),
+                  const SizedBox(width: 5),
+                  GestureDetector(
+                    child: const Icon(Icons.settings_outlined),
+                    onTap: () {
+                      Navigator.of(context).pushAndRemoveUntil(
+                        MaterialPageRoute(
+                          builder: (context) => Scaffold(
+                            appBar: AppBar(
+                              title: const Text("Settings"),
+                            ),
+                            drawer: const MobileAppDrawer(),
+                            body: const SettingsPage(),
+                          ),
+                        ),
+                        (Route<dynamic> route) => false,
+                      );
+                    },
+                  ),
+                ],
+              ),
+            ),
+            onTap: () {
+              Navigator.of(context).pushAndRemoveUntil(
+                MaterialPageRoute(
+                  builder: (context) => const MobileHomePage(),
+                ),
+                (Route<dynamic> route) => false,
+              );
+            },
+          )
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/screens/mobile/home_page/home_page.dart
+++ b/lib/screens/mobile/home_page/home_page.dart
@@ -1,6 +1,7 @@
 import 'package:apidash/consts.dart';
 import 'package:apidash/providers/collection_providers.dart';
 import 'package:apidash/screens/home_page/editor_pane/details_card/request_pane/request_pane.dart';
+import 'package:apidash/screens/home_page/editor_pane/details_card/response_pane.dart';
 import 'package:apidash/screens/home_page/editor_pane/url_card.dart';
 import 'package:apidash/screens/mobile/drawer.dart';
 import 'package:flutter/material.dart';
@@ -15,6 +16,11 @@ class MobileHomePage extends StatefulWidget {
 
 class _MobileHomePageState extends State<MobileHomePage> {
   int navIndex = 0;
+  final navPages = const [
+    EditRequestPane(),
+    ResponsePane(),
+    Text("code"),
+  ];
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -32,7 +38,7 @@ class _MobileHomePageState extends State<MobileHomePage> {
         children: [
           SizedBox(
             height: MediaQuery.of(context).size.height * 0.73,
-            child: const EditRequestPane(),
+            child: navPages[navIndex],
           ),
           SizedBox(
             height: MediaQuery.of(context).size.height * 0.1,

--- a/lib/screens/mobile/home_page/home_page.dart
+++ b/lib/screens/mobile/home_page/home_page.dart
@@ -1,5 +1,6 @@
 import 'package:apidash/consts.dart';
 import 'package:apidash/providers/collection_providers.dart';
+import 'package:apidash/screens/home_page/editor_pane/details_card/code_pane.dart';
 import 'package:apidash/screens/home_page/editor_pane/details_card/request_pane/request_pane.dart';
 import 'package:apidash/screens/home_page/editor_pane/details_card/response_pane.dart';
 import 'package:apidash/screens/home_page/editor_pane/url_card.dart';
@@ -19,7 +20,7 @@ class _MobileHomePageState extends State<MobileHomePage> {
   final navPages = const [
     EditRequestPane(),
     ResponsePane(),
-    Text("code"),
+    CodePane(),
   ];
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/mobile/home_page/home_page.dart
+++ b/lib/screens/mobile/home_page/home_page.dart
@@ -1,3 +1,4 @@
+import 'package:apidash/consts.dart';
 import 'package:apidash/providers/collection_providers.dart';
 import 'package:apidash/screens/home_page/editor_pane/details_card/request_pane/request_pane.dart';
 import 'package:apidash/screens/home_page/editor_pane/url_card.dart';
@@ -30,7 +31,53 @@ class MobileHomePage extends ConsumerWidget {
         ),
       ),
       drawer: const MobileAppDrawer(),
-      body: const EditRequestPane(),
+      body: ListView(
+        children: [
+          SizedBox(
+            height: MediaQuery.of(context).size.height * 0.8,
+            child: const EditRequestPane(),
+          ),
+          SizedBox(
+            height: MediaQuery.of(context).size.height * 0.1,
+            child: const MobileRequestEditor(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class MobileRequestEditor extends StatelessWidget {
+  const MobileRequestEditor({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        kHSpacer10,
+        Expanded(
+          child: Card(
+            shape: RoundedRectangleBorder(
+              side: BorderSide(
+                color: Theme.of(context).colorScheme.onBackground,
+              ),
+              borderRadius: kBorderRadius12,
+            ),
+            child: const Padding(
+              padding: EdgeInsets.symmetric(
+                horizontal: 10,
+              ),
+              child: URLTextField(),
+            ),
+          ),
+        ),
+        kHSpacer10,
+        SizedBox(
+          height: MediaQuery.of(context).size.height * 0.1 / 2,
+          child: const SendButton(),
+        ),
+        kHSpacer10,
+      ],
     );
   }
 }

--- a/lib/screens/mobile/home_page/home_page.dart
+++ b/lib/screens/mobile/home_page/home_page.dart
@@ -1,22 +1,30 @@
+import 'package:apidash/screens/home_page/editor_pane/details_card/request_pane/request_pane.dart';
+import 'package:apidash/screens/home_page/editor_pane/url_card.dart';
 import 'package:apidash/screens/mobile/drawer.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class MobileHomePage extends StatefulWidget {
+class MobileHomePage extends ConsumerWidget {
   const MobileHomePage({super.key});
 
   @override
-  State<MobileHomePage> createState() => _MobileHomePageState();
-}
-
-class _MobileHomePageState extends State<MobileHomePage> {
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text("Reuqests"),
+        title: const Padding(
+          padding: EdgeInsets.symmetric(
+            vertical: 5,
+            horizontal: 20,
+          ),
+          child: Row(
+            children: [
+              DropdownButtonHTTPMethod(),
+            ],
+          ),
+        ),
       ),
       drawer: const MobileAppDrawer(),
-      body: const Text("this"),
+      body: const EditRequestPane(),
     );
   }
 }

--- a/lib/screens/mobile/home_page/home_page.dart
+++ b/lib/screens/mobile/home_page/home_page.dart
@@ -1,22 +1,22 @@
 import 'package:apidash/consts.dart';
-import 'package:apidash/providers/collection_providers.dart';
+import 'package:apidash/providers/providers.dart';
 import 'package:apidash/screens/home_page/editor_pane/details_card/code_pane.dart';
 import 'package:apidash/screens/home_page/editor_pane/details_card/request_pane/request_pane.dart';
 import 'package:apidash/screens/home_page/editor_pane/details_card/response_pane.dart';
 import 'package:apidash/screens/home_page/editor_pane/url_card.dart';
 import 'package:apidash/screens/mobile/drawer.dart';
+import 'package:apidash/widgets/mobile_bottom_navbar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class MobileHomePage extends StatefulWidget {
+class MobileHomePage extends ConsumerStatefulWidget {
   const MobileHomePage({super.key});
 
   @override
-  State<MobileHomePage> createState() => _MobileHomePageState();
+  ConsumerState<MobileHomePage> createState() => _MobileHomePageState();
 }
 
-class _MobileHomePageState extends State<MobileHomePage> {
-  int navIndex = 0;
+class _MobileHomePageState extends ConsumerState<MobileHomePage> {
   final navPages = const [
     EditRequestPane(),
     ResponsePane(),
@@ -39,7 +39,7 @@ class _MobileHomePageState extends State<MobileHomePage> {
         children: [
           SizedBox(
             height: MediaQuery.of(context).size.height * 0.73,
-            child: navPages[navIndex],
+            child: navPages[ref.watch(mobileBottomNavIndexStateProvider)],
           ),
           SizedBox(
             height: MediaQuery.of(context).size.height * 0.1,
@@ -47,28 +47,7 @@ class _MobileHomePageState extends State<MobileHomePage> {
           ),
         ],
       ),
-      bottomNavigationBar: BottomNavigationBar(
-        items: const [
-          BottomNavigationBarItem(
-            icon: Icon(Icons.auto_awesome_mosaic_outlined),
-            label: "request",
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.north_east_rounded),
-            label: "response",
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.code),
-            label: "code",
-          ),
-        ],
-        currentIndex: navIndex,
-        onTap: (value) {
-          setState(() {
-            navIndex = value;
-          });
-        },
-      ),
+      bottomNavigationBar: const MobileBottomNavBar(),
     );
   }
 }

--- a/lib/screens/mobile/home_page/home_page.dart
+++ b/lib/screens/mobile/home_page/home_page.dart
@@ -1,0 +1,22 @@
+import 'package:apidash/screens/mobile/drawer.dart';
+import 'package:flutter/material.dart';
+
+class MobileHomePage extends StatefulWidget {
+  const MobileHomePage({super.key});
+
+  @override
+  State<MobileHomePage> createState() => _MobileHomePageState();
+}
+
+class _MobileHomePageState extends State<MobileHomePage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("Reuqests"),
+      ),
+      drawer: const MobileAppDrawer(),
+      body: const Text("this"),
+    );
+  }
+}

--- a/lib/screens/mobile/home_page/home_page.dart
+++ b/lib/screens/mobile/home_page/home_page.dart
@@ -6,35 +6,32 @@ import 'package:apidash/screens/mobile/drawer.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class MobileHomePage extends ConsumerWidget {
+class MobileHomePage extends StatefulWidget {
   const MobileHomePage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final requestItem = ref.watch(selectedRequestModelProvider)!;
-    String name =
-        requestItem.name.trim().isNotEmpty ? requestItem.name : "untitled";
+  State<MobileHomePage> createState() => _MobileHomePageState();
+}
+
+class _MobileHomePageState extends State<MobileHomePage> {
+  int navIndex = 0;
+  @override
+  Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Padding(
-          padding: const EdgeInsets.symmetric(
+        title: const Padding(
+          padding: EdgeInsets.symmetric(
             vertical: 5,
             horizontal: 20,
           ),
-          child: Row(
-            children: [
-              const DropdownButtonHTTPMethod(),
-              const SizedBox(width: 10),
-              Text(name),
-            ],
-          ),
+          child: MobileAppBarRequestTile(),
         ),
       ),
       drawer: const MobileAppDrawer(),
       body: ListView(
         children: [
           SizedBox(
-            height: MediaQuery.of(context).size.height * 0.8,
+            height: MediaQuery.of(context).size.height * 0.73,
             child: const EditRequestPane(),
           ),
           SizedBox(
@@ -43,6 +40,46 @@ class MobileHomePage extends ConsumerWidget {
           ),
         ],
       ),
+      bottomNavigationBar: BottomNavigationBar(
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.auto_awesome_mosaic_outlined),
+            label: "request",
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.north_east_rounded),
+            label: "response",
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.code),
+            label: "code",
+          ),
+        ],
+        currentIndex: navIndex,
+        onTap: (value) {
+          setState(() {
+            navIndex = value;
+          });
+        },
+      ),
+    );
+  }
+}
+
+class MobileAppBarRequestTile extends ConsumerWidget {
+  const MobileAppBarRequestTile({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final requestItem = ref.watch(selectedRequestModelProvider)!;
+    String name =
+        requestItem.name.trim().isNotEmpty ? requestItem.name : "untitled";
+    return Row(
+      children: [
+        const DropdownButtonHTTPMethod(),
+        const SizedBox(width: 10),
+        Text(name),
+      ],
     );
   }
 }

--- a/lib/screens/mobile/home_page/home_page.dart
+++ b/lib/screens/mobile/home_page/home_page.dart
@@ -1,3 +1,4 @@
+import 'package:apidash/providers/collection_providers.dart';
 import 'package:apidash/screens/home_page/editor_pane/details_card/request_pane/request_pane.dart';
 import 'package:apidash/screens/home_page/editor_pane/url_card.dart';
 import 'package:apidash/screens/mobile/drawer.dart';
@@ -9,16 +10,21 @@ class MobileHomePage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final requestItem = ref.watch(selectedRequestModelProvider)!;
+    String name =
+        requestItem.name.trim().isNotEmpty ? requestItem.name : "untitled";
     return Scaffold(
       appBar: AppBar(
-        title: const Padding(
-          padding: EdgeInsets.symmetric(
+        title: Padding(
+          padding: const EdgeInsets.symmetric(
             vertical: 5,
             horizontal: 20,
           ),
           child: Row(
             children: [
-              DropdownButtonHTTPMethod(),
+              const DropdownButtonHTTPMethod(),
+              const SizedBox(width: 10),
+              Text(name),
             ],
           ),
         ),

--- a/lib/widgets/buttons.dart
+++ b/lib/widgets/buttons.dart
@@ -61,23 +61,39 @@ class SendRequestButton extends StatelessWidget {
     bool disable = sentRequestId != null;
     return FilledButton(
       onPressed: disable ? null : onTap,
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            disable
-                ? (selectedId == sentRequestId ? kLabelSending : kLabelBusy)
-                : kLabelSend,
-            style: kTextStyleButton,
-          ),
-          if (!disable) kHSpacer10,
-          if (!disable)
-            const Icon(
-              size: 16,
-              Icons.send,
+      child: kIsMobile
+          ? Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  disable
+                      ? (selectedId == sentRequestId
+                          ? kLabelSending
+                          : kLabelBusy)
+                      : kLabelSend,
+                  style: kTextStyleButton,
+                ),
+              ],
+            )
+          : Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  disable
+                      ? (selectedId == sentRequestId
+                          ? kLabelSending
+                          : kLabelBusy)
+                      : kLabelSend,
+                  style: kTextStyleButton,
+                ),
+                if (!disable) kHSpacer10,
+                if (!disable)
+                  const Icon(
+                    size: 16,
+                    Icons.send,
+                  ),
+              ],
             ),
-        ],
-      ),
     );
   }
 }

--- a/lib/widgets/mobile_bottom_navbar.dart
+++ b/lib/widgets/mobile_bottom_navbar.dart
@@ -1,0 +1,38 @@
+import 'package:apidash/providers/providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class MobileBottomNavBar extends ConsumerStatefulWidget {
+  const MobileBottomNavBar({super.key});
+
+  @override
+  ConsumerState<MobileBottomNavBar> createState() => _MobileBottomNavBarState();
+}
+
+class _MobileBottomNavBarState extends ConsumerState<MobileBottomNavBar> {
+  @override
+  Widget build(BuildContext context) {
+    return BottomNavigationBar(
+      items: const [
+        BottomNavigationBarItem(
+          icon: Icon(Icons.auto_awesome_mosaic_outlined),
+          label: "request",
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(Icons.north_east_rounded),
+          label: "response",
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(Icons.code),
+          label: "code",
+        ),
+      ],
+      currentIndex: ref.read(mobileBottomNavIndexStateProvider),
+      onTap: (value) {
+        setState(() {
+          ref.watch(mobileBottomNavIndexStateProvider.notifier).state = value;
+        });
+      },
+    );
+  }
+}

--- a/lib/widgets/request_widgets.dart
+++ b/lib/widgets/request_widgets.dart
@@ -58,19 +58,22 @@ class _RequestPaneState extends State<RequestPane>
                   "Request",
                   style: Theme.of(context).textTheme.titleMedium,
                 ),
-                FilledButton.tonalIcon(
-                  onPressed: widget.onPressedCodeButton,
-                  icon: Icon(
-                    widget.codePaneVisible
-                        ? Icons.code_off_rounded
-                        : Icons.code_rounded,
-                  ),
-                  label: SizedBox(
-                    width: 75,
-                    child: Text(
-                        widget.codePaneVisible ? "Hide Code" : "View Code"),
-                  ),
-                ),
+                kIsMobile
+                    ? const Text("")
+                    : FilledButton.tonalIcon(
+                        onPressed: widget.onPressedCodeButton,
+                        icon: Icon(
+                          widget.codePaneVisible
+                              ? Icons.code_off_rounded
+                              : Icons.code_rounded,
+                        ),
+                        label: SizedBox(
+                          width: 75,
+                          child: Text(widget.codePaneVisible
+                              ? "Hide Code"
+                              : "View Code"),
+                        ),
+                      ),
               ],
             ),
           ),

--- a/test/widgets/mobile_bottom_navbar_test.dart
+++ b/test/widgets/mobile_bottom_navbar_test.dart
@@ -1,0 +1,64 @@
+import 'package:apidash/providers/providers.dart';
+import 'package:apidash/widgets/mobile_bottom_navbar.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group(
+    'Mobile bottom Navbar tests',
+    () {
+      testWidgets(
+        'Check if structure is maintained',
+        (tester) async {
+          await tester.pumpWidget(
+            const MaterialApp(
+              home: Scaffold(
+                bottomNavigationBar: ProviderScope(child: MobileBottomNavBar()),
+              ),
+            ),
+          );
+
+          // request, response, code text present
+          expect(find.text("request"), findsOneWidget);
+          expect(find.text("response"), findsOneWidget);
+          expect(find.text("code"), findsOneWidget);
+
+          // request, response, code icons present
+          expect(
+              find.byIcon(Icons.auto_awesome_mosaic_outlined), findsOneWidget);
+          expect(find.byIcon(Icons.north_east_rounded), findsOneWidget);
+          expect(find.byIcon(Icons.code), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'Check provider value on tap',
+        (tester) async {
+          await tester.pumpWidget(
+            const MaterialApp(
+              home: Scaffold(
+                bottomNavigationBar: ProviderScope(child: MobileBottomNavBar()),
+              ),
+            ),
+          );
+
+          final element = tester.element(find.byType(MobileBottomNavBar));
+          final container = ProviderScope.containerOf(element);
+
+          // request
+          await tester.tap(find.text("request"));
+          expect(container.read(mobileBottomNavIndexStateProvider), 0);
+
+          // response
+          await tester.tap(find.text("response"));
+          expect(container.read(mobileBottomNavIndexStateProvider), 1);
+
+          // code
+          await tester.tap(find.text("code"));
+          expect(container.read(mobileBottomNavIndexStateProvider), 2);
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
## PR Description

Initial Mobile support, to include base functionalities of the already existing desktop client as per the [mock-ups](https://github.com/foss42/apidash/issues/33#issuecomment-1605874012) suggested by @animator 

[Mobile client screen recording](https://github.com/foss42/apidash/assets/81746463/c42d721a-211c-4bed-af3c-a58d0d304cc3)

## Related Issues

- Related Issue #33 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Major ToDos
- The Request Tiles are nested under `Scrollable()` and `ReorderableListView()` widgets. Due to which scrolling and rearranging tiles works perfectly fine on desktop clients but glitches out on mobile.
- Scrolling on list of `params` and `headers` in request pane.
- Handle situation when there is no Request Tile (show `RequestEditorDefault()`) 

## Added/updated tests?
_We encourage you to add relevant test cases._

- [x] Yes
- [ ] No, will write them after i implement the major todos
- [ ] I need help with writing tests
