### PR TITLE
Updates fvp version from 0.14.0 to 0.17.0 to resolve build failure

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -508,10 +508,10 @@ packages:
     dependency: "direct main"
     description:
       name: fvp
-      sha256: "995328479ba4641da6760ddc84a168db157a3b9db4f0417fa68713d99344a146"
+      sha256: "398f8c342f40005f2f881b926b96a7bbf0b9c0c59267ce5c47377a1d4c324088"
       url: "https://pub.dev"
     source: hosted
-    version: "0.14.0"
+    version: "0.17.0"
   glob:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   package_info_plus: ^5.0.1
   flutter_typeahead: ^5.2.0
   provider: ^6.1.2
-  fvp: ^0.14.0
+  fvp: ^0.17.0
   video_player: ^2.3.2
   video_player_platform_interface: ^6.2.2
   json_data_explorer:


### PR DESCRIPTION
## PR Description
This PR fixed the build failure over Ubuntu and Windows due to version incompatibility of `fvp` package. A detailed description can be found in the related issue #385.

## Related Issues

- Related Issue #385 
- Closes #385 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md).
- [x] I have updated my branch and synced it with project `main` branch before making this PR.
- [x] I have run the tests (`flutter test`) and all tests are passing.

![Screenshot 2024-04-27 130329](https://github.com/foss42/apidash/assets/161834431/622c9d41-2f6b-45c2-9c00-3f8f6d327de7)


## Added/updated tests?

- [x] No, and this is why: Additional testing not required as all the current test cases pass.
