### PR TITLE
feat: Add a search/filter for collection pane

### DIFF
--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'settings_providers.dart';
 import 'ui_providers.dart';
@@ -8,6 +9,7 @@ import '../consts.dart';
 import 'package:http/http.dart' as http;
 
 final selectedIdStateProvider = StateProvider<String?>((ref) => null);
+final searchQueryProvider = StateProvider<String>((ref) => '');
 
 final selectedRequestModelProvider = StateProvider<RequestModel?>((ref) {
   final selectedId = ref.watch(selectedIdStateProvider);
@@ -31,7 +33,7 @@ final StateNotifierProvider<CollectionStateNotifier, Map<String, RequestModel>?>
 class CollectionStateNotifier
     extends StateNotifier<Map<String, RequestModel>?> {
   CollectionStateNotifier(this.ref, this.hiveHandler) : super(null) {
-    var status = loadData();
+    var status = filterRequests(ref.read(searchQueryProvider.notifier).state);
     Future.microtask(() {
       if (status) {
         ref.read(requestSequenceProvider.notifier).state = [
@@ -244,6 +246,37 @@ class CollectionStateNotifier
         }
       }
       state = data;
+      return false;
+    }
+  }
+
+  bool filterRequests(String query) {
+    if (query.isEmpty) {
+
+      loadData();
+      return true;
+    } else {
+      // Filter requests based on the query
+      final filteredRequests = state?.values.where((request) =>
+          request.name.toLowerCase().contains(query.toLowerCase())).toList();
+
+
+      if (filteredRequests != null && filteredRequests.isNotEmpty) {
+
+        Map<String, RequestModel> requestMap = {};
+
+        for (var request in filteredRequests) {
+          requestMap[request.id] = request;
+        }
+
+        state = requestMap;
+
+      } else {
+        print("No matching requests found");
+      }
+
+
+
       return false;
     }
   }

--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -1,4 +1,3 @@
-import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'settings_providers.dart';
 import 'ui_providers.dart';
@@ -9,7 +8,6 @@ import '../consts.dart';
 import 'package:http/http.dart' as http;
 
 final selectedIdStateProvider = StateProvider<String?>((ref) => null);
-final searchQueryProvider = StateProvider<String>((ref) => '');
 
 final selectedRequestModelProvider = StateProvider<RequestModel?>((ref) {
   final selectedId = ref.watch(selectedIdStateProvider);
@@ -33,7 +31,7 @@ final StateNotifierProvider<CollectionStateNotifier, Map<String, RequestModel>?>
 class CollectionStateNotifier
     extends StateNotifier<Map<String, RequestModel>?> {
   CollectionStateNotifier(this.ref, this.hiveHandler) : super(null) {
-    var status = filterRequests(ref.read(searchQueryProvider.notifier).state);
+    var status = loadData();
     Future.microtask(() {
       if (status) {
         ref.read(requestSequenceProvider.notifier).state = [
@@ -246,37 +244,6 @@ class CollectionStateNotifier
         }
       }
       state = data;
-      return false;
-    }
-  }
-
-  bool filterRequests(String query) {
-    if (query.isEmpty) {
-
-      loadData();
-      return true;
-    } else {
-      // Filter requests based on the query
-      final filteredRequests = state?.values.where((request) =>
-          request.name.toLowerCase().contains(query.toLowerCase())).toList();
-
-
-      if (filteredRequests != null && filteredRequests.isNotEmpty) {
-
-        Map<String, RequestModel> requestMap = {};
-
-        for (var request in filteredRequests) {
-          requestMap[request.id] = request;
-        }
-
-        state = requestMap;
-
-      } else {
-        print("No matching requests found");
-      }
-
-
-
       return false;
     }
   }

--- a/lib/providers/ui_providers.dart
+++ b/lib/providers/ui_providers.dart
@@ -23,3 +23,5 @@ final nameTextFieldFocusNodeProvider =
   });
   return focusNode;
 });
+
+final searchQueryProvider = StateProvider<String>((ref) => '');

--- a/lib/screens/home_page/collection_pane.dart
+++ b/lib/screens/home_page/collection_pane.dart
@@ -93,10 +93,7 @@ class CollectionPane extends ConsumerWidget {
                     style: Theme.of(context).textTheme.bodyMedium,
                     hintText: "Filter by name or URL",
                     onChanged: (value) {
-                      if (value.trim().isNotEmpty) {
-                        ref.read(searchQueryProvider.notifier).state = value;
-                        print(value);
-                      }
+                      ref.read(searchQueryProvider.notifier).state = value;
                     },
                   ),
                 ),
@@ -143,41 +140,44 @@ class _RequestListState extends ConsumerState<RequestList> {
     final requestItems = ref.watch(collectionStateNotifierProvider)!;
     final alwaysShowCollectionPaneScrollbar = ref.watch(settingsProvider
         .select((value) => value.alwaysShowCollectionPaneScrollbar));
+    final filterQuery = ref.watch(searchQueryProvider).trim();
 
     return Scrollbar(
       controller: controller,
       thumbVisibility: alwaysShowCollectionPaneScrollbar ? true : null,
       radius: const Radius.circular(12),
-      child: ReorderableListView.builder(
-        padding: kPr8CollectionPane,
-        scrollController: controller,
-        buildDefaultDragHandles: false,
-        itemCount: requestItems.length,
-        onReorder: (int oldIndex, int newIndex) {
-          if (oldIndex < newIndex) {
-            newIndex -= 1;
-          }
-          if (oldIndex != newIndex) {
-            ref
-                .read(collectionStateNotifierProvider.notifier)
-                .reorder(oldIndex, newIndex);
-          }
-        },
-        itemBuilder: (context, index) {
-          var id = requestSequence[index];
-          return ReorderableDragStartListener(
-            key: ValueKey(id),
-            index: index,
-            child: Padding(
-              padding: kP1,
-              child: RequestItem(
-                id: id,
-                requestModel: requestItems[id]!,
-              ),
-            ),
-          );
-        },
-      ),
+      child: filterQuery.isEmpty
+          ? ReorderableListView.builder(
+              padding: kPr8CollectionPane,
+              scrollController: controller,
+              buildDefaultDragHandles: false,
+              itemCount: requestItems.length,
+              onReorder: (int oldIndex, int newIndex) {
+                if (oldIndex < newIndex) {
+                  newIndex -= 1;
+                }
+                if (oldIndex != newIndex) {
+                  ref
+                      .read(collectionStateNotifierProvider.notifier)
+                      .reorder(oldIndex, newIndex);
+                }
+              },
+              itemBuilder: (context, index) {
+                var id = requestSequence[index];
+                return ReorderableDragStartListener(
+                  key: ValueKey(id),
+                  index: index,
+                  child: Padding(
+                    padding: kP1,
+                    child: RequestItem(
+                      id: id,
+                      requestModel: requestItems[id]!,
+                    ),
+                  ),
+                );
+              },
+            )
+          : SizedBox(),
     );
   }
 }

--- a/lib/screens/home_page/collection_pane.dart
+++ b/lib/screens/home_page/collection_pane.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:apidash/providers/providers.dart';
@@ -67,33 +66,44 @@ class CollectionPane extends ConsumerWidget {
                     style: kTextStyleButton,
                   ),
                 ),
-
               ],
             ),
           ),
           kVSpacer10,
