### PR TITLE
[feat] Enable parallel request handling

### DIFF
--- a/lib/models/request_model.dart
+++ b/lib/models/request_model.dart
@@ -29,6 +29,7 @@ class RequestModel {
     this.responseStatus,
     this.message,
     this.responseModel,
+    this.isWorking = false,
   });
 
   final String id;
@@ -47,6 +48,7 @@ class RequestModel {
   final int? responseStatus;
   final String? message;
   final ResponseModel? responseModel;
+  final bool isWorking;
 
   List<NameValueModel>? get enabledRequestHeaders =>
       getEnabledRows(requestHeaders, isHeaderEnabledList);
@@ -106,6 +108,7 @@ class RequestModel {
     int? responseStatus,
     String? message,
     ResponseModel? responseModel,
+    bool? isWorking,
   }) {
     var headers = requestHeaders ?? this.requestHeaders;
     var params = requestParams ?? this.requestParams;
@@ -129,6 +132,7 @@ class RequestModel {
       responseStatus: responseStatus ?? this.responseStatus,
       message: message ?? this.message,
       responseModel: responseModel ?? this.responseModel,
+      isWorking: isWorking ?? this.isWorking,
     );
   }
 

--- a/lib/providers/ui_providers.dart
+++ b/lib/providers/ui_providers.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final navRailIndexStateProvider = StateProvider<int>((ref) => 0);
 final selectedIdEditStateProvider = StateProvider<String?>((ref) => null);
-final sentRequestIdStateProvider = StateProvider<String?>((ref) => null);
 final codePaneVisibleStateProvider = StateProvider<bool>((ref) => false);
 final saveDataStateProvider = StateProvider<bool>((ref) => false);
 final clearDataStateProvider = StateProvider<bool>((ref) => false);

--- a/lib/screens/home_page/editor_pane/details_card/response_pane.dart
+++ b/lib/screens/home_page/editor_pane/details_card/response_pane.dart
@@ -9,13 +9,12 @@ class ResponsePane extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final selectedId = ref.watch(selectedIdStateProvider);
-    final sentRequestId = ref.watch(sentRequestIdStateProvider);
     final responseStatus = ref.watch(
         selectedRequestModelProvider.select((value) => value?.responseStatus));
+    final isWorking = ref.watch(selectedRequestModelProvider)?.isWorking;
     final message = ref
         .watch(selectedRequestModelProvider.select((value) => value?.message));
