### PR TITLE
Add CodeGen for C# HttpClient

### DIFF
--- a/lib/codegen/codegen.dart
+++ b/lib/codegen/codegen.dart
@@ -2,6 +2,7 @@ import 'package:apidash/models/models.dart' show RequestModel;
 import 'package:apidash/consts.dart';
 import 'package:apidash/utils/utils.dart' show getNewUuid;
 import 'c/curl.dart';
+import 'csharp/http_client.dart';
 import 'csharp/rest_sharp.dart';
 import 'dart/http.dart';
 import 'dart/dio.dart';
@@ -99,6 +100,8 @@ class Codegen {
         return PHPcURLCodeGen().getCode(rM);
       case CodegenLanguage.cCurlCodeGen:
         return CCurlCodeGen().getCode(rM);
+      case CodegenLanguage.cSharpHttpClient:
+        return CSharpHttpClientCodeGen().getCode(rM, boundary: boundary);
       case CodegenLanguage.cSharpRestSharp:
         return CSharpRestSharp().getCode(rM);
       case CodegenLanguage.phpHttpPlug:

--- a/lib/codegen/codegen.dart
+++ b/lib/codegen/codegen.dart
@@ -101,7 +101,7 @@ class Codegen {
       case CodegenLanguage.cCurlCodeGen:
         return CCurlCodeGen().getCode(rM);
       case CodegenLanguage.cSharpHttpClient:
-        return CSharpHttpClientCodeGen().getCode(rM, boundary: boundary);
+        return CSharpHttpClientCodeGen().getCode(rM);
       case CodegenLanguage.cSharpRestSharp:
         return CSharpRestSharp().getCode(rM);
       case CodegenLanguage.phpHttpPlug:

--- a/lib/codegen/csharp/http_client.dart
+++ b/lib/codegen/csharp/http_client.dart
@@ -78,13 +78,13 @@ using (var request = new HttpRequestMessage(HttpMethod.{{ method | capitalize }}
 }
 ''';
 
-  String? getCode(RequestModel requestModel, {String? boundary}) {
+  String? getCode(RequestModel requestModel) {
     try {
       StringBuffer result = StringBuffer();
 
       // Include necessary C# namespace
-      String formdataImport = requestModel.hasFormData //
-          ? (requestModel.hasFileInFormData ? "multipart" : "urlencoded")
+      String formdataImport = requestModel.hasFormData
+          ? "multipart" //(requestModel.hasFileInFormData ? "multipart" : "urlencoded")
           : "nodata";
       result.writeln(jj.Template(kTemplateNamespaces).render({"formdata": formdataImport}));
 
@@ -116,10 +116,11 @@ using (var request = new HttpRequestMessage(HttpMethod.{{ method | capitalize }}
             "mediaType": requestModel.requestBodyContentType.header,
           }));
         } else if (requestModel.hasFormData) {
-          final String renderingTemplate = requestModel.hasFileInFormData
-              ? kTemplateMultipartFormDataContent //
-              : kTemplateFormUrlEncodedContent;
+          // final String renderingTemplate = requestModel.hasFileInFormData
+          //     ? kTemplateMultipartFormDataContent 
+          //     : kTemplateFormUrlEncodedContent;
 
+          final String renderingTemplate = kTemplateMultipartFormDataContent;
           result.writeln(jj.Template(renderingTemplate).render({
             "formdata": requestModel.formDataMapList,
           }));

--- a/lib/codegen/csharp/http_client.dart
+++ b/lib/codegen/csharp/http_client.dart
@@ -73,7 +73,7 @@ using (var request = new HttpRequestMessage(HttpMethod.{{ method | capitalize }}
   final kStringEnd = '''
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';

--- a/lib/codegen/csharp/http_client.dart
+++ b/lib/codegen/csharp/http_client.dart
@@ -1,0 +1,138 @@
+import 'package:apidash/consts.dart';
+import 'package:jinja/jinja.dart' as jj;
+import 'package:apidash/models/models.dart' show RequestModel;
+import 'package:apidash/utils/http_utils.dart';
+
+class CSharpHttpClientCodeGen {
+  final String kTemplateNamespaces = r'''
+using System;
+using System.Net.Http;
+{%- if formdata == 'multipart' %}
+using System.IO;
+{%- elif formdata == 'urlencoded' %}
+using System.Collections.Generic;
+{%- endif %}
+
+''';
+
+  final String kTemplateUri = '''
+string uri = "{{ uri }}";
+
+''';
+
+  final String kTemplateHttpClientAndRequest = '''
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.{{ method | capitalize }}, uri))
+{
+''';
+
+  final String kTemplateHeaders = r'''
+    {% for name, value in headers -%}
+    request.Headers.Add("{{ name }}", "{{ value}}");
+    {% endfor %}
+''';
+
+  final String kTemplateFormUrlEncodedContent = '''
+    var payload = new Dictionary<string, string>
+    {
+    {%- for data in formdata %}
+        { "{{ data.name }}", "{{ data.value }}" },
+    {%- endfor %}
+    };
+    var content = new FormUrlEncodedContent(payload);
+''';
+
+  final String kTemplateMultipartFormDataContent = r'''
+    var content = new MultipartFormDataContent
+    {
+{%- for data in formdata %}
+{%- if data.type == "text" %}
+        { new StringContent("{{ data.value }}"), "{{ data.name }}" },
+{%- else %}
+        {
+            new StreamContent(File.OpenRead("{{ data.value }}")), 
+            "{{ data.name }}", 
+            "{{ data.value }}"
+        },
+{%- endif %}
+{%- endfor %}
+    }
+''';
+
+  final String kTemplateRawBody = '''
+    var payload = """
+{{ body }}
+""";
+    var content = new StringContent(payload, null, "{{ mediaType }}");
+''';
+
+  final String kStringContentSetup = '''
+    request.Content = content;
+''';
+
+  final kStringEnd = '''
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+
+  String? getCode(RequestModel requestModel, {String? boundary}) {
+    try {
+      StringBuffer result = StringBuffer();
+
+      // Include necessary C# namespace
+      String formdataImport = requestModel.hasFormData //
+          ? (requestModel.hasFileInFormData ? "multipart" : "urlencoded")
+          : "nodata";
+      result.writeln(jj.Template(kTemplateNamespaces).render({"formdata": formdataImport}));
+
+      // Set request URL
+      var (uri, _) = getValidRequestUri(requestModel.url, requestModel.enabledRequestParams);
+      if (uri != null) {
+        result.writeln(jj.Template(kTemplateUri).render({"uri": uri}));
+      }
+
+      // Initialize HttpClient and create HttpRequestMessage
+      result.writeln(jj.Template(kTemplateHttpClientAndRequest).render({
+        "method": requestModel.method.name,
+      }));
+
+      // Set request headers
+      var headers = requestModel.enabledHeadersMap;
+      if (headers.isNotEmpty) {
+        result.writeln(jj.Template(kTemplateHeaders).render({"headers": headers}));
+      }
+
+      // Set request body if exists
+      if (kMethodsWithBody.contains(requestModel.method) && requestModel.hasBody) {
+        var requestBody = requestModel.requestBody;
+
+        if (!requestModel.hasFormData && requestBody != null && requestBody.isNotEmpty) {
+          // if the request body is not formdata then render raw text body
+          result.writeln(jj.Template(kTemplateRawBody).render({
+            "body": requestBody,
+            "mediaType": requestModel.requestBodyContentType.header,
+          }));
+        } else if (requestModel.hasFormData) {
+          final String renderingTemplate = requestModel.hasFileInFormData
+              ? kTemplateMultipartFormDataContent //
+              : kTemplateFormUrlEncodedContent;
+
+          result.writeln(jj.Template(renderingTemplate).render({
+            "formdata": requestModel.formDataMapList,
+          }));
+        }
+
+        result.writeln(kStringContentSetup);
+      }
+
+      // Send request and get response
+      result.write(kStringEnd);
+      return result.toString();
+    } catch (e) {
+      return null;
+    }
+  }
+}

--- a/lib/codegen/csharp/http_client.dart
+++ b/lib/codegen/csharp/http_client.dart
@@ -56,7 +56,7 @@ using (var request = new HttpRequestMessage(HttpMethod.{{ method | capitalize }}
         },
 {%- endif %}
 {%- endfor %}
-    }
+    };
 ''';
 
   final String kTemplateRawBody = '''

--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -273,6 +273,7 @@ enum CodegenLanguage {
   curl("cURL", "bash", "curl"),
   har("HAR", "json", "har"),
   cCurlCodeGen("C (Curl)", "cpp", "c"),
+  cSharpHttpClient("C# (Http Client)", "cs", "cs"),
   cSharpRestSharp("C# (Rest Sharp)", "cs", "cs"),
   dartHttp("Dart (http)", "dart", "dart"),
   dartDio("Dart (dio)", "dart", "dart"),

--- a/lib/utils/http_utils.dart
+++ b/lib/utils/http_utils.dart
@@ -89,7 +89,7 @@ String stripUrlParams(String url) {
   }
 
   Map<String, String>? queryParams = rowsToMap(requestParams);
-  if (queryParams != null) {
+  if (queryParams != null && queryParams.isNotEmpty) {
     if (uri.hasQuery) {
       Map<String, String> urlQueryParams = uri.queryParameters;
       queryParams = mergeMaps(urlQueryParams, queryParams);

--- a/test/codegen/csharp_http_client_codegen_test.dart
+++ b/test/codegen/csharp_http_client_codegen_test.dart
@@ -361,20 +361,19 @@ using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
     test('POST 4', () {
       const expectedCode = r'''using System;
 using System.Net.Http;
-using System.Collections.Generic;
+using System.IO;
 
 string uri = "https://api.apidash.dev/io/form";
 
 using (var client = new HttpClient())
 using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
 {
-    var payload = new Dictionary<string, string>
+    var content = new MultipartFormDataContent
     {
-        { "text", "API" },
-        { "sep", "|" },
-        { "times", "3" },
+        { new StringContent("API"), "text" },
+        { new StringContent("|"), "sep" },
+        { new StringContent("3"), "times" },
     };
-    var content = new FormUrlEncodedContent(payload);
     request.Content = content;
 
     HttpResponseMessage response = await client.SendAsync(request);
@@ -389,7 +388,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
     test('POST 5', () {
       const expectedCode = r'''using System;
 using System.Net.Http;
-using System.Collections.Generic;
+using System.IO;
 
 string uri = "https://api.apidash.dev/io/form";
 
@@ -398,13 +397,12 @@ using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
 {
     request.Headers.Add("User-Agent", "Test Agent");
     
-    var payload = new Dictionary<string, string>
+    var content = new MultipartFormDataContent
     {
-        { "text", "API" },
-        { "sep", "|" },
-        { "times", "3" },
+        { new StringContent("API"), "text" },
+        { new StringContent("|"), "sep" },
+        { new StringContent("3"), "times" },
     };
-    var content = new FormUrlEncodedContent(payload);
     request.Content = content;
 
     HttpResponseMessage response = await client.SendAsync(request);
@@ -479,20 +477,19 @@ using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
     test('POST 8', () {
       const expectedCode = r'''using System;
 using System.Net.Http;
-using System.Collections.Generic;
+using System.IO;
 
 string uri = "https://api.apidash.dev/io/form?size=2&len=3";
 
 using (var client = new HttpClient())
 using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
 {
-    var payload = new Dictionary<string, string>
+    var content = new MultipartFormDataContent
     {
-        { "text", "API" },
-        { "sep", "|" },
-        { "times", "3" },
+        { new StringContent("API"), "text" },
+        { new StringContent("|"), "sep" },
+        { new StringContent("3"), "times" },
     };
-    var content = new FormUrlEncodedContent(payload);
     request.Content = content;
 
     HttpResponseMessage response = await client.SendAsync(request);

--- a/test/codegen/csharp_http_client_codegen_test.dart
+++ b/test/codegen/csharp_http_client_codegen_test.dart
@@ -18,7 +18,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
 {
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -36,7 +36,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
 {
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -54,7 +54,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
 {
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -72,7 +72,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
 {
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -92,7 +92,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
     
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -112,7 +112,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
     
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -130,7 +130,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
 {
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -150,7 +150,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
     
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -168,7 +168,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
 {
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -188,7 +188,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
     
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -208,7 +208,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
     
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -226,7 +226,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
 {
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -246,7 +246,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Head, uri))
 {
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -264,7 +264,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Head, uri))
 {
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -292,7 +292,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
 
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -323,7 +323,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
 
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -351,7 +351,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
 
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -378,7 +378,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
 
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -407,7 +407,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
 
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -437,7 +437,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
 
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -467,7 +467,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
 
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -494,7 +494,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
 
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -527,7 +527,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
 
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -556,7 +556,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Put, uri))
 
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -585,7 +585,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Patch, uri))
 
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -605,7 +605,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Delete, uri))
 {
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';
@@ -632,7 +632,7 @@ using (var request = new HttpRequestMessage(HttpMethod.Delete, uri))
 
     HttpResponseMessage response = await client.SendAsync(request);
 
-    Console.WriteLine(response.StatusCode);
+    Console.WriteLine((int)response.StatusCode);
     Console.WriteLine(await response.Content.ReadAsStringAsync());
 }
 ''';

--- a/test/codegen/csharp_http_client_codegen_test.dart
+++ b/test/codegen/csharp_http_client_codegen_test.dart
@@ -1,0 +1,645 @@
+import 'package:apidash/codegen/codegen.dart';
+import 'package:apidash/consts.dart';
+import 'package:test/test.dart';
+import '../request_models.dart';
+
+void main() {
+  final codeGen = Codegen();
+
+  group('Get Request', () {
+    test('GET 1', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+
+string uri = "https://api.apidash.dev";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
+{
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelGet1, "https"), expectedCode);
+    });
+
+    test('GET 2', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+
+string uri = "https://api.apidash.dev/country/data?code=US";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
+{
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelGet2, "https"), expectedCode);
+    });
+
+    test('GET 3', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+
+string uri = "https://api.apidash.dev/country/data?code=IND";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
+{
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelGet3, "https"), expectedCode);
+    });
+
+    test('GET 4', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+
+string uri = "https://api.apidash.dev/humanize/social?num=8700000&digits=3&system=SS&add_space=true&trailing_zeros=true";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
+{
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelGet4, "https"), expectedCode);
+    });
+
+    test('GET 5', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+
+string uri = "https://api.github.com/repos/foss42/apidash";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
+{
+    request.Headers.Add("User-Agent", "Test Agent");
+    
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelGet5, "https"), expectedCode);
+    });
+
+    test('GET 6', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+
+string uri = "https://api.github.com/repos/foss42/apidash?raw=true";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
+{
+    request.Headers.Add("User-Agent", "Test Agent");
+    
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelGet6, "https"), expectedCode);
+    });
+
+    test('GET 7', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+
+string uri = "https://api.apidash.dev";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
+{
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelGet7, "https"), expectedCode);
+    });
+
+    test('GET 8', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+
+string uri = "https://api.github.com/repos/foss42/apidash?raw=true";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
+{
+    request.Headers.Add("User-Agent", "Test Agent");
+    
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelGet8, "https"), expectedCode);
+    });
+
+    test('GET 9', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+
+string uri = "https://api.apidash.dev/humanize/social?num=8700000&add_space=true";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
+{
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelGet9, "https"), expectedCode);
+    });
+
+    test('GET 10', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+
+string uri = "https://api.apidash.dev/humanize/social";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
+{
+    request.Headers.Add("User-Agent", "Test Agent");
+    
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelGet10, "https"), expectedCode);
+    });
+
+    test('GET 11', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+
+string uri = "https://api.apidash.dev/humanize/social?num=8700000&digits=3";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
+{
+    request.Headers.Add("User-Agent", "Test Agent");
+    
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelGet11, "https"), expectedCode);
+    });
+
+    test('GET 12', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+
+string uri = "https://api.apidash.dev/humanize/social";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
+{
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelGet12, "https"), expectedCode);
+    });
+  });
+
+  group('Head Request', () {
+    test('HEAD 1', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+
+string uri = "https://api.apidash.dev";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Head, uri))
+{
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelHead1, "https"), expectedCode);
+    });
+
+    test('HEAD 2', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+
+string uri = "http://api.apidash.dev";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Head, uri))
+{
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelHead2, "http"), expectedCode);
+    });
+  });
+
+  group('Post Request', () {
+    test('POST 1', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+
+string uri = "https://api.apidash.dev/case/lower";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
+{
+    var payload = """
+{
+"text": "I LOVE Flutter"
+}
+""";
+    var content = new StringContent(payload, null, "text/plain");
+    request.Content = content;
+
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelPost1, "https"), expectedCode);
+    });
+
+    test('POST 2', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+
+string uri = "https://api.apidash.dev/case/lower";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
+{
+    var payload = """
+{
+"text": "I LOVE Flutter",
+"flag": null,
+"male": true,
+"female": false,
+"no": 1.2,
+"arr": ["null", "true", "false", null]
+}
+""";
+    var content = new StringContent(payload, null, "application/json");
+    request.Content = content;
+
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelPost2, "https"), expectedCode);
+    });
+
+    test('POST 3', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+
+string uri = "https://api.apidash.dev/case/lower";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
+{
+    request.Headers.Add("User-Agent", "Test Agent");
+    
+    var payload = """
+{
+"text": "I LOVE Flutter"
+}
+""";
+    var content = new StringContent(payload, null, "application/json");
+    request.Content = content;
+
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelPost3, "https"), expectedCode);
+    });
+
+    test('POST 4', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+using System.Collections.Generic;
+
+string uri = "https://api.apidash.dev/io/form";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
+{
+    var payload = new Dictionary<string, string>
+    {
+        { "text", "API" },
+        { "sep", "|" },
+        { "times", "3" },
+    };
+    var content = new FormUrlEncodedContent(payload);
+    request.Content = content;
+
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelPost4, "https"), expectedCode);
+    });
+
+    test('POST 5', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+using System.Collections.Generic;
+
+string uri = "https://api.apidash.dev/io/form";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
+{
+    request.Headers.Add("User-Agent", "Test Agent");
+    
+    var payload = new Dictionary<string, string>
+    {
+        { "text", "API" },
+        { "sep", "|" },
+        { "times", "3" },
+    };
+    var content = new FormUrlEncodedContent(payload);
+    request.Content = content;
+
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelPost5, "https"), expectedCode);
+    });
+
+    test('POST 6', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+using System.IO;
+
+string uri = "https://api.apidash.dev/io/img";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
+{
+    var content = new MultipartFormDataContent
+    {
+        { new StringContent("xyz"), "token" },
+        {
+            new StreamContent(File.OpenRead("/Documents/up/1.png")), 
+            "imfile", 
+            "/Documents/up/1.png"
+        },
+    };
+    request.Content = content;
+
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelPost6, "https"), expectedCode);
+    });
+
+    test('POST 7', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+using System.IO;
+
+string uri = "https://api.apidash.dev/io/img";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
+{
+    var content = new MultipartFormDataContent
+    {
+        { new StringContent("xyz"), "token" },
+        {
+            new StreamContent(File.OpenRead("/Documents/up/1.png")), 
+            "imfile", 
+            "/Documents/up/1.png"
+        },
+    };
+    request.Content = content;
+
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelPost7, "https"), expectedCode);
+    });
+
+    test('POST 8', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+using System.Collections.Generic;
+
+string uri = "https://api.apidash.dev/io/form?size=2&len=3";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
+{
+    var payload = new Dictionary<string, string>
+    {
+        { "text", "API" },
+        { "sep", "|" },
+        { "times", "3" },
+    };
+    var content = new FormUrlEncodedContent(payload);
+    request.Content = content;
+
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelPost8, "https"), expectedCode);
+    });
+
+    test('POST 9', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+using System.IO;
+
+string uri = "https://api.apidash.dev/io/img?size=2&len=3";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
+{
+    request.Headers.Add("User-Agent", "Test Agent");
+    request.Headers.Add("Keep-Alive", "true");
+    
+    var content = new MultipartFormDataContent
+    {
+        { new StringContent("xyz"), "token" },
+        {
+            new StreamContent(File.OpenRead("/Documents/up/1.png")), 
+            "imfile", 
+            "/Documents/up/1.png"
+        },
+    };
+    request.Content = content;
+
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelPost9, "https"), expectedCode);
+    });
+  });
+
+  group('Put Request', () {
+    test('PUT 1', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+
+string uri = "https://reqres.in/api/users/2";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Put, uri))
+{
+    var payload = """
+{
+"name": "morpheus",
+"job": "zion resident"
+}
+""";
+    var content = new StringContent(payload, null, "application/json");
+    request.Content = content;
+
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelPut1, "https"), expectedCode);
+    });
+  });
+
+  group('Patch Request', () {
+    test('PATCH 1', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+
+string uri = "https://reqres.in/api/users/2";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Patch, uri))
+{
+    var payload = """
+{
+"name": "marfeus",
+"job": "accountant"
+}
+""";
+    var content = new StringContent(payload, null, "application/json");
+    request.Content = content;
+
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelPatch1, "https"), expectedCode);
+    });
+  });
+
+  group('Delete Request', () {
+    test('DELETE 1', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+
+string uri = "https://reqres.in/api/users/2";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Delete, uri))
+{
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelDelete1, "https"), expectedCode);
+    });
+
+    test('DELETE 2', () {
+      const expectedCode = r'''using System;
+using System.Net.Http;
+
+string uri = "https://reqres.in/api/users/2";
+
+using (var client = new HttpClient())
+using (var request = new HttpRequestMessage(HttpMethod.Delete, uri))
+{
+    var payload = """
+{
+"name": "marfeus",
+"job": "accountant"
+}
+""";
+    var content = new StringContent(payload, null, "application/json");
+    request.Content = content;
+
+    HttpResponseMessage response = await client.SendAsync(request);
+
+    Console.WriteLine(response.StatusCode);
+    Console.WriteLine(await response.Content.ReadAsStringAsync());
+}
+''';
+      expect(codeGen.getCode(CodegenLanguage.cSharpHttpClient, requestModelDelete2, "https"), expectedCode);
+    });
+  });
+}


### PR DESCRIPTION
## PR Description

This PR adds automated code generation for C# [HttpClient](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient?view=net-8.0) library and also tests the generated code.

## Related Issues

- Related Issue #132 
- Closes #132 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
- [x] Yes
![image](https://github.com/foss42/apidash/assets/161834431/3f018a40-e243-4250-bb16-d7d63b751d45)


## Instructions to run the generated code in local computer
1. Install Visual Studio [Build Tools](https://visualstudio.microsoft.com/downloads/?q=build+tools)
2. Installed C++ for Windows Development and .NET for Windows Development.
3. Created a new directory named `ApiTesting` and used `cd` into that directory.
4. Using terminal, ran `dotnet new console` which creates a new console app inside that directory.
5. Paste the generated code inside `Program.cs` file.
6. Run the program using `dotnet run`.
7. You may additionally need to `ImplicitUsings` inside `ApiTesting.csproj` file.
