### PR TITLE
Added Code Generator For Ruby (Faraday)

### DIFF
--- a/lib/codegen/codegen.dart
+++ b/lib/codegen/codegen.dart
@@ -8,6 +8,7 @@ import 'kotlin/okhttp.dart';
 import 'php/guzzle.dart';
 import 'python/http_client.dart';
 import 'python/requests.dart';
+import 'ruby/faraday.dart';
 import 'rust/actix.dart';
 import 'rust/curl_rust.dart';
 import 'rust/reqwest.dart';
@@ -72,6 +73,8 @@ class Codegen {
             .getCode(rM, boundary: boundary ?? getNewUuid());
       case CodegenLanguage.pythonRequests:
         return PythonRequestsCodeGen().getCode(rM, boundary: boundary);
+      case CodegenLanguage.rubyFaraday:
+        return RubyFaradayCodeGen().getCode(rM, boundary: boundary ?? getNewUuid());
       case CodegenLanguage.rustActix:
         return RustActixCodeGen().getCode(rM, boundary: boundary);
       case CodegenLanguage.rustCurl:

--- a/lib/codegen/codegen.dart
+++ b/lib/codegen/codegen.dart
@@ -74,7 +74,7 @@ class Codegen {
       case CodegenLanguage.pythonRequests:
         return PythonRequestsCodeGen().getCode(rM, boundary: boundary);
       case CodegenLanguage.rubyFaraday:
-        return RubyFaradayCodeGen().getCode(rM, boundary: boundary ?? getNewUuid());
+        return RubyFaradayCodeGen().getCode(rM);
       case CodegenLanguage.rustActix:
         return RustActixCodeGen().getCode(rM, boundary: boundary);
       case CodegenLanguage.rustCurl:

--- a/lib/codegen/ruby/faraday.dart
+++ b/lib/codegen/ruby/faraday.dart
@@ -1,0 +1,14 @@
+import 'package:apidash/consts.dart';
+import 'package:jinja/jinja.dart' as jj;
+import 'package:apidash/utils/utils.dart' show getValidRequestUri;
+import 'package:apidash/utils/http_utils.dart' show stripUriParams;
+
+import 'package:apidash/models/models.dart' show RequestModel;
+
+// Note that delete is a special case in Faraday as API Dash supports request
+// body inside delete reqest, but Faraday does not. Hence we need to manually
+// setup request body for delete request and add that to request.
+//
+// Refer https://lostisland.github.io/faraday/#/getting-started/quick-start?id=get-head-delete-trace
+class RubyFaradayCodeGen {
+}

--- a/lib/codegen/ruby/faraday.dart
+++ b/lib/codegen/ruby/faraday.dart
@@ -11,4 +11,69 @@ import 'package:apidash/models/models.dart' show RequestModel;
 //
 // Refer https://lostisland.github.io/faraday/#/getting-started/quick-start?id=get-head-delete-trace
 class RubyFaradayCodeGen {
+  final String kStringFaradayRequireStatement = """
+require 'uri'
+require 'faraday'
+""";
+
+  final String kStringFaradayMultipartRequireStatement = '''
+require 'faraday/multipart'
+''';
+
+  final String kTemplateRequestUrl = """
+\nREQUEST_URL = URI("{{ url }}")\n\n
+""";
+
+  final String kTemplateBody = """
+PAYLOAD = <<-{{ boundary }}
+{{ body }}
+{{ boundary }}\n\n
+""";
+
+  final String kTemplateFormParamsWithFile = """
+PAYLOAD = {
+{% for param in params %}{% if param.type == "text" %}  "{{ param.name }}" => Faraday::Multipart::ParamPart.new("{{ param.value }}", "text/plain"),
+{% elif param.type == "file" %}  "{{ param.name }}" => Faraday::Multipart::FilePart.new("{{ param.value }}", "application/octet-stream"),{% endif %}{% endfor %}
+}\n\n
+""";
+
+  final String kTemplateFormParamsWithoutFile = """
+PAYLOAD = URI.encode_www_form({\n{% for param in params %}  "{{ param.name }}" => "{{ param.value }}",\n{% endfor %}})\n\n
+""";
+
+  final String kTemplateConnection = """
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter{% if hasFile %}\n  faraday.request :multipart{% endif %}
+end\n\n
+""";
+
+  final String kTemplateRequestStart = """
+response = conn.{{ method|lower }}(REQUEST_URL{% if doesMethodAcceptBody and containsBody %}, PAYLOAD{% endif %}) do |req|\n
+""";
+
+  final String kTemplateRequestOptionsBoundary = """
+  req.options.boundary = "{{ boundary }}"\n
+""";
+
+  final String kTemplateRequestParams = """
+  req.params = {\n{% for key, val in params %}    "{{ key }}" => "{{ val }}",\n{% endfor %}  }\n
+""";
+
+  final String kTemplateRequestHeaders = """
+  req.headers = {\n{% for key, val in headers %}    "{{ key }}" => "{{ val }}",\n{% endfor %}  }\n
+""";
+
+  final String kStringDeleteRequestBody = """
+  req.body = PAYLOAD
+""";
+
+  final String kStringRequestEnd = """
+end\n
+""";
+
+  final String kStringResponse = """
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+
 }

--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -282,6 +282,7 @@ enum CodegenLanguage {
   kotlinOkHttp("Kotlin (okhttp3)", "java", "kt"),
   pythonRequests("Python (requests)", "python", "py"),
   pythonHttpClient("Python (http.client)", "python", "py"),
+  rubyFaraday("Ruby (Faraday)", "ruby", "rb"),
   rustActix("Rust (Actix Client)", "rust", "rs"),
   rustReqwest("Rust (reqwest)", "rust", "rs"),
   rustCurl("Rust (curl-rust)", "rust", "rs"),

--- a/test/codegen/ruby_faraday_codegen_test.dart
+++ b/test/codegen/ruby_faraday_codegen_test.dart
@@ -331,11 +331,11 @@ require 'faraday'
 
 REQUEST_URL = URI("https://api.apidash.dev/case/lower")
 
-PAYLOAD = <<-apidash_a5d7a5d09d721f398905c39274c7fa33
+PAYLOAD = <<HEREDOC
 {
 "text": "I LOVE Flutter"
 }
-apidash_a5d7a5d09d721f398905c39274c7fa33
+HEREDOC
 
 conn = Faraday.new do |faraday|
   faraday.adapter Faraday.default_adapter
@@ -351,8 +351,7 @@ puts "Status Code: #{response.status}"
 puts "Response Body: #{response.body}"
 """;
       expect(
-          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPost1, "https",
-              boundary: "a5d7a5d09d721f398905c39274c7fa33"),
+          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPost1, "https"),
           expectedCode);
     });
 
