### PR TITLE
Add feat codegen for Kotlin using retrofit

### DIFF
--- a/lib/codegen/codegen.dart
+++ b/lib/codegen/codegen.dart
@@ -1,4 +1,3 @@
-import 'package:apidash/codegen/kotlin/retrofit.dart';
 import 'package:apidash/models/models.dart' show RequestModel;
 import 'package:apidash/consts.dart';
 import 'package:apidash/utils/utils.dart' show getNewUuid;
@@ -6,6 +5,7 @@ import 'dart/http.dart';
 import 'dart/dio.dart';
 import 'go/http.dart';
 import 'kotlin/okhttp.dart';
+import 'kotlin/retrofit.dart';
 import 'php/guzzle.dart';
 import 'python/http_client.dart';
 import 'python/requests.dart';

--- a/lib/codegen/codegen.dart
+++ b/lib/codegen/codegen.dart
@@ -1,3 +1,4 @@
+import 'package:apidash/codegen/kotlin/retrofit.dart';
 import 'package:apidash/models/models.dart' show RequestModel;
 import 'package:apidash/consts.dart';
 import 'package:apidash/utils/utils.dart' show getNewUuid;
@@ -51,17 +52,19 @@ class Codegen {
         return FetchCodeGen(isNodeJs: true).getCode(rM);
       case CodegenLanguage.kotlinOkHttp:
         return KotlinOkHttpCodeGen().getCode(rM);
+      case CodegenLanguage.kotlinRetrofit:
+        return KotlinRetrofitCodeGen().getCode(rM);
       case CodegenLanguage.pythonHttpClient:
         return PythonHttpClientCodeGen()
             .getCode(rM, boundary: boundary ?? getNewUuid());
       case CodegenLanguage.pythonRequests:
         return PythonRequestsCodeGen().getCode(rM, boundary: boundary);
       case CodegenLanguage.rustActix:
-        return RustActixCodeGen().getCode(rM, boundary: boundary); 
+        return RustActixCodeGen().getCode(rM, boundary: boundary);
       case CodegenLanguage.rustReqwest:
         return RustReqwestCodeGen().getCode(rM);
       case CodegenLanguage.rustUreq:
-        return RustUreqCodeGen().getCode(rM, boundary: boundary); 
+        return RustUreqCodeGen().getCode(rM, boundary: boundary);
       case CodegenLanguage.goHttp:
         return GoHttpCodeGen().getCode(rM);
     }

