### PR TITLE
Fuzzy header search

### DIFF
--- a/lib/utils/header_utils.dart
+++ b/lib/utils/header_utils.dart
@@ -121,7 +121,10 @@ List<String> getFuzzyHeaderSuggestions(String pattern) {
   final keys = headers.keys.toList();
   final fuse = Fuzzy(keys,
       options: FuzzyOptions(
-        distance: 50,
+        distance: 40,
+        matchAllTokens: true,
+        isCaseSensitive: true,
+        tokenize: true,
         threshold: 0.4,
       ));
   final results = fuse.search(pattern);

--- a/lib/utils/header_utils.dart
+++ b/lib/utils/header_utils.dart
@@ -1,3 +1,4 @@
+import 'package:fuzzy/data/result.dart';
 import 'package:fuzzy/fuzzy.dart';
 
 Map<String, String> headers = {
@@ -121,13 +122,16 @@ List<String> getFuzzyHeaderSuggestions(String pattern) {
   final keys = headers.keys.toList();
   final fuse = Fuzzy(keys,
       options: FuzzyOptions(
-        distance: 40,
-        matchAllTokens: true,
-        isCaseSensitive: true,
+        distance: 10,
         tokenize: true,
-        threshold: 0.4,
+        matchAllTokens: true,
+        tokenSeparator: "-",
+        threshold: 0.2,
+        shouldSort: true,
+        minMatchCharLength: 1,
       ));
   final results = fuse.search(pattern);
-  final suggestions = results.map((result) => result.item as String).toList();
+  final List<String> suggestions =
+      results.map((result) => result.item as String).toList();
   return suggestions;
 }

--- a/lib/utils/header_utils.dart
+++ b/lib/utils/header_utils.dart
@@ -121,8 +121,8 @@ List<String> getFuzzyHeaderSuggestions(String pattern) {
   final keys = headers.keys.toList();
   final fuse = Fuzzy(keys,
       options: FuzzyOptions(
-        distance: 0,
-        threshold: 0.35,
+        distance: 50,
+        threshold: 0.4,
       ));
   final results = fuse.search(pattern);
   final suggestions = results.map((result) => result.item as String).toList();

--- a/lib/utils/header_utils.dart
+++ b/lib/utils/header_utils.dart
@@ -137,11 +137,20 @@ List<String> getFuzzyHeaderSuggestions(String pattern) {
   final List<String> predictions = [];
   final List<String> recommendations = [];
   for (String s in suggestions) {
+    // segregate predictions and recommendations
     if (s.toLowerCase().contains(pattern.toLowerCase())) {
       predictions.add(s);
     } else {
       recommendations.add(s);
     }
   }
+  // sort the predictions based on first character match
+  for (int i = 0; i < predictions.length; i++) {
+    if (predictions[i][0].toLowerCase() == pattern[0].toLowerCase()) {
+      final String temp = predictions.removeAt(i);
+      predictions.insert(0, temp); //push to front
+    }
+  }
+
   return predictions.isEmpty ? recommendations : predictions;
 }

--- a/lib/utils/header_utils.dart
+++ b/lib/utils/header_utils.dart
@@ -144,11 +144,13 @@ List<String> getFuzzyHeaderSuggestions(String pattern) {
       recommendations.add(s);
     }
   }
+  int currentIndex = 0;
   // sort the predictions based on first character match
   for (int i = 0; i < predictions.length; i++) {
     if (predictions[i][0].toLowerCase() == pattern[0].toLowerCase()) {
       final String temp = predictions.removeAt(i);
-      predictions.insert(0, temp); //push to front
+      predictions.insert(currentIndex, temp); //push to front
+      currentIndex++;
     }
   }
 

--- a/lib/utils/header_utils.dart
+++ b/lib/utils/header_utils.dart
@@ -1,5 +1,6 @@
 import 'package:fuzzy/data/result.dart';
 import 'package:fuzzy/fuzzy.dart';
+import 'package:xml/xml.dart';
 
 Map<String, String> headers = {
   "Accept": "Specifies the media types that are acceptable for the response.",
@@ -133,5 +134,14 @@ List<String> getFuzzyHeaderSuggestions(String pattern) {
   final results = fuse.search(pattern);
   final List<String> suggestions =
       results.map((result) => result.item as String).toList();
-  return suggestions;
+  final List<String> predictions = [];
+  final List<String> recommendations = [];
+  for (String s in suggestions) {
+    if (s.toLowerCase().contains(pattern.toLowerCase())) {
+      predictions.add(s);
+    } else {
+      recommendations.add(s);
+    }
+  }
+  return predictions.isEmpty ? recommendations : predictions;
 }

--- a/lib/utils/header_utils.dart
+++ b/lib/utils/header_utils.dart
@@ -1,3 +1,5 @@
+import 'package:fuzzy/fuzzy.dart';
+
 Map<String, String> headers = {
   "Accept": "Specifies the media types that are acceptable for the response.",
   "Accept-Encoding":
@@ -51,7 +53,8 @@ Map<String, String> headers = {
       "Contains the date/time after which the response is considered expired",
   "Forwarded":
       "Contains information from the client-facing side of proxy servers that is altered or lost when a proxy is involved in the path of the request.",
-  "From": "Contains an Internet email address for a human user who controls the requesting user agent.",
+  "From":
+      "Contains an Internet email address for a human user who controls the requesting user agent.",
   "Host": "Specifies the domain name of the server and the port number.",
   "If-Match":
       "Used for conditional requests, allows the server to respond based on certain conditions.",
@@ -80,8 +83,7 @@ Map<String, String> headers = {
       "Specifies how much information the browser should include in the Referer header when navigating to other pages.",
   "Retry-After":
       "Informs the client how long it should wait before making another request after a server has responded with a rate-limiting status code.",
-  "Save-Data":
-      "Indicates the client's preference for reduced data usage.",
+  "Save-Data": "Indicates the client's preference for reduced data usage.",
   "Server": "Indicates the software used by the origin server.",
   "Strict-Transport-Security":
       "Instructs the browser to always use HTTPS for the given domain.",
@@ -113,4 +115,16 @@ List<String> getHeaderSuggestions(String pattern) {
         (element) => element.toLowerCase().contains(pattern.toLowerCase()),
       )
       .toList();
+}
+
+List<String> getFuzzyHeaderSuggestions(String pattern) {
+  final keys = headers.keys.toList();
+  final fuse = Fuzzy(keys,
+      options: FuzzyOptions(
+        distance: 0,
+        threshold: 0.35,
+      ));
+  final results = fuse.search(pattern);
+  final suggestions = results.map((result) => result.item as String).toList();
+  return suggestions;
 }

--- a/lib/widgets/headerfield.dart
+++ b/lib/widgets/headerfield.dart
@@ -121,6 +121,6 @@ class _HeaderFieldState extends State<HeaderField> {
     if (pattern.isEmpty) {
       return null;
     }
-    return getHeaderSuggestions(pattern);
+    return getFuzzyHeaderSuggestions(pattern);
   }
 }

--- a/lib/widgets/headerfield.dart
+++ b/lib/widgets/headerfield.dart
@@ -121,6 +121,6 @@ class _HeaderFieldState extends State<HeaderField> {
     if (pattern.isEmpty) {
       return null;
     }
-    return getFuzzyHeaderSuggestions(pattern);
+    return getHeaderSuggestions(pattern);
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -504,6 +504,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.0"
+  fuzzy:
+    dependency: "direct main"
+    description:
+      name: fuzzy
+      sha256: af5fbd36f2f8de0663a5b562ef5ca209aea957e81a2f0e97f97475cfbed044ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1"
   fvp:
     dependency: "direct main"
     description:
@@ -1206,6 +1214,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  stringr:
+    dependency: transitive
+    description:
+      name: stringr
+      sha256: "2846b6811c3cbb34c8937a35e623986e3fbf7203b3bb33ffe7f80e496ea3eff2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,6 +59,7 @@ dependencies:
   csv: ^6.0.0
   data_table_2: ^2.5.11
   file_selector: ^1.0.3
+  fuzzy: ^0.5.1
 
 dependency_overrides:
   web: ^0.5.0

--- a/test/utils/header_utils_test.dart
+++ b/test/utils/header_utils_test.dart
@@ -248,22 +248,6 @@ void main() {
       expect(getHeaderSuggestions(pattern), expected);
     });
 
-    test("Testing using 'x-' pattern", () {
-      String pattern = "x-";
-      List<String> expected = [
-        "Access-Control-Max-Age",
-        "Max-Forwards",
-        "X-Api-Key",
-        "X-Content-Type-Options",
-        "X-CSRF-Token",
-        "X-Forwarded-For",
-        "X-Frame-Options",
-        "X-Requested-With",
-        "X-XSS-Protection"
-      ];
-      expect(getHeaderSuggestions(pattern), expected);
-    });
-
     test("Testing for 'origin' pattern", () {
       String pattern = "origin";
       List<String> expected = [

--- a/test/utils/header_utils_test.dart
+++ b/test/utils/header_utils_test.dart
@@ -104,8 +104,8 @@ void main() {
         'Content-Disposition',
         'Content-Encoding',
         'Content-Length',
-        'Content-Security-Policy',
         'Content-Type',
+        'Content-Security-Policy',
         'X-Content-Type-Options'
       ];
       expect(getFuzzyHeaderSuggestions(pattern), expected);
@@ -130,11 +130,11 @@ void main() {
     test("Testing for 'origin' pattern", () {
       String pattern = "origin";
       List<String> expected = [
+        'Origin',
         'Access-Control-Allow-Origin',
         'Cross-Origin-Embedder-Policy',
         'Cross-Origin-Opener-Policy',
-        'Cross-Origin-Resource-Policy',
-        'Origin'
+        'Cross-Origin-Resource-Policy'
       ];
       expect(getFuzzyHeaderSuggestions(pattern), expected);
     });

--- a/test/utils/header_utils_test.dart
+++ b/test/utils/header_utils_test.dart
@@ -2,6 +2,143 @@ import 'package:apidash/utils/header_utils.dart';
 import 'package:test/test.dart';
 
 void main() {
+  group("Testing getFuzzyHeaderSuggestions function", () {
+    test("Testing using Allow-Headers", () {
+      String pattern = "Allow-Headers";
+      List<String> expected = ["Access-Control-Allow-Headers"];
+      expect(getFuzzyHeaderSuggestions(pattern), expected);
+    });
+
+    test("Testing using Allow-Methods", () {
+      String pattern = "Allow-Methods";
+      List<String> expected = ["Access-Control-Allow-Methods"];
+      expect(getFuzzyHeaderSuggestions(pattern), expected);
+    });
+
+    test("Testing using Allow-Origin", () {
+      String pattern = "Allow-Origin";
+      List<String> expected = ["Access-Control-Allow-Origin"];
+      expect(getFuzzyHeaderSuggestions(pattern), expected);
+    });
+
+    test("Testing using Request-Method", () {
+      String pattern = "Request-Method";
+      List<String> expected = ["Access-Control-Request-Method"];
+      expect(getFuzzyHeaderSuggestions(pattern), expected);
+    });
+
+    test("Testing using Max-Age", () {
+      String pattern = "Max-Age";
+      List<String> expected = ["Access-Control-Max-Age"];
+      expect(getFuzzyHeaderSuggestions(pattern), expected);
+    });
+
+    test("Testing using Access-Control-Allow-Headers", () {
+      String pattern = "Access-Control-Allow-Headers";
+      List<String> expected = ["Access-Control-Allow-Headers"];
+      expect(getFuzzyHeaderSuggestions(pattern), expected);
+    });
+
+    test("Testing using Access-Control-Allow-Methods", () {
+      String pattern = "Access-Control-Allow-Methods";
+      List<String> expected = ["Access-Control-Allow-Methods"];
+      expect(getFuzzyHeaderSuggestions(pattern), expected);
+    });
+
+    test("Testing using Access-Control-Allow-Origin", () {
+      String pattern = "Access-Control-Allow-Origin";
+      List<String> expected = ["Access-Control-Allow-Origin"];
+      expect(getFuzzyHeaderSuggestions(pattern), expected);
+    });
+
+    test("Testing using Access-Control-Request-Method", () {
+      String pattern = "Access-Control-Request-Method";
+      List<String> expected = ["Access-Control-Request-Method"];
+      expect(getFuzzyHeaderSuggestions(pattern), expected);
+    });
+
+    test("Testing using Access-Control-Max-Age", () {
+      String pattern = "Access-Control-Max-Age";
+      List<String> expected = ["Access-Control-Max-Age"];
+      expect(getFuzzyHeaderSuggestions(pattern), expected);
+    });
+
+    test("Testing using Content-Type", () {
+      String pattern = "Content-Type";
+      List<String> expected = ['Content-Type', 'X-Content-Type-Options'];
+      expect(getFuzzyHeaderSuggestions(pattern), expected);
+    });
+
+    test("Testing using Expires", () {
+      String pattern = "Expires";
+      List<String> expected = ["Expires"];
+      expect(getFuzzyHeaderSuggestions(pattern), expected);
+    });
+
+    test("Testing using 'Access-Control' pattern", () {
+      String pattern = "Access-Control";
+      List<String> expected = [
+        "Access-Control-Allow-Headers",
+        "Access-Control-Allow-Methods",
+        "Access-Control-Allow-Origin",
+        "Access-Control-Max-Age",
+        "Access-Control-Request-Headers",
+        "Access-Control-Request-Method"
+      ];
+      expect(getFuzzyHeaderSuggestions(pattern), expected);
+    });
+
+    test("Testing using 'allow-' pattern", () {
+      String pattern = 'allow-';
+      List<String> expected = [
+        "Access-Control-Allow-Headers",
+        "Access-Control-Allow-Methods",
+        "Access-Control-Allow-Origin"
+      ];
+      expect(getFuzzyHeaderSuggestions(pattern), expected);
+    });
+
+    test("Testing using 'content' pattern", () {
+      String pattern = "content";
+      List<String> expected = [
+        'Content-Disposition',
+        'Content-Encoding',
+        'Content-Length',
+        'Content-Security-Policy',
+        'Content-Type',
+        'X-Content-Type-Options'
+      ];
+      expect(getFuzzyHeaderSuggestions(pattern), expected);
+    });
+
+    test("Testing using 'x-' pattern", () {
+      String pattern = "x-";
+      List<String> expected = [
+        "Access-Control-Max-Age",
+        "Max-Forwards",
+        "X-Api-Key",
+        "X-Content-Type-Options",
+        "X-CSRF-Token",
+        "X-Forwarded-For",
+        "X-Frame-Options",
+        "X-Requested-With",
+        "X-XSS-Protection"
+      ];
+      expect(getFuzzyHeaderSuggestions(pattern), expected);
+    });
+
+    test("Testing for 'origin' pattern", () {
+      String pattern = "origin";
+      List<String> expected = [
+        'Access-Control-Allow-Origin',
+        'Cross-Origin-Embedder-Policy',
+        'Cross-Origin-Opener-Policy',
+        'Cross-Origin-Resource-Policy',
+        'Origin'
+      ];
+      expect(getFuzzyHeaderSuggestions(pattern), expected);
+    });
+  });
   group("Testing getHeaderSuggestions function", () {
     test("Testing using Allow-Headers", () {
       String pattern = "Allow-Headers";

--- a/test/utils/header_utils_test.dart
+++ b/test/utils/header_utils_test.dart
@@ -248,6 +248,24 @@ void main() {
       expect(getHeaderSuggestions(pattern), expected);
     });
 
+    test("Testing using 'x-' pattern", () {
+      String pattern = "x-";
+      List<String> expected = [
+        'X-XSS-Protection',
+        'X-Api-Key',
+        'X-CSRF-Token',
+        'X-Forwarded-For',
+        'X-Frame-Options',
+        'X-Requested-With',
+        'X-Content-Type-Options',
+        'Max-Forwards',
+        'Expect',
+        'Expires',
+        'Access-Control-Max-Age'
+      ];
+      expect(getHeaderSuggestions(pattern), expected);
+    });
+
     test("Testing for 'origin' pattern", () {
       String pattern = "origin";
       List<String> expected = [

--- a/test/utils/header_utils_test.dart
+++ b/test/utils/header_utils_test.dart
@@ -114,15 +114,17 @@ void main() {
     test("Testing using 'x-' pattern", () {
       String pattern = "x-";
       List<String> expected = [
-        "Access-Control-Max-Age",
-        "Max-Forwards",
-        "X-Api-Key",
-        "X-Content-Type-Options",
-        "X-CSRF-Token",
-        "X-Forwarded-For",
-        "X-Frame-Options",
-        "X-Requested-With",
-        "X-XSS-Protection"
+        'X-XSS-Protection',
+        'X-Api-Key',
+        'X-CSRF-Token',
+        'X-Forwarded-For',
+        'X-Frame-Options',
+        'X-Requested-With',
+        'X-Content-Type-Options',
+        'Max-Forwards',
+        'Expect',
+        'Expires',
+        'Access-Control-Max-Age'
       ];
       expect(getFuzzyHeaderSuggestions(pattern), expected);
     });
@@ -251,17 +253,15 @@ void main() {
     test("Testing using 'x-' pattern", () {
       String pattern = "x-";
       List<String> expected = [
-        'X-XSS-Protection',
-        'X-Api-Key',
-        'X-CSRF-Token',
-        'X-Forwarded-For',
-        'X-Frame-Options',
-        'X-Requested-With',
-        'X-Content-Type-Options',
-        'Max-Forwards',
-        'Expect',
-        'Expires',
-        'Access-Control-Max-Age'
+        "Access-Control-Max-Age",
+        "Max-Forwards",
+        "X-Api-Key",
+        "X-Content-Type-Options",
+        "X-CSRF-Token",
+        "X-Forwarded-For",
+        "X-Frame-Options",
+        "X-Requested-With",
+        "X-XSS-Protection"
       ];
       expect(getHeaderSuggestions(pattern), expected);
     });

--- a/test/utils/header_utils_test.dart
+++ b/test/utils/header_utils_test.dart
@@ -122,8 +122,6 @@ void main() {
         'X-Requested-With',
         'X-Content-Type-Options',
         'Max-Forwards',
-        'Expect',
-        'Expires',
         'Access-Control-Max-Age'
       ];
       expect(getFuzzyHeaderSuggestions(pattern), expected);


### PR DESCRIPTION
## PR Description

Previously we were only checking if a pattern is  present in a header string. As a result you would not get suggestions if you made a typo.
BEFORE:
![320200891-35e13df0-5a8a-49bd-adf9-a96b5e22d569](https://github.com/foss42/apidash/assets/109033080/2b70fbb2-1693-46eb-a3ae-00582508050f)

This PR attempts to fix this issue using [Fuzzy](https://pub.dev/packages/fuzzy) package.

AFTER:
![320200720-079a90ca-80e6-41fe-ad90-6e37702410bb](https://github.com/foss42/apidash/assets/109033080/85e78c3b-803a-4e58-aa19-f13cda9ad17a)



## Related Issues

- Related Issue #207 
- Closes #207 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_All previous tests except one have been added for the new function._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