@@ -362,7 +361,7 @@ require 'faraday'
 
 REQUEST_URL = URI("https://api.apidash.dev/case/lower")
 
-PAYLOAD = <<-apidash_8b9b12a09dc81f398905c39274c7fa33
+PAYLOAD = <<HEREDOC
 {
 "text": "I LOVE Flutter",
 "flag": null,
@@ -371,7 +370,7 @@ PAYLOAD = <<-apidash_8b9b12a09dc81f398905c39274c7fa33
 "no": 1.2,
 "arr": ["null", "true", "false", null]
 }
-apidash_8b9b12a09dc81f398905c39274c7fa33
+HEREDOC
 
 conn = Faraday.new do |faraday|
   faraday.adapter Faraday.default_adapter
@@ -387,8 +386,7 @@ puts "Status Code: #{response.status}"
 puts "Response Body: #{response.body}"
 """;
       expect(
-          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPost2, "https",
-              boundary: "8b9b12a09dc81f398905c39274c7fa33"),
+          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPost2, "https"),
           expectedCode);
     });
 
@@ -398,11 +396,11 @@ require 'faraday'
 
 REQUEST_URL = URI("https://api.apidash.dev/case/lower")
 
-PAYLOAD = <<-apidash_5c3b98809e3c1f398905c39274c7fa33
+PAYLOAD = <<HEREDOC
 {
 "text": "I LOVE Flutter"
 }
-apidash_5c3b98809e3c1f398905c39274c7fa33
+HEREDOC
 
 conn = Faraday.new do |faraday|
   faraday.adapter Faraday.default_adapter
@@ -419,8 +417,7 @@ puts "Status Code: #{response.status}"
 puts "Response Body: #{response.body}"
 """;
       expect(
-          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPost3, "https",
-              boundary: "5c3b98809e3c1f398905c39274c7fa33"),
+          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPost3, "https"),
           expectedCode);
     });
 