--- a/lib/codegen/kotlin/retrofit.dart
+++ b/lib/codegen/kotlin/retrofit.dart
@@ -32,8 +32,7 @@ fun main() {
 """;
 
   String kMethodTemplate = '''
-    @{{method}}("{{endpoint}}"{{queryParameters}}{{hasBodyAnnotation}})
-    {{headers}}
+    @{{method}}("{{endpoint}}"{{queryParameters}}{{hasBodyAnnotation}}){{headers}}
     fun {{methodName}}({{parameters}}): Call<ResponseBody>
 ''';
 

--- a/lib/codegen/kotlin/retrofit.dart
+++ b/lib/codegen/kotlin/retrofit.dart
@@ -1,0 +1,141 @@
+import 'dart:convert';
+import 'package:jinja/jinja.dart' as jj;
+import 'package:apidash/utils/utils.dart'
+    show getValidRequestUri, stripUriParams;
+import '../../models/request_model.dart';
+import 'package:apidash/consts.dart';
+
+class KotlinRetrofitCodeGen {
+  final String kTemplateStart = """
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+
+""";
+
+  final String kTemplateEnd = """
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("{{baseUrl}}")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+
+""";
+
+  String kMethodTemplate = '''
+    @{{method}}("{{endpoint}}"{{queryParameters}}{{hasBodyAnnotation}})
+    {{headers}}
+    fun {{methodName}}({{parameters}}): Call<ResponseBody>
+''';
+
+  String? getCode(RequestModel requestModel) {
+    try {
+      String result = "";
+      String baseUrl = "";
+      List<String> methodAnnotations = [];
+      List<String> queryParameters = [];
+      String headersAnnotation = "";
+
+      var rec = getValidRequestUri(
+        requestModel.url,
+        requestModel.enabledRequestParams,
+      );
+      Uri? uri = rec.$1;
+
+      if (uri != null) {
+        baseUrl = uri.origin;
+
+        var method = requestModel.method;
+        var endpoint = stripUriParams(uri);
+        var methodName = requestModel.name;
+
+        // Handle query parameters
+        var params = uri.queryParameters;
+        if (params.isNotEmpty) {
+          for (var param in params.entries) {
+            queryParameters
+                .add("@Query(\"${param.key}\") ${param.key}: String");
+          }
+        }
+
+        // Handle headers
+        var headers = requestModel.enabledHeadersMap;
+        if (headers.isNotEmpty) {
+          headersAnnotation = headers.entries
+              .map((header) =>
+                  '@Header("${header.value}") ${header.key}: String')
+              .join('\n    ');
+        }
+
+        // Add annotations for HTTP method and possible body
+        var hasBodyAnnotation = "";
+        var requestBody = requestModel.requestBody;
+        if (requestBody != null && !requestModel.hasFormData) {
+          hasBodyAnnotation = ", @Body requestBody: RequestBody";
+        }
+
+        methodAnnotations.add(method.name.toUpperCase());
+
+        var parameters = '';
+        // If request body is FormData, add its parameters to method signature
+        if (requestModel.hasFormData) {
+          var formData = requestModel.formDataMapList;
+          for (var item in formData) {
+            parameters +=
+                "@Field(\"${item['value']}\") ${item['name']} : String,";
+          }
+          parameters = parameters.substring(
+              0, parameters.length - 1); // Remove last comma
+        }
+
+        result +=
+            kMethodTemplate.replaceAllMapped(RegExp(r'\{\{(\w+)\}\}'), (match) {
+          switch (match[1]) {
+            case 'method':
+              return methodAnnotations.join(', ');
+            case 'endpoint':
+              return endpoint.replaceFirst(
+                  baseUrl, ""); // Ensure the endpoint is relative
+            case 'queryParameters':
+              return queryParameters.isNotEmpty
+                  ? ", ${queryParameters.join(", ")}"
+                  : "";
+            case 'hasBodyAnnotation':
+              return hasBodyAnnotation;
+            case 'headers':
+              return headersAnnotation;
+            case 'methodName':
+              return methodName;
+            case 'parameters':
+              return parameters;
+            default:
+              return match[0]!;
+          }
+        });
+      }
+
+      var templateStart = jj.Template(kTemplateStart);
+      result = templateStart.render() + result;
+
+      var templateEnd = jj.Template(kTemplateEnd);
+      result += templateEnd.render({"baseUrl": baseUrl});
+
+      return result;
+    } catch (e) {
+      return null;
+    }
+  }
+}
+
+String stripUriParams(Uri uri) {
+  return uri.path;
+}

--- a/lib/codegen/kotlin/retrofit.dart
+++ b/lib/codegen/kotlin/retrofit.dart
@@ -1,9 +1,6 @@
-import 'dart:convert';
 import 'package:jinja/jinja.dart' as jj;
-import 'package:apidash/utils/utils.dart'
-    show getValidRequestUri, stripUriParams;
+import 'package:apidash/utils/utils.dart' show getValidRequestUri;
 import '../../models/request_model.dart';
-import 'package:apidash/consts.dart';
 
 class KotlinRetrofitCodeGen {
   final String kTemplateStart = """
@@ -77,8 +74,7 @@ fun main() {
 
         // Add annotations for HTTP method and possible body
         var hasBodyAnnotation = "";
-        var requestBody = requestModel.requestBody;
-        if (requestBody != null && !requestModel.hasFormData) {
+        if (requestModel.hasJsonData || requestModel.hasTextData) {
           hasBodyAnnotation = ", @Body requestBody: RequestBody";
         }
 

--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -272,6 +272,7 @@ enum CodegenLanguage {
   nodejsAxios("node.js (axios)", "javascript", "js"),
   nodejsFetch("node.js (fetch)", "javascript", "js"),
   kotlinOkHttp("Kotlin (okhttp3)", "java", "kt"),
+  kotlinRetrofit("Kotlin (Retrofit)", "java", "kt"),
   pythonHttpClient("Python (http.client)", "python", "py"),
   pythonRequests("Python (requests)", "python", "py"),
   rustActix("Rust (Actix Client)", "rust", "rs"),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  web: ^0.5.0
+  web: 0.3.0
   multi_split_view: ^2.4.0
   url_launcher: ^6.1.12
   flutter_riverpod: ^2.3.7

--- a/test/codegen/kotlin_retrofit_codegen_test.dart
+++ b/test/codegen/kotlin_retrofit_codegen_test.dart
@@ -1,0 +1,279 @@
+import 'package:apidash/codegen/codegen.dart';
+import 'package:apidash/consts.dart';
+import 'package:test/test.dart';
+import '../request_models.dart';
+
+void main() {
+  final codeGen = Codegen();
+
+  group('GET Request', () {
+    test('GET 1', () {
+      const expectedCode = '''
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+    @GET("")
+    fun (): Call<ResponseBody>
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("https://api.apidash.dev")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+''';
+      expect(
+          codeGen.getCode(
+              CodegenLanguage.kotlinRetrofit, requestModelGet1, "https"),
+          expectedCode);
+    });
+
+    test('GET 2', () {
+      const expectedCode = '''
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+    @GET("/country/data", @Query("code") code: String)
+    fun (): Call<ResponseBody>
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("https://api.apidash.dev")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+''';
+      expect(
+          codeGen.getCode(
+              CodegenLanguage.kotlinRetrofit, requestModelGet2, "https"),
+          expectedCode);
+    });
+
+    test('GET 3', () {
+      const expectedCode = '''
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+    @GET("/country/data", @Query("code") code: String)
+    fun (): Call<ResponseBody>
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("https://api.apidash.dev")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+''';
+      expect(
+          codeGen.getCode(
+              CodegenLanguage.kotlinRetrofit, requestModelGet2, "https"),
+          expectedCode);
+    });
+  });
+
+  group('POST Request', () {
+    test('POST 4', () {
+      const expectedCode = '''
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+    @POST("/io/form")
+
+    fun (@Field("API") text : String,@Field("|") sep : String,@Field("3") times : String): Call<ResponseBody>
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("https://api.apidash.dev")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+''';
+      expect(
+          codeGen.getCode(
+              CodegenLanguage.kotlinRetrofit, requestModelPost4, "https"),
+          expectedCode);
+    });
+
+    test('POST 5', () {
+      const expectedCode = '''
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+    @POST("/io/form")
+    @Header("Test Agent") User-Agent: String
+    fun (@Field("API") text : String,@Field("|") sep : String,@Field("3") times : String): Call<ResponseBody>
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("https://api.apidash.dev")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+''';
+      expect(
+          codeGen.getCode(
+              CodegenLanguage.kotlinRetrofit, requestModelPost5, "https"),
+          expectedCode);
+    });
+
+    test('POST 6', () {
+      const expectedCode = '''
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+    @POST("/io/img")
+    
+    fun (@Field("xyz") token : String,@Field("/Documents/up/1.png") imfile : String): Call<ResponseBody>
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("https://api.apidash.dev")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+''';
+      expect(
+          codeGen.getCode(
+              CodegenLanguage.kotlinRetrofit, requestModelPost6, "https"),
+          expectedCode);
+    });
+
+    test('POST 7', () {
+      const expectedCode = '''
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+    @POST("/io/img")
+    
+    fun (@Field("xyz") token : String,@Field("/Documents/up/1.png") imfile : String): Call<ResponseBody>
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("https://api.apidash.dev")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+''';
+      expect(
+          codeGen.getCode(
+              CodegenLanguage.kotlinRetrofit, requestModelPost7, "https"),
+          expectedCode);
+    });
+
+    test('POST 8', () {
+      const expectedCode = '''
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+    @POST("/io/form", @Query("size") size: String, @Query("len") len: String)
+    
+    fun (@Field("API") text : String,@Field("|") sep : String,@Field("3") times : String): Call<ResponseBody>
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("https://api.apidash.dev")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+''';
+      expect(
+          codeGen.getCode(
+              CodegenLanguage.kotlinRetrofit, requestModelPost8, "https"),
+          expectedCode);
+    });
+
+    test('POST 9', () {
+      const expectedCode = '''
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+    @POST("/io/img", @Query("size") size: String, @Query("len") len: String)
+    @Header("Test Agent") User-Agent: String
+    @Header("true") Keep-Alive: String
+    fun (@Field("xyz") token : String,@Field("/Documents/up/1.png") imfile : String): Call<ResponseBody>
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("https://api.apidash.dev")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+''';
+      expect(
+          codeGen.getCode(
+              CodegenLanguage.kotlinRetrofit, requestModelPost9, "https"),
+          expectedCode);
+    });
+  });
+
+  group('PUT Request', () {
+    // Add test cases for PUT requests...
+  });
+
+  group('DELETE Request', () {
+    // Add test cases for DELETE requests...
+  });
+}

--- a/test/codegen/kotlin_retrofit_codegen_test.dart
+++ b/test/codegen/kotlin_retrofit_codegen_test.dart
@@ -102,7 +102,6 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 interface ApiService {
     @POST("/io/form")
-
     fun (@Field("API") text : String,@Field("|") sep : String,@Field("3") times : String): Call<ResponseBody>
 }
 
@@ -130,8 +129,7 @@ import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
 interface ApiService {
-    @POST("/io/form")
-    @Header("Test Agent") User-Agent: String
+    @POST("/io/form")@Header("Test Agent") User-Agent: String
     fun (@Field("API") text : String,@Field("|") sep : String,@Field("3") times : String): Call<ResponseBody>
 }
 
@@ -160,7 +158,6 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 interface ApiService {
     @POST("/io/img")
-    
     fun (@Field("xyz") token : String,@Field("/Documents/up/1.png") imfile : String): Call<ResponseBody>
 }
 
@@ -189,7 +186,6 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 interface ApiService {
     @POST("/io/img")
-    
     fun (@Field("xyz") token : String,@Field("/Documents/up/1.png") imfile : String): Call<ResponseBody>
 }
 
@@ -218,7 +214,6 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 interface ApiService {
     @POST("/io/form", @Query("size") size: String, @Query("len") len: String)
-    
     fun (@Field("API") text : String,@Field("|") sep : String,@Field("3") times : String): Call<ResponseBody>
 }
 
@@ -246,8 +241,7 @@ import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
 interface ApiService {
-    @POST("/io/img", @Query("size") size: String, @Query("len") len: String)
-    @Header("Test Agent") User-Agent: String
+    @POST("/io/img", @Query("size") size: String, @Query("len") len: String)@Header("Test Agent") User-Agent: String
     @Header("true") Keep-Alive: String
     fun (@Field("xyz") token : String,@Field("/Documents/up/1.png") imfile : String): Call<ResponseBody>
 }

--- a/test/codegen/kotlin_retrofit_codegen_test.dart
+++ b/test/codegen/kotlin_retrofit_codegen_test.dart
@@ -183,7 +183,7 @@ import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
 interface ApiService {
-    @GET("", @Body requestBody: RequestBody)
+    @GET("")
     fun (): Call<ResponseBody>
 }
 

--- a/test/codegen/kotlin_retrofit_codegen_test.dart
+++ b/test/codegen/kotlin_retrofit_codegen_test.dart
@@ -87,12 +87,347 @@ fun main() {
 ''';
       expect(
           codeGen.getCode(
-              CodegenLanguage.kotlinRetrofit, requestModelGet2, "https"),
+              CodegenLanguage.kotlinRetrofit, requestModelGet3, "https"),
+          expectedCode);
+    });
+
+    test('GET 4', () {
+      const expectedCode = '''
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+    @GET("/humanize/social", @Query("num") num: String, @Query("digits") digits: String, @Query("system") system: String, @Query("add_space") add_space: String, @Query("trailing_zeros") trailing_zeros: String)
+    fun (): Call<ResponseBody>
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("https://api.apidash.dev")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+''';
+      expect(
+          codeGen.getCode(
+              CodegenLanguage.kotlinRetrofit, requestModelGet4, "https"),
+          expectedCode);
+    });
+
+    test('GET 5', () {
+      const expectedCode = '''
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+    @GET("/repos/foss42/apidash")@Header("Test Agent") User-Agent: String
+    fun (): Call<ResponseBody>
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("https://api.github.com")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+''';
+      expect(
+          codeGen.getCode(
+              CodegenLanguage.kotlinRetrofit, requestModelGet5, "https"),
+          expectedCode);
+    });
+
+    test('GET 6', () {
+      const expectedCode = '''
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+    @GET("/repos/foss42/apidash", @Query("raw") raw: String)@Header("Test Agent") User-Agent: String
+    fun (): Call<ResponseBody>
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("https://api.github.com")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+''';
+      expect(
+          codeGen.getCode(
+              CodegenLanguage.kotlinRetrofit, requestModelGet6, "https"),
+          expectedCode);
+    });
+
+    test('GET 7', () {
+      const expectedCode = '''
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+    @GET("", @Body requestBody: RequestBody)
+    fun (): Call<ResponseBody>
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("https://api.apidash.dev")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+''';
+      expect(
+          codeGen.getCode(
+              CodegenLanguage.kotlinRetrofit, requestModelGet7, "https"),
+          expectedCode);
+    });
+
+    test('GET 8', () {
+      const expectedCode = '''
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+    @GET("/repos/foss42/apidash", @Query("raw") raw: String)@Header("Test Agent") User-Agent: String
+    fun (): Call<ResponseBody>
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("https://api.github.com")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+''';
+      expect(
+          codeGen.getCode(
+              CodegenLanguage.kotlinRetrofit, requestModelGet8, "https"),
+          expectedCode);
+    });
+
+    test('GET 9', () {
+      const expectedCode = '''
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+    @GET("/humanize/social", @Query("num") num: String, @Query("add_space") add_space: String)
+    fun (): Call<ResponseBody>
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("https://api.apidash.dev")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+''';
+      expect(
+          codeGen.getCode(
+              CodegenLanguage.kotlinRetrofit, requestModelGet9, "https"),
+          expectedCode);
+    });
+
+    test('GET 10', () {
+      const expectedCode = '''
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+    @GET("/humanize/social")@Header("Test Agent") User-Agent: String
+    fun (): Call<ResponseBody>
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("https://api.apidash.dev")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+''';
+      expect(
+          codeGen.getCode(
+              CodegenLanguage.kotlinRetrofit, requestModelGet10, "https"),
+          expectedCode);
+    });
+
+    test('GET 11', () {
+      const expectedCode = '''
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+    @GET("/humanize/social", @Query("num") num: String, @Query("digits") digits: String)@Header("Test Agent") User-Agent: String
+    fun (): Call<ResponseBody>
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("https://api.apidash.dev")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+''';
+      expect(
+          codeGen.getCode(
+              CodegenLanguage.kotlinRetrofit, requestModelGet11, "https"),
+          expectedCode);
+    });
+
+    test('GET 12', () {
+      const expectedCode = '''
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+    @GET("/humanize/social")
+    fun (): Call<ResponseBody>
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("https://api.apidash.dev")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+''';
+      expect(
+          codeGen.getCode(
+              CodegenLanguage.kotlinRetrofit, requestModelGet12, "https"),
           expectedCode);
     });
   });
 
   group('POST Request', () {
+    test('POST 1', () {
+      const expectedCode = '''
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+    @POST("/case/lower", @Body requestBody: RequestBody)
+    fun (): Call<ResponseBody>
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("https://api.apidash.dev")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+''';
+      expect(
+          codeGen.getCode(
+              CodegenLanguage.kotlinRetrofit, requestModelPost1, "https"),
+          expectedCode);
+    });
+
+    test('POST 2', () {
+      const expectedCode = '''
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+    @POST("/case/lower", @Body requestBody: RequestBody)
+    fun (): Call<ResponseBody>
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("https://api.apidash.dev")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+''';
+      expect(
+          codeGen.getCode(
+              CodegenLanguage.kotlinRetrofit, requestModelPost2, "https"),
+          expectedCode);
+    });
+
+    test('POST 3', () {
+      const expectedCode = '''
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+    @POST("/case/lower", @Body requestBody: RequestBody)@Header("Test Agent") User-Agent: String
+    fun (): Call<ResponseBody>
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("https://api.apidash.dev")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+''';
+      expect(
+          codeGen.getCode(
+              CodegenLanguage.kotlinRetrofit, requestModelPost3, "https"),
+          expectedCode);
+    });
     test('POST 4', () {
       const expectedCode = '''
 import retrofit2.http.*
@@ -264,10 +599,119 @@ fun main() {
   });
 
   group('PUT Request', () {
-    // Add test cases for PUT requests...
+    test('Put 1', () {
+      const expectedCode = '''
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+    @PUT("/api/users/2", @Body requestBody: RequestBody)
+    fun (): Call<ResponseBody>
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("https://reqres.in")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+''';
+      expect(
+          codeGen.getCode(
+              CodegenLanguage.kotlinRetrofit, requestModelPut1, "https"),
+          expectedCode);
+    });
   });
 
+  group('PATCH Request', () {
+    test('Patch 1', () {
+      const expectedCode = '''
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+    @PATCH("/api/users/2", @Body requestBody: RequestBody)
+    fun (): Call<ResponseBody>
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("https://reqres.in")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+''';
+      expect(
+          codeGen.getCode(
+              CodegenLanguage.kotlinRetrofit, requestModelPatch1, "https"),
+          expectedCode);
+    });
+  });
   group('DELETE Request', () {
-    // Add test cases for DELETE requests...
+    test('Delete 1', () {
+      const expectedCode = '''
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+    @DELETE("/api/users/2")
+    fun (): Call<ResponseBody>
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("https://reqres.in")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+''';
+      expect(
+          codeGen.getCode(
+              CodegenLanguage.kotlinRetrofit, requestModelDelete1, "https"),
+          expectedCode);
+    });
+
+    test('Delete 2', () {
+      const expectedCode = '''
+import retrofit2.http.*
+import retrofit2.Call
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+interface ApiService {
+    @DELETE("/api/users/2", @Body requestBody: RequestBody)
+    fun (): Call<ResponseBody>
+}
+
+fun main() {
+    val service = Retrofit.Builder()
+        .baseUrl("https://reqres.in")
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+        .create(ApiService::class.java)
+
+    // Call your API methods here using service object
+}
+''';
+      expect(
+          codeGen.getCode(
+              CodegenLanguage.kotlinRetrofit, requestModelDelete2, "https"),
+          expectedCode);
+    });
   });
 }


### PR DESCRIPTION
## PR Description

This PR introduces support for generating Kotlin code using Retrofit for API communication. Retrofit is a type-safe HTTP client for Android and Java by Square, Inc., that makes it easy to consume RESTful web services

<img src= "https://github.com/foss42/apidash/assets/100941430/d6087a07-5649-4b6f-9f5b-d3341f9e5a27" alt="Description of image" width="600">


## Related Issues

- Related Issue #247 
- Closes #247

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
