### PR TITLE
feat(tests): add more tests for codegen with multipart body

### DIFF
--- a/test/request_models.dart
+++ b/test/request_models.dart
@@ -1,4 +1,5 @@
-import 'package:apidash/models/models.dart' show NameValueModel, RequestModel;
+import 'package:apidash/models/models.dart'
+    show FormDataModel, NameValueModel, RequestModel;
 import 'package:apidash/consts.dart';
 
 /// Basic GET request model
@@ -224,6 +225,105 @@ const requestModelPost3 = RequestModel(
   requestHeaders: [
     NameValueModel(name: 'User-Agent', value: 'Test Agent'),
   ],
+);
+
+/// POST request model with multipart body(text)
+const requestModelPost4 = RequestModel(
+  id: 'post4',
+  url: 'https://oshi.at',
+  method: HTTPVerb.post,
+  requestFormDataList: [
+    FormDataModel(
+        name: "text", value: "some textual string", type: FormDataType.file)
+  ],
+  requestBodyContentType: ContentType.formdata,
+);
+
+/// POST request model with multipart body and headers
+const requestModelPost5 = RequestModel(
+  id: 'post5',
+  url: 'https://oshi.at',
+  method: HTTPVerb.post,
+  requestFormDataList: [
+    FormDataModel(
+        name: "text", value: "some textual string", type: FormDataType.text)
+  ],
+  requestHeaders: [
+    NameValueModel(name: 'User-Agent', value: 'Test Agent'),
+  ],
+  requestBodyContentType: ContentType.formdata,
+);
+
+/// POST request model with multipart body(file)
+const requestModelPost6 = RequestModel(
+  id: 'post6',
+  url: 'https://oshi.at',
+  method: HTTPVerb.post,
+  requestFormDataList: [
+    FormDataModel(name: "f", value: "/path/to/file", type: FormDataType.file)
+  ],
+  requestBodyContentType: ContentType.formdata,
+);
+
+/// POST request model with multipart body and requestBody (the requestBody shouldn't be in codegen)
+const requestModelPost7 = RequestModel(
+  id: 'post7',
+  url: 'https://oshi.at',
+  method: HTTPVerb.post,
+  requestBody: r"""{
+"text": "I LOVE Flutter"
+}""",
+  requestFormDataList: [
+    FormDataModel(
+        name: "text", value: "some textual string", type: FormDataType.text)
+  ],
+  requestBodyContentType: ContentType.formdata,
+);
+
+/// POST request model with multipart body and requestParams
+const requestModelPost8 = RequestModel(
+  id: 'post8',
+  url: 'https://oshi.at',
+  method: HTTPVerb.post,
+  requestFormDataList: [
+    FormDataModel(
+        name: "text", value: "some textual string", type: FormDataType.text)
+  ],
+  requestParams: [
+    NameValueModel(name: 'num', value: '8700000'),
+    NameValueModel(name: 'digits', value: '3'),
+    NameValueModel(name: 'system', value: 'SS'),
+    NameValueModel(name: 'add_space', value: 'true'),
+    NameValueModel(name: 'trailing_zeros', value: 'true'),
+  ],
+  requestBodyContentType: ContentType.formdata,
+);
+
+/// POST request model with multipart body(file and text), requestParams, requestHeaders and requestBody
+const requestModelPost9 = RequestModel(
+  id: 'post9',
+  url: 'https://oshi.at',
+  method: HTTPVerb.post,
+  requestBody: r"""{
+"text": "I LOVE Flutter"
+}""",
+  requestFormDataList: [
+    FormDataModel(
+        name: "text", value: "some textual string", type: FormDataType.text),
+    FormDataModel(name: "f", value: "/path/to/file", type: FormDataType.file)
+  ],
+  requestParams: [
+    NameValueModel(name: 'num', value: '8700000'),
+    NameValueModel(name: 'digits', value: '3'),
+    NameValueModel(name: 'system', value: 'SS'),
+    NameValueModel(name: 'add_space', value: 'true'),
+    NameValueModel(name: 'trailing_zeros', value: 'true'),
+  ],
+  requestHeaders: [
+    NameValueModel(name: 'User-Agent', value: 'Test Agent'),
+    NameValueModel(name: 'Content-Type', value: 'multipart/form-data'),
+  ],
+  requestBodyContentType: ContentType.formdata,
 );
 
 /// PUT request model