@@ -441,9 +438,6 @@ conn = Faraday.new do |faraday|
 end
 
 response = conn.post(REQUEST_URL, PAYLOAD) do |req|
-  req.headers = {
-    "Content-Type" => "application/x-www-form-urlencoded",
-  }
 end
 
 puts "Status Code: #{response.status}"
@@ -476,14 +470,13 @@ end
 response = conn.post(REQUEST_URL, PAYLOAD) do |req|
   req.headers = {
     "User-Agent" => "Test Agent",
-    "Content-Type" => "application/x-www-form-urlencoded",
   }
 end
 
 puts "Status Code: #{response.status}"
 puts "Response Body: #{response.body}"
 """;
-      expect(codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPost5, "https", boundary: "test"), expectedCode);
+      expect(codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPost5, "https"), expectedCode);
     });
     test('POST 6', () {
       const expectedCode = r"""require 'uri'
@@ -503,18 +496,13 @@ conn = Faraday.new do |faraday|
 end
 
 response = conn.post(REQUEST_URL, PAYLOAD) do |req|
-  req.options.boundary = "apidash_6f6629609fb41f398905c39274c7fa33"
-  req.headers = {
-    "Content-Type" => "multipart/form-data",
-  }
 end
 
 puts "Status Code: #{response.status}"
 puts "Response Body: #{response.body}"
 """;
       expect(
-          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPost6, "https",
-              boundary: "6f6629609fb41f398905c39274c7fa33"),
+          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPost6, "https"),
           expectedCode);
     });
     test('POST 7', () {
@@ -535,18 +523,13 @@ conn = Faraday.new do |faraday|
 end
 
 response = conn.post(REQUEST_URL, PAYLOAD) do |req|
-  req.options.boundary = "apidash_3955fcc0a0b71f398905c39274c7fa33"
-  req.headers = {
-    "Content-Type" => "multipart/form-data",
-  }
 end
 
 puts "Status Code: #{response.status}"
 puts "Response Body: #{response.body}"
 """;
       expect(
-          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPost7, "https",
-              boundary: "3955fcc0a0b71f398905c39274c7fa33"),
+          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPost7, "https"),
           expectedCode);
     });
     test('POST 8', () {
@@ -566,9 +549,6 @@ conn = Faraday.new do |faraday|
 end
 
 response = conn.post(REQUEST_URL, PAYLOAD) do |req|
-  req.headers = {
-    "Content-Type" => "application/x-www-form-urlencoded",
-  }
   req.params = {
     "size" => "2",
     "len" => "3",
@@ -578,7 +558,7 @@ end
 puts "Status Code: #{response.status}"
 puts "Response Body: #{response.body}"
 """;
-      expect(codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPost8, "https", boundary: "test"), expectedCode);
+      expect(codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPost8, "https"), expectedCode);
     });
     test('POST 9', () {
       const expectedCode = r"""require 'uri'
@@ -598,11 +578,9 @@ conn = Faraday.new do |faraday|
 end
 
 response = conn.post(REQUEST_URL, PAYLOAD) do |req|
-  req.options.boundary = "apidash_599e5a20a1361f398905c39274c7fa33"
   req.headers = {
     "User-Agent" => "Test Agent",
     "Keep-Alive" => "true",
-    "Content-Type" => "multipart/form-data",
   }
   req.params = {
     "size" => "2",
@@ -614,8 +592,7 @@ puts "Status Code: #{response.status}"
 puts "Response Body: #{response.body}"
 """;
       expect(
-          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPost9, "https",
-              boundary: "599e5a20a1361f398905c39274c7fa33"),
+          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPost9, "https"),
           expectedCode);
     });
   });
@@ -627,12 +604,12 @@ require 'faraday'
 
 REQUEST_URL = URI("https://reqres.in/api/users/2")
 
-PAYLOAD = <<-apidash_b4e90990a34b1f398905c39274c7fa33
+PAYLOAD = <<HEREDOC
 {
 "name": "morpheus",
 "job": "zion resident"
 }
-apidash_b4e90990a34b1f398905c39274c7fa33
+HEREDOC
 
 conn = Faraday.new do |faraday|
   faraday.adapter Faraday.default_adapter
@@ -648,8 +625,7 @@ puts "Status Code: #{response.status}"
 puts "Response Body: #{response.body}"
 """;
       expect(
-          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPut1, "https",
-              boundary: "b4e90990a34b1f398905c39274c7fa33"),
+          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPut1, "https"),
           expectedCode);
     });
   });
