### PR TITLE
fix: prevent adding multiple empty rows

### DIFF
--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_form_data.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_form_data.dart
@@ -18,6 +18,7 @@ class _FormDataBodyState extends ConsumerState<FormDataWidget> {
   late int seed;
   final random = Random.secure();
   late List<FormDataModel> formRows;
+  bool isAddingRow = false;
 
   @override
   void initState() {
@@ -45,6 +46,7 @@ class _FormDataBodyState extends ConsumerState<FormDataWidget> {
           ]
         : rF;
     formRows = isFormDataEmpty ? rows : rows + [kFormDataEmptyModel];
+    isAddingRow = false;
 
     DaviModel<FormDataModel> daviModelRows = DaviModel<FormDataModel>(
       rows: formRows,
@@ -64,7 +66,10 @@ class _FormDataBodyState extends ConsumerState<FormDataWidget> {
                 hintText: " Add Key",
                 onChanged: (value) {
                   formRows[idx] = formRows[idx].copyWith(name: value);
-                  if (isLast) formRows.add(kFormDataEmptyModel);
+                  if (isLast && !isAddingRow) {
+                    isAddingRow = true;
+                    formRows.add(kFormDataEmptyModel);
+                  }
                   _onFieldChange(selectedId!);
                 },
                 colorScheme: Theme.of(context).colorScheme,
@@ -75,7 +80,7 @@ class _FormDataBodyState extends ConsumerState<FormDataWidget> {
                     type: value ?? FormDataType.text,
                   );
                   formRows[idx] = formRows[idx].copyWith(value: "");
-                  if (idx == formRows.length - 1 && hasChanged) {
+                  if (isLast && hasChanged) {
                     formRows.add(kFormDataEmptyModel);
                   }
                   setState(() {});
@@ -157,7 +162,10 @@ class _FormDataBodyState extends ConsumerState<FormDataWidget> {
                     hintText: " Add Value",
                     onChanged: (value) {
                       formRows[idx] = formRows[idx].copyWith(value: value);
-                      if (isLast) formRows.add(kFormDataEmptyModel);
+                      if (isLast && !isAddingRow) {
+                        isAddingRow = true;
+                        formRows.add(kFormDataEmptyModel);
+                      }
                       _onFieldChange(selectedId!);
                     },
                     colorScheme: Theme.of(context).colorScheme,

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_headers.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_headers.dart
@@ -19,6 +19,7 @@ class EditRequestHeadersState extends ConsumerState<EditRequestHeaders> {
   final random = Random.secure();
   late List<NameValueModel> headerRows;
   late List<bool> isRowEnabledList;
+  bool isAddingRow = false;
 
   @override
   void initState() {
@@ -52,6 +53,7 @@ class EditRequestHeadersState extends ConsumerState<EditRequestHeaders> {
         ref.read(selectedRequestModelProvider)?.isHeaderEnabledList ??
             List.filled(rH?.length ?? 0, true, growable: true);
     isRowEnabledList.add(false);
+    isAddingRow = false;
 
     DaviModel<NameValueModel> model = DaviModel<NameValueModel>(
       rows: headerRows,
@@ -90,7 +92,8 @@ class EditRequestHeadersState extends ConsumerState<EditRequestHeaders> {
               hintText: "Add Header Name",
               onChanged: (value) {
                 headerRows[idx] = headerRows[idx].copyWith(name: value);
-                if (isLast) {
+                if (isLast && !isAddingRow) {
+                  isAddingRow = true;
                   isRowEnabledList[idx] = true;
                   headerRows.add(kNameValueEmptyModel);
                   isRowEnabledList.add(false);
@@ -123,7 +126,8 @@ class EditRequestHeadersState extends ConsumerState<EditRequestHeaders> {
               hintText: " Add Header Value",
               onChanged: (value) {
                 headerRows[idx] = headerRows[idx].copyWith(value: value);
-                if (isLast) {
+                if (isLast && !isAddingRow) {
+                  isAddingRow = true;
                   isRowEnabledList[idx] = true;
                   headerRows.add(kNameValueEmptyModel);
                   isRowEnabledList.add(false);

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_params.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_params.dart
@@ -20,6 +20,7 @@ class EditRequestURLParamsState extends ConsumerState<EditRequestURLParams> {
   final random = Random.secure();
   late List<NameValueModel> paramRows;
   late List<bool> isRowEnabledList;
+  bool isAddingRow = false;
 
   @override
   void initState() {
@@ -52,6 +53,7 @@ class EditRequestURLParamsState extends ConsumerState<EditRequestURLParams> {
         ref.read(selectedRequestModelProvider)?.isParamEnabledList ??
             List.filled(rP?.length ?? 0, true, growable: true);
     isRowEnabledList.add(false);
+    isAddingRow = false;
 
     DaviModel<NameValueModel> model = DaviModel<NameValueModel>(
       rows: paramRows,
@@ -90,7 +92,8 @@ class EditRequestURLParamsState extends ConsumerState<EditRequestURLParams> {
               hintText: "Add URL Parameter",
               onChanged: (value) {
                 paramRows[idx] = paramRows[idx].copyWith(name: value);
-                if (isLast) {
+                if (isLast && !isAddingRow) {
+                  isAddingRow = true;
                   isRowEnabledList[idx] = true;
                   paramRows.add(kNameValueEmptyModel);
                   isRowEnabledList.add(false);
@@ -123,7 +126,8 @@ class EditRequestURLParamsState extends ConsumerState<EditRequestURLParams> {
               hintText: "Add Value",
               onChanged: (value) {
                 paramRows[idx] = paramRows[idx].copyWith(value: value);
-                if (isLast) {
+                if (isLast && !isAddingRow) {
+                  isAddingRow = true;
                   isRowEnabledList[idx] = true;
                   paramRows.add(kNameValueEmptyModel);
                   isRowEnabledList.add(false);


### PR DESCRIPTION
## PR Description
Resolved the issue of multiple rows being added by introducing an `isAddingRow` flag. The flag prevents additional rows from being added while the user is still typing rapidly.

https://github.com/foss42/apidash/assets/95911940/b832fbf0-46e4-43cd-9651-c53585b696af

## Related Issues

- Related Issue #345 
- Closes #345  

### Checklist
- [X] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [X] I have updated my branch and synced it with project `main` branch before making this PR
- [X] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [X] No, and this is why: Doesn't require/break any tests.