-           SizedBox(
-            height:30,
-            child:SearchBar(
-
-              onChanged: (value){
-                  if(value.isNotEmpty){
-                  ref.read(searchQueryProvider.notifier).state = value;
-                  ref.read(collectionStateNotifierProvider.notifier)
-                      .filterRequests(value);
-                  }
-                  else{
-
-                  }
-
-              },
-              hintText: "search",
-              leading: Icon(Icons.search),
-              textStyle: MaterialStateTextStyle.resolveWith((states) => TextStyle(fontSize: 15.0)),
-              elevation: MaterialStateProperty.all(2.0),
-            )),
+          Container(
+            height: 30,
+            margin: const EdgeInsets.only(right: 8),
+            decoration: BoxDecoration(
+              borderRadius: kBorderRadius8,
+              border: Border.all(
+                color: Theme.of(context).colorScheme.surfaceVariant,
+              ),
+            ),
+            child: Row(
+              children: [
+                kHSpacer5,
+                Icon(
+                  Icons.filter_alt,
+                  size: 18,
+                  color: Theme.of(context).colorScheme.secondary,
+                ),
+                kHSpacer5,
+                Expanded(
+                  child: RawTextField(
+                    style: Theme.of(context).textTheme.bodyMedium,
+                    hintText: "Filter by name or URL",
+                    onChanged: (value) {
+                      if (value.trim().isNotEmpty) {
+                        ref.read(searchQueryProvider.notifier).state = value;
+                        print(value);
+                      }
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
           kVSpacer10,
-
           const Expanded(
             child: RequestList(),
           ),
@@ -134,7 +144,7 @@ class _RequestListState extends ConsumerState<RequestList> {
     final alwaysShowCollectionPaneScrollbar = ref.watch(settingsProvider
         .select((value) => value.alwaysShowCollectionPaneScrollbar));
 
-    return requestItems.isNotEmpty?Scrollbar(
+    return Scrollbar(
       controller: controller,
       thumbVisibility: alwaysShowCollectionPaneScrollbar ? true : null,
       radius: const Radius.circular(12),
@@ -155,7 +165,6 @@ class _RequestListState extends ConsumerState<RequestList> {
         },
         itemBuilder: (context, index) {
           var id = requestSequence[index];
-          print(requestItems[id]!);
 
           return ReorderableDragStartListener(
             key: ValueKey(id),
@@ -170,7 +179,7 @@ class _RequestListState extends ConsumerState<RequestList> {
           );
         },
       ),
-    ):Text("data");
+    );
   }
 }
 

--- a/lib/screens/home_page/collection_pane.dart
+++ b/lib/screens/home_page/collection_pane.dart
@@ -93,7 +93,8 @@ class CollectionPane extends ConsumerWidget {
                     style: Theme.of(context).textTheme.bodyMedium,
                     hintText: "Filter by name or URL",
                     onChanged: (value) {
-                      ref.read(searchQueryProvider.notifier).state = value;
+                      ref.read(searchQueryProvider.notifier).state =
+                          value.toLowerCase();
                     },
                   ),
                 ),
@@ -177,7 +178,24 @@ class _RequestListState extends ConsumerState<RequestList> {
                 );
               },
             )
-          : SizedBox(),
+          : ListView(
+              padding: kPe8,
+              controller: controller,
+              children: requestSequence.map((id) {
+                var item = requestItems[id]!;
+                if (item.url.toLowerCase().contains(filterQuery) ||
+                    item.name.toLowerCase().contains(filterQuery)) {
+                  return Padding(
+                    padding: kP1,
+                    child: RequestItem(
+                      id: id,
+                      requestModel: item,
+                    ),
+                  );
+                }
+                return const SizedBox();
+              }).toList(),
+            ),
     );
   }
 }

