### PR TITLE
feat: ability to clear current response

### DIFF
--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -96,6 +96,29 @@ class CollectionStateNotifier
     state = map;
   }
 
+  void clearResponse(String id) {
+    var map = {...state!};
+    map[id] = RequestModel(
+      id: id,
+      method: state![id]!.method,
+      url: state![id]!.url,
+      name: state![id]!.name,
+      description: state![id]!.description,
+      requestTabIndex: state![id]!.requestTabIndex,
+      requestHeaders: state![id]!.requestHeaders,
+      requestParams: state![id]!.requestParams,
+      isHeaderEnabledList: state![id]!.isHeaderEnabledList,
+      isParamEnabledList: state![id]!.isParamEnabledList,
+      requestBodyContentType: state![id]!.requestBodyContentType,
+      requestBody: state![id]!.requestBody,
+      requestFormDataList: state![id]!.requestFormDataList,
+      responseStatus: null,
+      message: null,
+      responseModel: null,
+    );
+    state = map;
+  }
+
   void duplicate(String id) {
     final newId = getNewUuid();
 

--- a/lib/widgets/buttons.dart
+++ b/lib/widgets/buttons.dart
@@ -1,5 +1,7 @@
+import 'package:apidash/providers/providers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:apidash/utils/utils.dart';
 import 'package:apidash/consts.dart';
@@ -231,6 +233,37 @@ class SaveButton extends StatelessWidget {
       label: const Text(
         kLabelSave,
         style: kTextStyleButton,
+      ),
+    );
+  }
+}
+
+class ClearResponseButton extends ConsumerWidget {
+  const ClearResponseButton({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    var sm = ScaffoldMessenger.of(context);
+    return Tooltip(
+      message: 'Clear response',
+      child: TextButton(
+        style: TextButton.styleFrom(minimumSize: const Size(40, 40)),
+        onPressed: () {
+          final selectedId = ref.watch(selectedIdStateProvider);
+          ref
+              .read(collectionStateNotifierProvider.notifier)
+              .clearResponse(selectedId!);
+          sm.hideCurrentSnackBar();
+          sm.showSnackBar(
+            const SnackBar(
+              content: Text('Response cleared'),
+            ),
+          );
+        },
+        child: const Icon(
+          Icons.delete,
+          size: 20,
+        ),
       ),
     );
   }

--- a/lib/widgets/response_widgets.dart
+++ b/lib/widgets/response_widgets.dart
@@ -116,6 +116,8 @@ class ResponsePaneHeader extends StatelessWidget {
                     color: Theme.of(context).colorScheme.secondary,
                   ),
             ),
+            kHSpacer10,
+            const ClearResponseButton()
           ],
         ),
       ),

--- a/test/widgets/buttons_test.dart
+++ b/test/widgets/buttons_test.dart
@@ -186,4 +186,18 @@ void main() {
     expect(find.byIcon(Icons.save), findsOneWidget);
     expect(find.text("Save"), findsOneWidget);
   });
+
+  testWidgets('Testing for ClearResponseButton', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        title: 'ClearResponseButton',
+        theme: kThemeDataLight,
+        home: const Scaffold(
+          body: ClearResponseButton(),
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.delete), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## PR Description

Adds the ability to clear the current response of a request.
Note: The `clearResponse` method in the `CollectionStateNotifier` doesn't utilise the copyWith method of the `RequestModel` because the copyWith method uses null checks for `responseStatus`, `message` and `responseModel`

## Related Issues

- Related Issue #310 
- Closes #310 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [x] Yes
