### PR TITLE
fix: when snapshot.hasError is true, text has not been initialized

### DIFF
--- a/lib/widgets/intro_message.dart
+++ b/lib/widgets/intro_message.dart
@@ -23,6 +23,9 @@ class IntroMessage extends StatelessWidget {
     return FutureBuilder(
       future: introData(),
       builder: (BuildContext context, AsyncSnapshot<void> snapshot) {
+        if (snapshot.hasError) {
+          return const ErrorMessage(message: "An error occured");
+        }
         if (snapshot.connectionState == ConnectionState.done) {
           if (Theme.of(context).brightness == Brightness.dark) {
             text = text.replaceAll("{{mode}}", "dark");
@@ -36,9 +39,6 @@ class IntroMessage extends StatelessWidget {
             data: text,
             padding: kPh60,
           );
-        }
-        if (snapshot.hasError) {
-          return const ErrorMessage(message: "An error occured");
         }
         return const Center(child: CircularProgressIndicator());
       },


### PR DESCRIPTION
## PR Description

fix: when snapshot.hasError is true, text has not been initialized.

![image](https://github.com/foss42/apidash/assets/16632207/3fe4bab9-a5c0-4533-a87d-da8c2c548977)

## Related Issues

- Related Issue #
- Closes #

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
