### PR TITLE
[fix] enter saves edits to model

### DIFF
--- a/lib/widgets/cards.dart
+++ b/lib/widgets/cards.dart
@@ -97,6 +97,12 @@ class SidebarRequestCard extends StatelessWidget {
                               onTapOutsideNameEditor?.call();
                               //FocusScope.of(context).unfocus();
                             },
+                            onFieldSubmitted: (value) {
+                              // As new name is being contantly updated by
+                              // [onChangedNameEditor], stop editing by
+                              // calling this fn
+                              onTapOutsideNameEditor?.call();
+                            },
                             onChanged: onChangedNameEditor,
                             decoration: const InputDecoration(
                               isCollapsed: true,


### PR DESCRIPTION
## PR Description

It was noted that pressing enter on keyboard doesn't save active name edits on `RequestModel` via `SidebarRequestCard`.
This was fixed by setting `selectedIdEditStateProvider` provider to null, same as the function `onTapOutsideNameEditor`.

This works as the new name is constantly updated on `collectionStateNotifierProvider` via `onChanged` callback

## Related Issues

- Related Issue #254
- Closes #254 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Will be added soon!
