### PR TITLE
[fix] fine tune form data input padding

### DIFF
--- a/lib/widgets/form_data_field.dart
+++ b/lib/widgets/form_data_field.dart
@@ -52,7 +52,8 @@ class _FormDataFieldState extends State<FormDataField> {
                 ),
               ),
               hintText: widget.hintText,
-              contentPadding: const EdgeInsets.only(bottom: 12),
+              isCollapsed: true,
+              contentPadding: const EdgeInsets.only(bottom: 8),
               focusedBorder: UnderlineInputBorder(
                 borderSide: BorderSide(
                   color: colorScheme.primary.withOpacity(

--- a/lib/widgets/form_data_field.dart
+++ b/lib/widgets/form_data_field.dart
@@ -52,7 +52,7 @@ class _FormDataFieldState extends State<FormDataField> {
                 ),
               ),
               hintText: widget.hintText,
-              contentPadding: const EdgeInsets.only(bottom: 16),
+              contentPadding: const EdgeInsets.only(bottom: 12),
               focusedBorder: UnderlineInputBorder(
                 borderSide: BorderSide(
                   color: colorScheme.primary.withOpacity(
@@ -65,7 +65,7 @@ class _FormDataFieldState extends State<FormDataField> {
                   color: colorScheme.surfaceVariant,
                 ),
               ),
-              suffixIcon: DropdownButtonFormData(
+              suffix: DropdownButtonFormData(
                 formDataType: widget.formDataType,
                 onChanged: (p0) {
                   if (widget.onFormDataTypeChanged != null) {

--- a/lib/widgets/textfields.dart
+++ b/lib/widgets/textfields.dart
@@ -62,6 +62,7 @@ class CellField extends StatelessWidget {
         color: clrScheme.onSurface,
       ),
       decoration: InputDecoration(
+        contentPadding: const EdgeInsets.only(bottom: 8),
         hintStyle: kCodeStyle.copyWith(
           color: clrScheme.outline.withOpacity(
             kHintOpacity,


### PR DESCRIPTION
## PR Description
Fixes partial obscuring of letters such as `g` and `y` on form data field. This was again due to padding mismatch, which I suspect to be an issue with framework itself.

## Alignments
![image](https://github.com/foss42/apidash/assets/84124091/1807440b-f6d4-45d6-802c-001070b10e93)


## Related Issues

- Related Issue #250 
- Closes #250 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
- [ ] Yes
- [x] No, and this is why: Unable to be tested properly.
