### PR TITLE
Fix: Fixed codegen dropdown button overflow

### DIFF
--- a/lib/widgets/codegen_previewer.dart
+++ b/lib/widgets/codegen_previewer.dart
@@ -135,7 +135,7 @@ class ViewCodePane extends StatelessWidget {
           child: Column(
             children: [
               SizedBox(
-                height: constraints.maxWidth > 340 ? kHeaderHeight : kTabHeight,
+                height: kHeaderHeight,
                 child: Row(
                   children: [
                     Expanded(

--- a/lib/widgets/codegen_previewer.dart
+++ b/lib/widgets/codegen_previewer.dart
@@ -135,7 +135,7 @@ class ViewCodePane extends StatelessWidget {
           child: Column(
             children: [
               SizedBox(
-                height: kHeaderHeight,
+                height: constraints.maxWidth > 340 ? kHeaderHeight : kTabHeight,
                 child: Row(
                   children: [
                     Expanded(

--- a/lib/widgets/dropdowns.dart
+++ b/lib/widgets/dropdowns.dart
@@ -182,6 +182,8 @@ class DropdownButtonCodegenLanguage extends StatelessWidget {
             child: Text(
               value.label,
               style: kTextStyleButton,
+              overflow: TextOverflow.ellipsis,
+              maxLines: 1,
             ),
           ),
         );

--- a/lib/widgets/dropdowns.dart
+++ b/lib/widgets/dropdowns.dart
@@ -157,6 +157,7 @@ class DropdownButtonCodegenLanguage extends StatelessWidget {
   Widget build(BuildContext context) {
     final surfaceColor = Theme.of(context).colorScheme.surface;
     return DropdownButton<CodegenLanguage>(
+      isExpanded: true,
       focusColor: surfaceColor,
       value: codegenLanguage,
       icon: const Icon(


### PR DESCRIPTION
## PR Description

This PR attempts to solve the issue of the codeview pane dropdown button overflowing when the screen is resized.
I achieved this by setting the expanded value of the dropdown to true. This however makes the text to fold to two lines, one way of solving this is allowing it wrap, which then means the height of the dropdown becomes small to accommodate. 
With this in mind, I increased the height of sizedbox for the header to the kTabHeight value, when the code pane is reduced to 340 and below

## Related Issues

- Related Issue #329 
- Closes #329

### Checklist
- [x ] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [ x] I have updated my branch and synced it with project `main` branch before making this PR
- [ x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [ x] No, and this is why:The updates were covered in previous tests which run successfully