--- a/lib/screens/home_page/collection_pane.dart
+++ b/lib/screens/home_page/collection_pane.dart
@@ -165,7 +165,6 @@ class _RequestListState extends ConsumerState<RequestList> {
         },
         itemBuilder: (context, index) {
           var id = requestSequence[index];
-
           return ReorderableDragStartListener(
             key: ValueKey(id),
             index: index,

--- a/lib/screens/home_page/collection_pane.dart
+++ b/lib/screens/home_page/collection_pane.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:apidash/providers/providers.dart';
@@ -66,10 +67,33 @@ class CollectionPane extends ConsumerWidget {
                     style: kTextStyleButton,
                   ),
                 ),
+
               ],
             ),
           ),
-          kVSpacer8,
+          kVSpacer10,
+           SizedBox(
+            height:30,
+            child:SearchBar(
+
+              onChanged: (value){
+                  if(value.isNotEmpty){
+                  ref.read(searchQueryProvider.notifier).state = value;
+                  ref.read(collectionStateNotifierProvider.notifier)
+                      .filterRequests(value);
+                  }
+                  else{
+
+                  }
+
+              },
+              hintText: "search",
+              leading: Icon(Icons.search),
+              textStyle: MaterialStateTextStyle.resolveWith((states) => TextStyle(fontSize: 15.0)),
+              elevation: MaterialStateProperty.all(2.0),
+            )),
+          kVSpacer10,
+
           const Expanded(
             child: RequestList(),
           ),