--- a/test/request_models.dart
+++ b/test/request_models.dart
@@ -230,11 +230,12 @@ const requestModelPost3 = RequestModel(
 /// POST request model with multipart body(text)
 const requestModelPost4 = RequestModel(
   id: 'post4',
-  url: 'https://oshi.at',
+  url: 'https://api.apidash.dev/io/form',
   method: HTTPVerb.post,
   requestFormDataList: [
-    FormDataModel(
-        name: "text", value: "some textual string", type: FormDataType.file)
+    FormDataModel(name: "text", value: "API", type: FormDataType.text),
+    FormDataModel(name: "sep", value: "|", type: FormDataType.text),
+    FormDataModel(name: "times", value: "3", type: FormDataType.text),
   ],
   requestBodyContentType: ContentType.formdata,
 );
@@ -242,11 +243,12 @@ const requestModelPost4 = RequestModel(
 /// POST request model with multipart body and headers
 const requestModelPost5 = RequestModel(
   id: 'post5',
-  url: 'https://oshi.at',
+  url: 'https://api.apidash.dev/io/form',
   method: HTTPVerb.post,
   requestFormDataList: [
-    FormDataModel(
-        name: "text", value: "some textual string", type: FormDataType.text)
+    FormDataModel(name: "text", value: "API", type: FormDataType.text),
+    FormDataModel(name: "sep", value: "|", type: FormDataType.text),
+    FormDataModel(name: "times", value: "3", type: FormDataType.text),
   ],
   requestHeaders: [
     NameValueModel(name: 'User-Agent', value: 'Test Agent'),
@@ -254,13 +256,15 @@ const requestModelPost5 = RequestModel(
   requestBodyContentType: ContentType.formdata,
 );
 
-/// POST request model with multipart body(file)
+/// POST request model with multipart body(text, file)
 const requestModelPost6 = RequestModel(
   id: 'post6',
-  url: 'https://oshi.at',
+  url: 'https://api.apidash.dev/io/img',
   method: HTTPVerb.post,
   requestFormDataList: [
-    FormDataModel(name: "f", value: "/path/to/file", type: FormDataType.file)
+    FormDataModel(name: "token", value: "xyz", type: FormDataType.text),
+    FormDataModel(
+        name: "imfile", value: "/Documents/up/1.png", type: FormDataType.file),
   ],
   requestBodyContentType: ContentType.formdata,
 );
@@ -268,14 +272,15 @@ const requestModelPost6 = RequestModel(
 /// POST request model with multipart body and requestBody (the requestBody shouldn't be in codegen)
 const requestModelPost7 = RequestModel(
   id: 'post7',
-  url: 'https://oshi.at',
+  url: 'https://api.apidash.dev/io/img',
   method: HTTPVerb.post,
   requestBody: r"""{
 "text": "I LOVE Flutter"
 }""",
   requestFormDataList: [
+    FormDataModel(name: "token", value: "xyz", type: FormDataType.text),
     FormDataModel(
-        name: "text", value: "some textual string", type: FormDataType.text)
+        name: "imfile", value: "/Documents/up/1.png", type: FormDataType.file),
   ],
   requestBodyContentType: ContentType.formdata,
 );
@@ -283,18 +288,16 @@ const requestModelPost7 = RequestModel(
 /// POST request model with multipart body and requestParams
 const requestModelPost8 = RequestModel(
   id: 'post8',
-  url: 'https://oshi.at',
+  url: 'https://api.apidash.dev/io/form',
   method: HTTPVerb.post,
   requestFormDataList: [
-    FormDataModel(
-        name: "text", value: "some textual string", type: FormDataType.text)
+    FormDataModel(name: "text", value: "API", type: FormDataType.text),
+    FormDataModel(name: "sep", value: "|", type: FormDataType.text),
+    FormDataModel(name: "times", value: "3", type: FormDataType.text),
   ],
   requestParams: [
-    NameValueModel(name: 'num', value: '8700000'),
-    NameValueModel(name: 'digits', value: '3'),
-    NameValueModel(name: 'system', value: 'SS'),
-    NameValueModel(name: 'add_space', value: 'true'),
-    NameValueModel(name: 'trailing_zeros', value: 'true'),
+    NameValueModel(name: 'size', value: '2'),
+    NameValueModel(name: 'len', value: '3'),
   ],
   requestBodyContentType: ContentType.formdata,
 );
@@ -302,26 +305,23 @@ const requestModelPost8 = RequestModel(
 /// POST request model with multipart body(file and text), requestParams, requestHeaders and requestBody
 const requestModelPost9 = RequestModel(
   id: 'post9',
-  url: 'https://oshi.at',
+  url: 'https://api.apidash.dev/io/img',
   method: HTTPVerb.post,
   requestBody: r"""{
 "text": "I LOVE Flutter"
 }""",
   requestFormDataList: [
+    FormDataModel(name: "token", value: "xyz", type: FormDataType.text),
     FormDataModel(
-        name: "text", value: "some textual string", type: FormDataType.text),
-    FormDataModel(name: "f", value: "/path/to/file", type: FormDataType.file)
+        name: "imfile", value: "/Documents/up/1.png", type: FormDataType.file),
   ],
   requestParams: [
-    NameValueModel(name: 'num', value: '8700000'),
-    NameValueModel(name: 'digits', value: '3'),
-    NameValueModel(name: 'system', value: 'SS'),
-    NameValueModel(name: 'add_space', value: 'true'),
-    NameValueModel(name: 'trailing_zeros', value: 'true'),
+    NameValueModel(name: 'size', value: '2'),
+    NameValueModel(name: 'len', value: '3'),
   ],
   requestHeaders: [
     NameValueModel(name: 'User-Agent', value: 'Test Agent'),
-    NameValueModel(name: 'Content-Type', value: 'multipart/form-data'),
+    NameValueModel(name: 'Keep-Alive', value: 'true'),
   ],
   requestBodyContentType: ContentType.formdata,
 );


### PR DESCRIPTION
## PR Description
This PR adds tests for requests with a multipart body. 

@animator @ashitaprasad Do I add more tests for post requests (e.g when request params and request headers are disabled).

Also, Currently, I've just added the request models. Do I add them to individual codegen tests as well or I should do this in a separate PR after this is merged? Currently, This PR doesn't add any functionality to the actual tests but rather just code that other tests will use. 


## Related Issues

- Related Issue #234 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
- [ ] I need help with writing tests
