### PR TITLE
[fix] Fix vertical obscuring issue in form data section

### DIFF
--- a/lib/widgets/form_data_field.dart
+++ b/lib/widgets/form_data_field.dart
@@ -46,32 +46,34 @@ class _FormDataFieldState extends State<FormDataField> {
               color: colorScheme.onSurface,
             ),
             decoration: InputDecoration(
-                hintStyle: kCodeStyle.copyWith(
-                  color: colorScheme.outline.withOpacity(
+              hintStyle: kCodeStyle.copyWith(
+                color: colorScheme.outline.withOpacity(
+                  kHintOpacity,
+                ),
+              ),
+              hintText: widget.hintText,
+              contentPadding: const EdgeInsets.only(bottom: 16),
+              focusedBorder: UnderlineInputBorder(
+                borderSide: BorderSide(
+                  color: colorScheme.primary.withOpacity(
                     kHintOpacity,
                   ),
                 ),
-                hintText: widget.hintText,
-                focusedBorder: UnderlineInputBorder(
-                  borderSide: BorderSide(
-                    color: colorScheme.primary.withOpacity(
-                      kHintOpacity,
-                    ),
-                  ),
+              ),
+              enabledBorder: UnderlineInputBorder(
+                borderSide: BorderSide(
+                  color: colorScheme.surfaceVariant,
                 ),
-                enabledBorder: UnderlineInputBorder(
-                  borderSide: BorderSide(
-                    color: colorScheme.surfaceVariant,
-                  ),
-                ),
-                suffixIcon: DropdownButtonFormData(
-                  formDataType: widget.formDataType,
-                  onChanged: (p0) {
-                    if (widget.onFormDataTypeChanged != null) {
-                      widget.onFormDataTypeChanged!(p0);
-                    }
-                  },
-                )),
+              ),
+              suffixIcon: DropdownButtonFormData(
+                formDataType: widget.formDataType,
+                onChanged: (p0) {
+                  if (widget.onFormDataTypeChanged != null) {
+                    widget.onFormDataTypeChanged!(p0);
+                  }
+                },
+              ),
+            ),
             onChanged: widget.onChanged,
           ),
         ),


### PR DESCRIPTION
Issue Addressed:
This PR resolves an issue where vertical spacing is lost in text fields within the body tab's formdata section, causing input text to be hidden when users type long sentences.

## PR Description
The fix involves adjusting the padding of text field. This behavior is observed when `TextField` or `TextFormField`  is wrapped inside a `Row`, where padding either needs to be removed, or hardcoded.

## Related Issues

- Related Issue #250 
- Closes #250 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Soon after initial feedback.