### PR TITLE
[feat] Implement Press Enter to Send Request in URL Input Field

### DIFF
--- a/lib/screens/home_page/editor_pane/url_card.dart
+++ b/lib/screens/home_page/editor_pane/url_card.dart
@@ -81,6 +81,11 @@ class URLTextField extends ConsumerWidget {
             .read(collectionStateNotifierProvider.notifier)
             .update(selectedId, url: value);
       },
+      onFieldSubmitted: (value) {
+        ref
+            .read(collectionStateNotifierProvider.notifier)
+            .sendRequest(selectedId);
+      },
     );
   }
 }

--- a/lib/widgets/textfields.dart
+++ b/lib/widgets/textfields.dart
@@ -7,11 +7,13 @@ class URLField extends StatelessWidget {
     required this.selectedId,
     this.initialValue,
     this.onChanged,
+    this.onFieldSubmitted,
   });
 
   final String selectedId;
   final String? initialValue;
   final void Function(String)? onChanged;
+  final void Function(String)? onFieldSubmitted;
 
   @override
   Widget build(BuildContext context) {
@@ -29,6 +31,7 @@ class URLField extends StatelessWidget {
         border: InputBorder.none,
       ),
       onChanged: onChanged,
+      onFieldSubmitted: onFieldSubmitted,
     );
   }
 }

--- a/test/widgets/textfields_test.dart
+++ b/test/widgets/textfields_test.dart
@@ -57,4 +57,41 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('entering 123 for cell field'), findsOneWidget);
   });
+
+  testWidgets('URL Field sends request on enter keystroke', (tester) async {
+    bool wasSubmitCalled = false;
+
+    void testSubmit(String val) {
+      wasSubmitCalled = true;
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(
+        title: 'URL Field',
+        theme: kThemeDataDark,
+        home: Scaffold(
+          body: Column(children: [
+            URLField(
+              selectedId: '2',
+              onFieldSubmitted: testSubmit,
+            )
+          ]),
+        ),
+      ),
+    );
+
+    // ensure URLField is blank
+    expect(find.byType(TextFormField), findsOneWidget);
+    expect(find.textContaining('Enter API endpoint '), findsOneWidget);
+    expect(wasSubmitCalled, false);
+
+    // modify value and press enter
+    var txtForm = find.byKey(const Key("url-2"));
+    await tester.enterText(txtForm, 'entering 123');
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pump();
+
+    // check if value was updated
+    expect(wasSubmitCalled, true);
+  });
 }


### PR DESCRIPTION
## PR Description

Triggers `sendRequest` when enter is clicked and `URLField` is in focus.
Implemented the 'Press Enter to Send Request' feature in the URL card, using `onFieldSubmitted`.

## Related Issues

- Related Issue #252 
- Closes #252 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: Will be added soon!

### Testing:
 - Verifiy that pressing Enter sends the request as expected without any issues.

### Awaiting Feedback:

Your feedback and suggestions regarding the implementation are highly appreciated.
Please review and provide any comments or suggestions for improvement.