@@ -661,12 +637,12 @@ require 'faraday'
 
 REQUEST_URL = URI("https://reqres.in/api/users/2")
 
-PAYLOAD = <<-apidash_b2e9a260a3931f398905c39274c7fa33
+PAYLOAD = <<HEREDOC
 {
 "name": "marfeus",
 "job": "accountant"
 }
-apidash_b2e9a260a3931f398905c39274c7fa33
+HEREDOC
 
 conn = Faraday.new do |faraday|
   faraday.adapter Faraday.default_adapter
@@ -682,8 +658,7 @@ puts "Status Code: #{response.status}"
 puts "Response Body: #{response.body}"
 """;
       expect(
-          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPatch1, "https",
-              boundary: "b2e9a260a3931f398905c39274c7fa33"),
+          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPatch1, "https"),
           expectedCode);
     });
   });
@@ -714,12 +689,12 @@ require 'faraday'
 
 REQUEST_URL = URI("https://reqres.in/api/users/2")
 
-PAYLOAD = <<-apidash_f2291be0a40b1f398905c39274c7fa33
+PAYLOAD = <<HEREDOC
 {
 "name": "marfeus",
 "job": "accountant"
 }
-apidash_f2291be0a40b1f398905c39274c7fa33
+HEREDOC
 
 conn = Faraday.new do |faraday|
   faraday.adapter Faraday.default_adapter
@@ -736,8 +711,7 @@ puts "Status Code: #{response.status}"
 puts "Response Body: #{response.body}"
 """;
       expect(
-          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelDelete2, "https",
-              boundary: "f2291be0a40b1f398905c39274c7fa33"),
+          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelDelete2, "https"),
           expectedCode);
     });
   });