@@ -110,7 +134,7 @@ class _RequestListState extends ConsumerState<RequestList> {
     final alwaysShowCollectionPaneScrollbar = ref.watch(settingsProvider
         .select((value) => value.alwaysShowCollectionPaneScrollbar));
 
-    return Scrollbar(
+    return requestItems.isNotEmpty?Scrollbar(
       controller: controller,
       thumbVisibility: alwaysShowCollectionPaneScrollbar ? true : null,
       radius: const Radius.circular(12),
@@ -118,7 +142,7 @@ class _RequestListState extends ConsumerState<RequestList> {
         padding: kPr8CollectionPane,
         scrollController: controller,
         buildDefaultDragHandles: false,
-        itemCount: requestSequence.length,
+        itemCount: requestItems.length,
         onReorder: (int oldIndex, int newIndex) {
           if (oldIndex < newIndex) {
             newIndex -= 1;
@@ -131,6 +155,8 @@ class _RequestListState extends ConsumerState<RequestList> {
         },
         itemBuilder: (context, index) {
           var id = requestSequence[index];
+          print(requestItems[id]!);
+
           return ReorderableDragStartListener(
             key: ValueKey(id),
             index: index,
@@ -144,7 +170,7 @@ class _RequestListState extends ConsumerState<RequestList> {
           );
         },
       ),
-    );
+    ):Text("data");
   }
 }
 

--- a/lib/widgets/textfields.dart
+++ b/lib/widgets/textfields.dart
@@ -94,14 +94,39 @@ class JsonSearchField extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return TextField(
+    return RawTextField(
       controller: controller,
       onChanged: onChanged,
       style: kCodeStyle,
-      decoration: const InputDecoration(
+      hintText: 'Search..',
+    );
+  }
+}
+
+class RawTextField extends StatelessWidget {
+  const RawTextField({
+    super.key,
+    this.onChanged,
+    this.controller,
+    this.hintText,
+    this.style,
+  });
+
+  final void Function(String)? onChanged;
+  final TextEditingController? controller;
+  final String? hintText;
+  final TextStyle? style;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      onChanged: onChanged,
+      style: style,
+      decoration: InputDecoration(
         isDense: true,
         border: InputBorder.none,
-        hintText: 'Search..',
+        hintText: hintText,
       ),
     );
   }

--- a/test/providers/ui_providers_test.dart
+++ b/test/providers/ui_providers_test.dart
@@ -214,13 +214,13 @@ void main() {
   });
 
   group("Testing selectedIdEditStateProvider", () {
-    testWidgets(
-        'selectedIdEditStateProvider should have an initial value of null',
-        (tester) async {
+    testWidgets('It should have an initial value of null', (tester) async {
       await tester.pumpWidget(
         const ProviderScope(
           child: MaterialApp(
-            home: CollectionPane(),
+            home: Scaffold(
+              body: CollectionPane(),
+            ),
           ),
         ),
       );
@@ -237,7 +237,9 @@ void main() {
       await tester.pumpWidget(
         const ProviderScope(
           child: MaterialApp(
-            home: CollectionPane(),
+            home: Scaffold(
+              body: CollectionPane(),
+            ),
           ),
         ),
       );
@@ -267,7 +269,9 @@ void main() {
       await tester.pumpWidget(
         const ProviderScope(
           child: MaterialApp(
-            home: CollectionPane(),
+            home: Scaffold(
+              body: CollectionPane(),
+            ),
           ),
         ),
       );
@@ -303,7 +307,9 @@ void main() {
       await tester.pumpWidget(
         const ProviderScope(
           child: MaterialApp(
-            home: CollectionPane(),
+            home: Scaffold(
+              body: CollectionPane(),
+            ),
           ),
         ),
       );


### PR DESCRIPTION
This feature adds a search/filter functionality to the collection pane, allowing users to easily search for specific requests based on their names. Users can input search queries to filter the requests displayed in the collection pane, improving the navigation and organization of requests within the application.

## PR Description

_Add your description_

## Related Issues

- Related Issue #305 
- Closes #305 

### Checklist
- [ x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x ] I have updated my branch and synced it with project `main` branch before making this PR
- [ ] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
