### PR TITLE
added code generation language selector when error

### DIFF
--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -1,9 +1,10 @@
-import 'dart:io';
 import 'dart:convert';
+import 'dart:io';
+
+import 'package:davi/davi.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:davi/davi.dart';
 
 const kDiscordUrl = "https://bit.ly/heyfoss";
 const kGitUrl = "https://github.com/foss42/apidash";
@@ -508,3 +509,4 @@ const kLabelBusy = "Busy";
 const kLabelCopy = "Copy";
 const kLabelSave = "Save";
 const kLabelDownload = "Download";
+const kLabelRetry = "Retry";

--- a/lib/widgets/buttons.dart
+++ b/lib/widgets/buttons.dart
@@ -1,8 +1,9 @@
+import 'package:apidash/consts.dart';
+import 'package:apidash/utils/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'package:apidash/utils/utils.dart';
-import 'package:apidash/consts.dart';
+
 import "snackbars.dart";
 
 class CopyButton extends StatelessWidget {
@@ -230,6 +231,26 @@ class SaveButton extends StatelessWidget {
       ),
       label: const Text(
         kLabelSave,
+        style: kTextStyleButton,
+      ),
+    );
+  }
+}
+
+class RetryButton extends StatelessWidget {
+  const RetryButton({super.key, required this.onPressed});
+  final Function() onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton.icon(
+      onPressed: onPressed,
+      icon: const Icon(
+        Icons.refresh_sharp,
+        size: 20,
+      ),
+      label: const Text(
+        kLabelRetry,
         style: kTextStyleButton,
       ),
     );

--- a/lib/widgets/codegen_previewer.dart
+++ b/lib/widgets/codegen_previewer.dart
@@ -1,10 +1,16 @@
-import 'package:flutter/material.dart';
-import 'package:highlighter/highlighter.dart' show highlight;
 import 'package:apidash/consts.dart';
 import 'package:apidash/utils/utils.dart';
+import 'package:flutter/material.dart';
+import 'package:highlighter/highlighter.dart' show highlight;
+
 import 'code_previewer.dart';
 import 'widgets.dart'
-    show CopyButton, DropdownButtonCodegenLanguage, SaveInDownloadsButton;
+    show
+        CopyButton,
+        DropdownButtonCodegenLanguage,
+        ErrorMessage,
+        RetryButton,
+        SaveInDownloadsButton;
 
 class CodeGenPreviewer extends StatefulWidget {
   const CodeGenPreviewer({
@@ -105,7 +111,7 @@ class ViewCodePane extends StatelessWidget {
     required this.onChangedCodegenLanguage,
   });
 
-  final String code;
+  final String? code;
   final CodegenLanguage codegenLanguage;
   final Function(CodegenLanguage?) onChangedCodegenLanguage;
 
@@ -130,6 +136,42 @@ class ViewCodePane extends StatelessWidget {
         var showLabel = showButtonLabelsInViewCodePane(
           constraints.maxWidth,
         );
+        if (code == null) {
+          return Padding(
+            padding: kP10,
+            child: Column(
+              children: [
+                SizedBox(
+                  height: kHeaderHeight,
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: DropdownButtonCodegenLanguage(
+                          codegenLanguage: codegenLanguage,
+                          onChanged: onChangedCodegenLanguage,
+                        ),
+                      ),
+                      RetryButton(onPressed: () {
+                        onChangedCodegenLanguage;
+                      })
+                    ],
+                  ),
+                ),
+                kVSpacer10,
+                Expanded(
+                  child: Container(
+                      width: double.maxFinite,
+                      padding: kP8,
+                      decoration: textContainerdecoration,
+                      child: const ErrorMessage(
+                        message:
+                            "An error was encountered while generating code. $kRaiseIssue",
+                      )),
+                ),
+              ],
+            ),
+          );
+        }
         return Padding(
           padding: kP10,
           child: Column(
@@ -145,7 +187,7 @@ class ViewCodePane extends StatelessWidget {
                       ),
                     ),
                     CopyButton(
-                      toCopy: code,
+                      toCopy: code!,
                       showLabel: showLabel,
                     ),
                     SaveInDownloadsButton(
@@ -163,7 +205,7 @@ class ViewCodePane extends StatelessWidget {
                   padding: kP8,
                   decoration: textContainerdecoration,
                   child: CodeGenPreviewer(
-                    code: code,
+                    code: code!,
                     theme: codeTheme,
                     language: codegenLanguage.codeHighlightLang,
                     textStyle: kCodeStyle,

--- a/test/widgets/buttons_test.dart
+++ b/test/widgets/buttons_test.dart
@@ -1,8 +1,10 @@
 import 'dart:typed_data';
+
+import 'package:apidash/consts.dart';
+import 'package:apidash/widgets/buttons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:apidash/widgets/buttons.dart';
-import 'package:apidash/consts.dart';
+
 import '../test_consts.dart';
 
 void main() {
@@ -185,5 +187,22 @@ void main() {
 
     expect(find.byIcon(Icons.save), findsOneWidget);
     expect(find.text("Save"), findsOneWidget);
+  });
+  testWidgets('Testing for Retry button', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        title: 'Retry button',
+        theme: kThemeDataLight,
+        home: Scaffold(
+          body: RetryButton(
+            onPressed: () {},
+          ),
+        ),
+      ),
+    );
+    final labelFinder = find.text(kLabelRetry);
+    final iconFinder = find.byIcon(Icons.refresh_sharp);
+    expect(iconFinder, findsOneWidget);
+    expect(labelFinder, findsOneWidget);
   });
 }


### PR DESCRIPTION
## PR Description
prior we were checking if the code generated in code_pane is null or not and returning the error widget without adding the code generator language changing bar . I removed the check in code_pane and added the check in the ViewCodePane(class) which render the error with the code generator language selector and replace the copy and download button with a single button Retry.

## Related Issues
- Related Issue #275 
- Closes #275 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
- [x] Yes for the RetryButton Widget
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