-    if (sentRequestId != null && sentRequestId == selectedId) {
+    if (isWorking == true) {
       return const SendingWidget();
     }
     if (responseStatus == null) {

--- a/lib/screens/home_page/editor_pane/details_card/response_pane.dart
+++ b/lib/screens/home_page/editor_pane/details_card/response_pane.dart
@@ -9,12 +9,14 @@ class ResponsePane extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final isWorking = ref.watch(
+            selectedRequestModelProvider.select((value) => value?.isWorking)) ??
+        false;
     final responseStatus = ref.watch(
         selectedRequestModelProvider.select((value) => value?.responseStatus));
-    final isWorking = ref.watch(selectedRequestModelProvider)?.isWorking;
     final message = ref
         .watch(selectedRequestModelProvider.select((value) => value?.message));
-    if (isWorking == true) {
+    if (isWorking) {
       return const SendingWidget();
     }
     if (responseStatus == null) {

--- a/lib/screens/home_page/editor_pane/url_card.dart
+++ b/lib/screens/home_page/editor_pane/url_card.dart
@@ -93,10 +93,11 @@ class SendButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final selectedId = ref.watch(selectedIdStateProvider);
-    final isWorking = ref.watch(selectedRequestModelProvider)?.isWorking;
+    final isWorking = ref.watch(
+        selectedRequestModelProvider.select((value) => value?.isWorking));
 
     return SendRequestButton(
-      isWorking: isWorking,
+      isWorking: isWorking ?? false,
       onTap: () {
         ref
             .read(collectionStateNotifierProvider.notifier)

--- a/lib/screens/home_page/editor_pane/url_card.dart
+++ b/lib/screens/home_page/editor_pane/url_card.dart
@@ -93,10 +93,10 @@ class SendButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final selectedId = ref.watch(selectedIdStateProvider);
-    final sentRequestId = ref.watch(sentRequestIdStateProvider);
+    final isWorking = ref.watch(selectedRequestModelProvider)?.isWorking;
+
     return SendRequestButton(
-      selectedId: selectedId,
-      sentRequestId: sentRequestId,
+      isWorking: isWorking,
       onTap: () {
         ref
             .read(collectionStateNotifierProvider.notifier)

--- a/lib/widgets/buttons.dart
+++ b/lib/widgets/buttons.dart
@@ -51,27 +51,33 @@ class SendRequestButton extends StatelessWidget {
     required this.onTap,
   });
 
-  final bool? isWorking;
+  final bool isWorking;
   final void Function() onTap;
 
   @override
   Widget build(BuildContext context) {
     return FilledButton(
-      onPressed: isWorking == true ? null : onTap,
+      onPressed: isWorking ? null : onTap,
       child: Row(
         mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            isWorking == true ? kLabelSending : kLabelSend,
-            style: kTextStyleButton,
-          ),
-          if (isWorking == false) kHSpacer10,
-          if (isWorking == false)
-            const Icon(
-              size: 16,
-              Icons.send,
-            ),
-        ],
+        children: isWorking
+            ? const [
+                Text(
+                  kLabelSending,
+                  style: kTextStyleButton,
+                ),
+              ]
+            : const [
+                Text(
+                  kLabelSend,
+                  style: kTextStyleButton,
+                ),
+                kHSpacer10,
+                Icon(
+                  size: 16,
+                  Icons.send,
+                ),
+              ],
       ),
     );
   }

--- a/lib/widgets/buttons.dart
+++ b/lib/widgets/buttons.dart
@@ -47,31 +47,26 @@ class CopyButton extends StatelessWidget {
 class SendRequestButton extends StatelessWidget {
   const SendRequestButton({
     super.key,
-    required this.selectedId,
-    required this.sentRequestId,
+    required this.isWorking,
     required this.onTap,
   });
 
-  final String? selectedId;
-  final String? sentRequestId;
+  final bool? isWorking;
   final void Function() onTap;
 
   @override
   Widget build(BuildContext context) {
-    bool disable = sentRequestId != null;
     return FilledButton(
-      onPressed: disable ? null : onTap,
+      onPressed: isWorking == true ? null : onTap,
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
           Text(
-            disable
-                ? (selectedId == sentRequestId ? kLabelSending : kLabelBusy)
-                : kLabelSend,
+            isWorking == true ? kLabelSending : kLabelSend,
             style: kTextStyleButton,
           ),
-          if (!disable) kHSpacer10,
-          if (!disable)
+          if (isWorking == false) kHSpacer10,
+          if (isWorking == false)
             const Icon(
               size: 16,
               Icons.send,

--- a/test/widgets/buttons_test.dart
+++ b/test/widgets/buttons_test.dart
@@ -36,8 +36,7 @@ void main() {
         theme: kThemeDataLight,
         home: Scaffold(
           body: SendRequestButton(
-            selectedId: '1',
-            sentRequestId: null,
+            isWorking: false,
             onTap: () {
               changedValue = 'Send';
             },
@@ -55,7 +54,8 @@ void main() {
     expect(changedValue, 'Send');
   });
 
-  testWidgets('Testing for Send Request button when sentRequestId is not null',
+  testWidgets(
+      'Testing for Send Request button when RequestModel is viewed and is waiting for response',
       (tester) async {
     await tester.pumpWidget(
       MaterialApp(
@@ -63,32 +63,7 @@ void main() {
         theme: kThemeDataLight,
         home: Scaffold(
           body: SendRequestButton(
-            selectedId: '1',
-            sentRequestId: '2',
-            onTap: () {},
-          ),
-        ),
-      ),
-    );
-
-    expect(find.byIcon(Icons.send), findsNothing);
-    expect(find.text(kLabelBusy), findsOneWidget);
-    final button1 = find.byType(FilledButton);
-    expect(button1, findsOneWidget);
-
-    expect(tester.widget<FilledButton>(button1).enabled, isFalse);
-  });
-
-  testWidgets('Testing for Send Request button when sentRequestId = selectedId',
-      (tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        title: 'Send Request button',
-        theme: kThemeDataLight,
-        home: Scaffold(
-          body: SendRequestButton(
-            selectedId: '1',
-            sentRequestId: '1',
+            isWorking: true,
             onTap: () {},
           ),
         ),


### PR DESCRIPTION
## PR Description

This fix addresses the bottleneck issue where only one request could be sent at a time in API Dash, causing the app to show "Busy" and hindering users from performing other tasks. With this enhancement, users can now send multiple requests concurrently, improving the app's efficiency and user experience.

### Preview
<details>

https://github.com/foss42/apidash/assets/84124091/d7602b71-4dc2-4002-8f32-0b8f1c8d7c1f

</details>


### Implementation Brief
To achieve this, the top-level dependency on `sentRequestIdStateProvider` was removed. Instead, a parameter was added to the `RequestModel` to track whether a specific request is awaiting a response. This change enables proper state management and allows widgets to adapt dynamically based on the status of each request.

## Related Issues

- Related Issue #114, #100 
- Closes #114 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have run the tests (`flutter test`) and all tests are passing

## TODO
 - [x] Fix existing broken tests, due to class parameter refactor.

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [x] No, and this is why: Will do soon!
- [ ] I need help with writing tests