--- a/test/codegen/ruby_faraday_codegen_test.dart
+++ b/test/codegen/ruby_faraday_codegen_test.dart
@@ -1,0 +1,744 @@
+import 'package:apidash/codegen/codegen.dart';
+import 'package:apidash/consts.dart';
+import 'package:test/test.dart';
+import '../request_models.dart';
+
+void main() {
+  final codeGen = Codegen();
+
+  group('GET Request', () {
+    test('GET 1', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+
+REQUEST_URL = URI("https://api.apidash.dev")
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+end
+
+response = conn.get(REQUEST_URL) do |req|
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelGet1, "https"), expectedCode);
+    });
+
+    test('GET 2', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+
+REQUEST_URL = URI("https://api.apidash.dev/country/data")
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+end
+
+response = conn.get(REQUEST_URL) do |req|
+  req.params = {
+    "code" => "US",
+  }
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelGet2, "https"), expectedCode);
+    });
+
+    test('GET 3', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+
+REQUEST_URL = URI("https://api.apidash.dev/country/data")
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+end
+
+response = conn.get(REQUEST_URL) do |req|
+  req.params = {
+    "code" => "IND",
+  }
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelGet3, "https"), expectedCode);
+    });
+
+    test('GET 4', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+
+REQUEST_URL = URI("https://api.apidash.dev/humanize/social")
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+end
+
+response = conn.get(REQUEST_URL) do |req|
+  req.params = {
+    "num" => "8700000",
+    "digits" => "3",
+    "system" => "SS",
+    "add_space" => "true",
+    "trailing_zeros" => "true",
+  }
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelGet4, "https"), expectedCode);
+    });
+
+    test('GET 5', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+
+REQUEST_URL = URI("https://api.github.com/repos/foss42/apidash")
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+end
+
+response = conn.get(REQUEST_URL) do |req|
+  req.headers = {
+    "User-Agent" => "Test Agent",
+  }
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelGet5, "https"), expectedCode);
+    });
+
+    test('GET 6', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+
+REQUEST_URL = URI("https://api.github.com/repos/foss42/apidash")
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+end
+
+response = conn.get(REQUEST_URL) do |req|
+  req.headers = {
+    "User-Agent" => "Test Agent",
+  }
+  req.params = {
+    "raw" => "true",
+  }
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelGet6, "https"), expectedCode);
+    });
+
+    test('GET 7', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+
+REQUEST_URL = URI("https://api.apidash.dev")
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+end
+
+response = conn.get(REQUEST_URL) do |req|
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelGet7, "https"), expectedCode);
+    });
+
+    test('GET 8', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+
+REQUEST_URL = URI("https://api.github.com/repos/foss42/apidash")
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+end
+
+response = conn.get(REQUEST_URL) do |req|
+  req.headers = {
+    "User-Agent" => "Test Agent",
+  }
+  req.params = {
+    "raw" => "true",
+  }
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelGet8, "https"), expectedCode);
+    });
+
+    test('GET 9', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+
+REQUEST_URL = URI("https://api.apidash.dev/humanize/social")
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+end
+
+response = conn.get(REQUEST_URL) do |req|
+  req.params = {
+    "num" => "8700000",
+    "add_space" => "true",
+  }
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelGet9, "https"), expectedCode);
+    });
+
+    test('GET 10', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+
+REQUEST_URL = URI("https://api.apidash.dev/humanize/social")
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+end
+
+response = conn.get(REQUEST_URL) do |req|
+  req.headers = {
+    "User-Agent" => "Test Agent",
+  }
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(
+          codeGen.getCode(
+            CodegenLanguage.rubyFaraday,
+            requestModelGet10,
+            "https",
+          ),
+          expectedCode);
+    });
+
+    test('GET 11', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+
+REQUEST_URL = URI("https://api.apidash.dev/humanize/social")
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+end
+
+response = conn.get(REQUEST_URL) do |req|
+  req.headers = {
+    "User-Agent" => "Test Agent",
+  }
+  req.params = {
+    "num" => "8700000",
+    "digits" => "3",
+  }
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelGet11, "https"), expectedCode);
+    });
+
+    test('GET 12', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+
+REQUEST_URL = URI("https://api.apidash.dev/humanize/social")
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+end
+
+response = conn.get(REQUEST_URL) do |req|
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelGet12, "https"), expectedCode);
+    });
+  });
+
+  group('HEAD Request', () {
+    test('HEAD 1', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+
+REQUEST_URL = URI("https://api.apidash.dev")
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+end
+
+response = conn.head(REQUEST_URL) do |req|
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelHead1, "https"), expectedCode);
+    });
+
+    test('HEAD 2', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+
+REQUEST_URL = URI("http://api.apidash.dev")
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+end
+
+response = conn.head(REQUEST_URL) do |req|
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelHead2, "http"), expectedCode);
+    });
+  });
+
+  group('POST Request', () {
+    test('POST 1', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+
+REQUEST_URL = URI("https://api.apidash.dev/case/lower")
+
+PAYLOAD = <<-apidash_a5d7a5d09d721f398905c39274c7fa33
+{
+"text": "I LOVE Flutter"
+}
+apidash_a5d7a5d09d721f398905c39274c7fa33
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+end
+
+response = conn.post(REQUEST_URL, PAYLOAD) do |req|
+  req.headers = {
+    "Content-Type" => "text/plain",
+  }
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(
+          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPost1, "https",
+              boundary: "a5d7a5d09d721f398905c39274c7fa33"),
+          expectedCode);
+    });
+
+    test('POST 2', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+
+REQUEST_URL = URI("https://api.apidash.dev/case/lower")
+
+PAYLOAD = <<-apidash_8b9b12a09dc81f398905c39274c7fa33
+{
+"text": "I LOVE Flutter",
+"flag": null,
+"male": true,
+"female": false,
+"no": 1.2,
+"arr": ["null", "true", "false", null]
+}
+apidash_8b9b12a09dc81f398905c39274c7fa33
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+end
+
+response = conn.post(REQUEST_URL, PAYLOAD) do |req|
+  req.headers = {
+    "Content-Type" => "application/json",
+  }
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(
+          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPost2, "https",
+              boundary: "8b9b12a09dc81f398905c39274c7fa33"),
+          expectedCode);
+    });
+
+    test('POST 3', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+
+REQUEST_URL = URI("https://api.apidash.dev/case/lower")
+
+PAYLOAD = <<-apidash_5c3b98809e3c1f398905c39274c7fa33
+{
+"text": "I LOVE Flutter"
+}
+apidash_5c3b98809e3c1f398905c39274c7fa33
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+end
+
+response = conn.post(REQUEST_URL, PAYLOAD) do |req|
+  req.headers = {
+    "User-Agent" => "Test Agent",
+    "Content-Type" => "application/json",
+  }
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(
+          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPost3, "https",
+              boundary: "5c3b98809e3c1f398905c39274c7fa33"),
+          expectedCode);
+    });
+
+    test('POST 4', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+
+REQUEST_URL = URI("https://api.apidash.dev/io/form")
+
+PAYLOAD = URI.encode_www_form({
+  "text" => "API",
+  "sep" => "|",
+  "times" => "3",
+})
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+end
+
+response = conn.post(REQUEST_URL, PAYLOAD) do |req|
+  req.headers = {
+    "Content-Type" => "application/x-www-form-urlencoded",
+  }
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(
+          codeGen.getCode(
+            CodegenLanguage.rubyFaraday,
+            requestModelPost4,
+            "https",
+          ),
+          expectedCode);
+    });
+    test('POST 5', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+
+REQUEST_URL = URI("https://api.apidash.dev/io/form")
+
+PAYLOAD = URI.encode_www_form({
+  "text" => "API",
+  "sep" => "|",
+  "times" => "3",
+})
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+end
+
+response = conn.post(REQUEST_URL, PAYLOAD) do |req|
+  req.headers = {
+    "User-Agent" => "Test Agent",
+    "Content-Type" => "application/x-www-form-urlencoded",
+  }
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPost5, "https", boundary: "test"), expectedCode);
+    });
+    test('POST 6', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+require 'faraday/multipart'
+
+REQUEST_URL = URI("https://api.apidash.dev/io/img")
+
+PAYLOAD = {
+  "token" => Faraday::Multipart::ParamPart.new("xyz", "text/plain"),
+  "imfile" => Faraday::Multipart::FilePart.new("/Documents/up/1.png", "application/octet-stream"),
+}
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+  faraday.request :multipart
+end
+
+response = conn.post(REQUEST_URL, PAYLOAD) do |req|
+  req.options.boundary = "apidash_6f6629609fb41f398905c39274c7fa33"
+  req.headers = {
+    "Content-Type" => "multipart/form-data",
+  }
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(
+          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPost6, "https",
+              boundary: "6f6629609fb41f398905c39274c7fa33"),
+          expectedCode);
+    });
+    test('POST 7', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+require 'faraday/multipart'
+
+REQUEST_URL = URI("https://api.apidash.dev/io/img")
+
+PAYLOAD = {
+  "token" => Faraday::Multipart::ParamPart.new("xyz", "text/plain"),
+  "imfile" => Faraday::Multipart::FilePart.new("/Documents/up/1.png", "application/octet-stream"),
+}
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+  faraday.request :multipart
+end
+
+response = conn.post(REQUEST_URL, PAYLOAD) do |req|
+  req.options.boundary = "apidash_3955fcc0a0b71f398905c39274c7fa33"
+  req.headers = {
+    "Content-Type" => "multipart/form-data",
+  }
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(
+          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPost7, "https",
+              boundary: "3955fcc0a0b71f398905c39274c7fa33"),
+          expectedCode);
+    });
+    test('POST 8', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+
+REQUEST_URL = URI("https://api.apidash.dev/io/form")
+
+PAYLOAD = URI.encode_www_form({
+  "text" => "API",
+  "sep" => "|",
+  "times" => "3",
+})
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+end
+
+response = conn.post(REQUEST_URL, PAYLOAD) do |req|
+  req.headers = {
+    "Content-Type" => "application/x-www-form-urlencoded",
+  }
+  req.params = {
+    "size" => "2",
+    "len" => "3",
+  }
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPost8, "https", boundary: "test"), expectedCode);
+    });
+    test('POST 9', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+require 'faraday/multipart'
+
+REQUEST_URL = URI("https://api.apidash.dev/io/img")
+
+PAYLOAD = {
+  "token" => Faraday::Multipart::ParamPart.new("xyz", "text/plain"),
+  "imfile" => Faraday::Multipart::FilePart.new("/Documents/up/1.png", "application/octet-stream"),
+}
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+  faraday.request :multipart
+end
+
+response = conn.post(REQUEST_URL, PAYLOAD) do |req|
+  req.options.boundary = "apidash_599e5a20a1361f398905c39274c7fa33"
+  req.headers = {
+    "User-Agent" => "Test Agent",
+    "Keep-Alive" => "true",
+    "Content-Type" => "multipart/form-data",
+  }
+  req.params = {
+    "size" => "2",
+    "len" => "3",
+  }
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(
+          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPost9, "https",
+              boundary: "599e5a20a1361f398905c39274c7fa33"),
+          expectedCode);
+    });
+  });
+
+  group('PUT Request', () {
+    test('PUT 1', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+
+REQUEST_URL = URI("https://reqres.in/api/users/2")
+
+PAYLOAD = <<-apidash_b4e90990a34b1f398905c39274c7fa33
+{
+"name": "morpheus",
+"job": "zion resident"
+}
+apidash_b4e90990a34b1f398905c39274c7fa33
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+end
+
+response = conn.put(REQUEST_URL, PAYLOAD) do |req|
+  req.headers = {
+    "Content-Type" => "application/json",
+  }
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(
+          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPut1, "https",
+              boundary: "b4e90990a34b1f398905c39274c7fa33"),
+          expectedCode);
+    });
+  });
+
+  group('PATCH Request', () {
+    test('PATCH 1', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+
+REQUEST_URL = URI("https://reqres.in/api/users/2")
+
+PAYLOAD = <<-apidash_b2e9a260a3931f398905c39274c7fa33
+{
+"name": "marfeus",
+"job": "accountant"
+}
+apidash_b2e9a260a3931f398905c39274c7fa33
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+end
+
+response = conn.patch(REQUEST_URL, PAYLOAD) do |req|
+  req.headers = {
+    "Content-Type" => "application/json",
+  }
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(
+          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelPatch1, "https",
+              boundary: "b2e9a260a3931f398905c39274c7fa33"),
+          expectedCode);
+    });
+  });
+
+  group('DELETE Request', () {
+    test('DELETE 1', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+
+REQUEST_URL = URI("https://reqres.in/api/users/2")
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+end
+
+response = conn.delete(REQUEST_URL) do |req|
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelDelete1, "https"), expectedCode);
+    });
+
+    test('DELETE 2', () {
+      const expectedCode = r"""require 'uri'
+require 'faraday'
+
+REQUEST_URL = URI("https://reqres.in/api/users/2")
+
+PAYLOAD = <<-apidash_f2291be0a40b1f398905c39274c7fa33
+{
+"name": "marfeus",
+"job": "accountant"
+}
+apidash_f2291be0a40b1f398905c39274c7fa33
+
+conn = Faraday.new do |faraday|
+  faraday.adapter Faraday.default_adapter
+end
+
+response = conn.delete(REQUEST_URL) do |req|
+  req.headers = {
+    "Content-Type" => "application/json",
+  }
+  req.body = PAYLOAD
+end
+
+puts "Status Code: #{response.status}"
+puts "Response Body: #{response.body}"
+""";
+      expect(
+          codeGen.getCode(CodegenLanguage.rubyFaraday, requestModelDelete2, "https",
+              boundary: "f2291be0a40b1f398905c39274c7fa33"),
+          expectedCode);
+    });
+  });
+}


