### PR TITLE
Add feature codegen for Kotlin using retrofit

### DIFF
--- a/lib/codegen/codegen.dart
+++ b/lib/codegen/codegen.dart
@@ -1,3 +1,4 @@
+import 'package:apidash/codegen/kotlin/retrofit.dart';
 import 'package:apidash/models/models.dart' show RequestModel;
 import 'package:apidash/consts.dart';
 import 'dart/http.dart';
@@ -37,6 +38,8 @@ class Codegen {
             .getCode(requestModel, defaultUriScheme);
       case CodegenLanguage.kotlinOkHttp:
         return KotlinOkHttpCodeGen().getCode(requestModel, defaultUriScheme);
+      case CodegenLanguage.kotlinRetrofit:
+        return KotlinRetrofitCodeGen().getCode(requestModel, defaultUriScheme);
       case CodegenLanguage.pythonHttpClient:
         return PythonHttpClientCodeGen()
             .getCode(requestModel, defaultUriScheme);

--- a/lib/codegen/kotlin/retrofit.dart
+++ b/lib/codegen/kotlin/retrofit.dart
@@ -1,0 +1,72 @@
+import 'package:jinja/jinja.dart' as jj;
+import 'package:apidash/utils/utils.dart' show getValidRequestUri;
+import '../../models/request_model.dart';
+
+class KotlinRetrofitCodeGen {
+  final String kTemplateInterfaceStart = """import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.*
+
+interface ApiService {
+""";
+
+  final String kTemplateFunction = """
+    @{{httpMethod}}("{{urlPath}}")
+    fun {{functionName}}({{parameters}})
+""";
+
+  final String kRetrofitSetup = """
+fun getApiService(): ApiService {
+    val retrofit = Retrofit.Builder()
+        .baseUrl("{{baseUrl}}")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+
+    return retrofit.create(ApiService::class.java)
+}
+""";
+
+  String? getCode(
+    RequestModel requestModel,
+    String defaultUriScheme,
+  ) {
+    try {
+      String result = "";
+      String baseUrl = getValidRequestUri(requestModel.url, []).$1.toString();
+      baseUrl =
+          baseUrl.substring(0, baseUrl.indexOf("/", 8)); // Extracting base URL
+      String path = requestModel.url.substring(baseUrl.length);
+
+      var methodName =
+          "callApi"; // This should ideally be derived or set based on the context
+
+      var httpMethod = requestModel.method.name.toUpperCase();
+      var parameters = "";
+
+      if (requestModel.isFormDataRequest) {
+        parameters += "@Body body: RequestBody";
+      } else if (requestModel.requestBody != null &&
+          requestModel.requestBody!.isNotEmpty) {
+        parameters += "@Body body: RequestBody";
+      }
+
+      var templateFunction = jj.Template(kTemplateFunction);
+      result += templateFunction.render({
+        "httpMethod": httpMethod,
+        "urlPath": path,
+        "functionName": methodName,
+        "parameters": parameters,
+      });
+
+      var templateInterfaceStart = jj.Template(kTemplateInterfaceStart);
+      result = "${templateInterfaceStart.render({})}$result}\n\n";
+
+      var retrofitSetup = jj.Template(kRetrofitSetup);
+      result += retrofitSetup.render({"baseUrl": baseUrl});
+
+      return result;
+    } catch (e) {
+      return null;
+    }
+  }
+}

--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -267,6 +267,7 @@ enum CodegenLanguage {
   nodejsAxios("node.js (axios)", "javascript", "js"),
   nodejsFetch("node.js (fetch)", "javascript", "js"),
   kotlinOkHttp("Kotlin (okhttp3)", "java", "kt"),
+  kotlinRetrofit("Kotlin (Retrofit)", "java", "kt"),
   pythonHttpClient("Python (http.client)", "python", "py"),
   pythonRequests("Python (requests)", "python", "py");
 

--- a/test/codegen/kotlin_retrofit_codegen_test.dart
+++ b/test/codegen/kotlin_retrofit_codegen_test.dart
@@ -1,0 +1,66 @@
+import 'package:test/test.dart';
+import 'package:apidash/codegen/kotlin/retrofit.dart';
+import '../request_models.dart';
+
+void main() {
+  final kotlinRetrofitCodeGen = KotlinRetrofitCodeGen();
+
+  group('GET Request', () {
+    test('GET 1', () {
+      const expectedCode = r'''
+    @GET("https://api.foss42.com")
+    fun callApi()
+''';
+      expect(kotlinRetrofitCodeGen.getCode(requestModelGet1, "https"),
+          expectedCode);
+    });
+
+    test('GET 2', () {
+      const expectedCode = r'''
+    @GET("https://api.foss42.com/country/data")
+    fun callApi()
+''';
+      expect(kotlinRetrofitCodeGen.getCode(requestModelGet2, "https"),
+          expectedCode);
+    });
+
+    test('GET 3', () {
+      const expectedCode = r'''
+    @GET("https://api.foss42.com/country/data")
+    fun callApi()
+''';
+      expect(kotlinRetrofitCodeGen.getCode(requestModelGet3, "https"),
+          expectedCode);
+    });
+
+    // Add tests for other GET requests...
+  });
+
+  group('HEAD Request', () {
+    test('HEAD 1', () {
+      const expectedCode = r'''
+    @HEAD("https://api.foss42.com")
+    fun callApi()
+''';
+      expect(kotlinRetrofitCodeGen.getCode(requestModelHead1, "https"),
+          expectedCode);
+    });
+
+    // Add tests for other HEAD requests...
+  });
+
+  group('POST Request', () {
+    test('POST 1', () {
+      const expectedCode = r'''
+    @POST("https://api.foss42.com/case/lower")
+    fun callApi(@Body body: RequestBody)
+''';
+      expect(kotlinRetrofitCodeGen.getCode(requestModelPost1, "https"),
+          expectedCode);
+    });
+
+    // Add tests for other POST requests...
+  });
+
+  // Add groups and tests for other request types (PUT, PATCH, DELETE)...
+}


### PR DESCRIPTION
## PR Description

This PR introduces support for generating Kotlin code using Retrofit for API communication. Retrofit is a type-safe HTTP client for Android and Java by Square, Inc., that makes it easy to consume RESTful web services

<img src="https://github.com/foss42/apidash/assets/100941430/6ffb9527-2335-4e9f-a2bd-f11bad490883" alt="Alt text" width="650">



## Related Issues

- Related Issue #247
- Closes #247

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
