### PR TITLE
Fix hive persistence issue

### DIFF
--- a/lib/services/hive_services.dart
+++ b/lib/services/hive_services.dart
@@ -8,7 +8,7 @@ const String kKeyDataBoxIds = "ids";
 const String kSettingsBox = "apidash-settings";
 
 Future<void> openBoxes() async {
-  final supportDir = await getApplicationSupportDirectory();
+  final supportDir = await getLibraryDirectory();
   await Hive.initFlutter(supportDir.path);
   await Hive.openBox(kDataBox);
   await Hive.openBox(kSettingsBox);

--- a/lib/services/hive_services.dart
+++ b/lib/services/hive_services.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
+import 'package:path_provider/path_provider.dart';
 
 const String kDataBox = "apidash-data";
 const String kKeyDataBoxIds = "ids";
@@ -7,7 +8,8 @@ const String kKeyDataBoxIds = "ids";
 const String kSettingsBox = "apidash-settings";
 
 Future<void> openBoxes() async {
-  await Hive.initFlutter();
+  final supportDir = await getApplicationSupportDirectory();
+  await Hive.initFlutter(supportDir.path);
   await Hive.openBox(kDataBox);
   await Hive.openBox(kSettingsBox);
 }


### PR DESCRIPTION
## PR Description
Added a directory path for hive to store files. The path is application support directory which will be accessible by the app irrespective of permissions by the OS firewall.

By default hive stores its files at `getApplicationDocumentsDirectory`

Use `getApplicationSupportDirectory` instead of `getApplicationDocumentsDirectory` to ensure read and write permissions.
https://github.com/hivedb/hive/blob/3b12c31a221f97f5ec86fe20df63515aeedf88f0/hive_flutter/lib/src/hive_extensions.dart#L16

Related issue
https://github.com/isar/hive/issues/1044

## Related Issues

- Related Issue #359 
- Closes #359 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
- [x] No, and this is why: Not Required