### PR DESCRIPTION
## PR Description

This PR adds automated code generation for Ruby's [Faraday](https://lostisland.github.io/faraday/#/) library and also tests the generated code.

## Related Issues

- Related Issue #147 
- Closes #147 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
- [x] Yes, I have added and tested all the test cases and the generated code behaves as expected.

## Instructions to run the generated code in local computer
1. Install ruby and setup path so that `ruby` and `gem` executable are available.
2. Run
```bash
gem install bundler
``` 
to install `bundle` as a command line tool.
4. Inside a directory create one `GemFile` and `main.rb` file.
5. Add faraday as mentioned in the [Documentation](https://lostisland.github.io/faraday/#/getting-started/quick-start) and [Faraday Multipart](https://github.com/lostisland/faraday-multipart) for sending multipart form requests. Add them inside the `GemFile` along with one `source` attribute at the top of the `GemFile`. Then run
```bash
bundle install
``` 
to install the dependencies.
6. Copy the generated code inside `main.rb` file. 
7. Run `ruby ./main.rb` to run the generated code.

**Note:** For `HEAD 2` test case, the initial response has status code 301 but [faraday_middleware](https://github.com/lostisland/faraday_middleware) gem, which was previously required for following redirections, is deprecated and a curated list has been published under [awesome-faraday](https://github.com/lostisland/awesome-faraday?tab=readme-ov-file) by the maintainers. The redirection middleware is now bundled as it's own gem [faraday-follow-redirects](https://github.com/tisba/faraday-follow-redirects) which is an external dependency which I have not included in code generator.

I wish to add that after discussing that with maintainers. Integrating redirection following is mentioned in the documentation as 
![image](https://github.com/foss42/apidash/assets/161834431/2890360f-8d08-4286-8363-92ee3b87519d)
and can be achieved by adding the `faraday.response :follow_redirects` statement above adapter setup.

![image](https://github.com/foss42/apidash/assets/161834431/0b43085a-ae0a-4e04-bcd7-9812ac8f7216)

Along with that, we need to add the require statement with the existing require statements so that the respective code is imported.

Thus currently running generated code for `HEAD 2` returns 301 but API Dash returns 405, which can be modified accordingly for both to return 405 and get the desired output of the user. If required, I am willing to add the support for redirection and modify the required code.