### PR TITLE
fix: renderflex overflow issues in pane

### DIFF
--- a/lib/widgets/button_copy.dart
+++ b/lib/widgets/button_copy.dart
@@ -16,28 +16,29 @@ class CopyButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     var sm = ScaffoldMessenger.of(context);
-    return Tooltip(
-      message: showLabel ? '' : kLabelCopy,
-      child: SizedBox(
-        width: showLabel ? null : kTextButtonMinWidth,
-        child: TextButton(
-          onPressed: () async {
-            await Clipboard.setData(ClipboardData(text: toCopy));
-            sm.hideCurrentSnackBar();
-            sm.showSnackBar(getSnackBar("Copied"));
-          },
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Icon(
-                Icons.content_copy,
-                size: 20,
-              ),
-              if (showLabel) const Text(kLabelCopy)
-            ],
-          ),
-        ),
-      ),
+    const icon = Icon(
+      Icons.content_copy,
+      size: 18,
     );
+    const label = kLabelCopy;
+    onPressed() async {
+      await Clipboard.setData(ClipboardData(text: toCopy));
+      sm.hideCurrentSnackBar();
+      sm.showSnackBar(getSnackBar("Copied"));
+    }
+
+    return showLabel
+        ? TextButton.icon(
+            onPressed: onPressed,
+            icon: icon,
+            label: const Text(label),
+          )
+        : IconButton(
+            tooltip: label,
+            color: Theme.of(context).colorScheme.primary,
+            visualDensity: VisualDensity.compact,
+            onPressed: onPressed,
+            icon: icon,
+          );
   }
 }

--- a/lib/widgets/button_save_download.dart
+++ b/lib/widgets/button_save_download.dart
@@ -23,45 +23,46 @@ class SaveInDownloadsButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     var sm = ScaffoldMessenger.of(context);
-    return Tooltip(
-      message: showLabel ? '' : kLabelDownload,
-      child: SizedBox(
-        width: showLabel ? null : kTextButtonMinWidth,
-        child: TextButton(
-          onPressed: (content != null)
-              ? () async {
-                  var message = "";
-                  var path = await getFileDownloadpath(
-                    name,
-                    ext ?? getFileExtension(mimeType),
-                  );
-                  if (path != null) {
-                    try {
-                      await saveFile(path, content!);
-                      var sp = getShortPath(path);
-                      message = 'Saved to $sp';
-                    } catch (e) {
-                      message = "An error occurred while saving file.";
-                    }
-                  } else {
-                    message = "Unable to determine the download path.";
-                  }
-                  sm.hideCurrentSnackBar();
-                  sm.showSnackBar(getSnackBar(message, small: false));
-                }
-              : null,
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Icon(
-                Icons.download,
-                size: 20,
-              ),
-              if (showLabel) const Text(kLabelDownload)
-            ],
-          ),
-        ),
-      ),
+    const icon = Icon(
+      Icons.download,
+      size: 18,
     );
+    const label = kLabelDownload;
+    final onPressed = (content != null)
+        ? () async {
+            var message = "";
+            var path = await getFileDownloadpath(
+              name,
+              ext ?? getFileExtension(mimeType),
+            );
+            if (path != null) {
+              try {
+                await saveFile(path, content!);
+                var sp = getShortPath(path);
+                message = 'Saved to $sp';
+              } catch (e) {
+                message = "An error occurred while saving file.";
+              }
+            } else {
+              message = "Unable to determine the download path.";
+            }
+            sm.hideCurrentSnackBar();
+            sm.showSnackBar(getSnackBar(message, small: false));
+          }
+        : null;
+
+    return showLabel
+        ? TextButton.icon(
+            onPressed: onPressed,
+            icon: icon,
+            label: const Text(label),
+          )
+        : IconButton(
+            tooltip: label,
+            color: Theme.of(context).colorScheme.primary,
+            visualDensity: VisualDensity.compact,
+            onPressed: onPressed,
+            icon: icon,
+          );
   }
 }

--- a/lib/widgets/json_previewer.dart
+++ b/lib/widgets/json_previewer.dart
@@ -176,35 +176,77 @@ class _JsonPreviewerState extends State<JsonPreviewer> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    children: [
-                      TextButton(
-                        onPressed: () async {
-                          await _copy(kEncoder.convert(widget.code), sm);
-                        },
-                        child: const Text(
-                          'Copy',
-                          style: kTextStyleButtonSmall,
-                        ),
-                      ),
-                      TextButton(
-                        onPressed:
-                            state.areAllExpanded() ? null : state.expandAll,
-                        child: const Text(
-                          'Expand All',
-                          style: kTextStyleButtonSmall,
-                        ),
-                      ),
-                      TextButton(
-                        onPressed:
-                            state.areAllCollapsed() ? null : state.collapseAll,
-                        child: const Text(
-                          'Collapse All',
-                          style: kTextStyleButtonSmall,
-                        ),
-                      ),
-                    ],
-                  ),
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: constraints.minWidth > kMinWindowSize.width
+                          ? [
+                              TextButton(
+                                onPressed: () async {
+                                  await _copy(
+                                      kEncoder.convert(widget.code), sm);
+                                },
+                                child: const Text(
+                                  'Copy',
+                                  style: kTextStyleButtonSmall,
+                                ),
+                              ),
+                              TextButton(
+                                onPressed: state.areAllExpanded()
+                                    ? null
+                                    : state.expandAll,
+                                child: const Text(
+                                  'Expand All',
+                                  style: kTextStyleButtonSmall,
+                                ),
+                              ),
+                              TextButton(
+                                onPressed: state.areAllCollapsed()
+                                    ? null
+                                    : state.collapseAll,
+                                child: const Text(
+                                  'Collapse All',
+                                  style: kTextStyleButtonSmall,
+                                ),
+                              ),
+                            ]
+                          : [
+                              IconButton(
+                                tooltip: "Copy",
+                                color: Theme.of(context).colorScheme.primary,
+                                visualDensity: VisualDensity.compact,
+                                onPressed: () async {
+                                  await _copy(
+                                      kEncoder.convert(widget.code), sm);
+                                },
+                                icon: const Icon(
+                                  Icons.copy,
+                                  size: 16,
+                                ),
+                              ),
+                              IconButton(
+                                tooltip: "Expand All",
+                                color: Theme.of(context).colorScheme.primary,
+                                visualDensity: VisualDensity.compact,
+                                onPressed: state.areAllExpanded()
+                                    ? null
+                                    : state.expandAll,
+                                icon: const Icon(
+                                  Icons.unfold_more,
+                                  size: 16,
+                                ),
+                              ),
+                              IconButton(
+                                tooltip: "Collapse All",
+                                color: Theme.of(context).colorScheme.primary,
+                                visualDensity: VisualDensity.compact,
+                                onPressed: state.areAllCollapsed()
+                                    ? null
+                                    : state.collapseAll,
+                                icon: const Icon(
+                                  Icons.unfold_less,
+                                  size: 16,
+                                ),
+                              ),
+                            ]),
                   Expanded(
                     child: JsonDataExplorer(
                       nodes: state.displayNodes,

--- a/lib/widgets/response_widgets.dart
+++ b/lib/widgets/response_widgets.dart
@@ -425,6 +425,7 @@ class _BodySuccessState extends State<BodySuccess> {
                   (widget.options == kRawBodyViewOptions)
                       ? const SizedBox()
                       : SegmentedButton<ResponseBodyView>(
+                          showSelectedIcon: showLabel,
                           style: const ButtonStyle(
                             padding: WidgetStatePropertyAll(
                               EdgeInsets.symmetric(
@@ -438,7 +439,7 @@ class _BodySuccessState extends State<BodySuccess> {
                                 (e) => ButtonSegment<ResponseBodyView>(
                                   value: e,
                                   label: Text(e.label),
-                                  icon: Icon(e.icon),
+                                  icon: showLabel ? Icon(e.icon) : null,
                                 ),
                               )
                               .toList(),

--- a/lib/widgets/response_widgets.dart
+++ b/lib/widgets/response_widgets.dart
@@ -425,13 +425,8 @@ class _BodySuccessState extends State<BodySuccess> {
                   (widget.options == kRawBodyViewOptions)
                       ? const SizedBox()
                       : SegmentedButton<ResponseBodyView>(
-                          showSelectedIcon: showLabel,
-                          style: const ButtonStyle(
-                            padding: WidgetStatePropertyAll(
-                              EdgeInsets.symmetric(
-                                horizontal: 8,
-                              ),
-                            ),
+                          style: SegmentedButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(horizontal: 8),
                           ),
                           selectedIcon: Icon(currentSeg.icon),
                           segments: widget.options
@@ -439,7 +434,10 @@ class _BodySuccessState extends State<BodySuccess> {
                                 (e) => ButtonSegment<ResponseBodyView>(
                                   value: e,
                                   label: Text(e.label),
-                                  icon: showLabel ? Icon(e.icon) : null,
+                                  icon: constraints.maxWidth >
+                                          kMinWindowSize.width
+                                      ? Icon(e.icon)
+                                      : null,
                                 ),
                               )
                               .toList(),

--- a/test/widgets/buttons_test.dart
+++ b/test/widgets/buttons_test.dart
@@ -19,11 +19,26 @@ void main() {
       ),
     );
 
-    expect(find.byIcon(Icons.content_copy), findsOneWidget);
-    expect(find.text(kLabelCopy), findsOneWidget);
-    final textButton1 = find.byType(TextButton);
-    expect(textButton1, findsOneWidget);
-    await tester.tap(textButton1);
+    final icon = find.byIcon(Icons.content_copy);
+    expect(icon, findsOneWidget);
+
+    Finder button;
+    if (tester.any(find.ancestor(
+        of: icon,
+        matching: find.byWidgetPredicate((widget) => widget is TextButton)))) {
+      expect(find.text(kLabelCopy), findsOneWidget);
+      button = find.ancestor(
+          of: icon,
+          matching: find.byWidgetPredicate((widget) => widget is TextButton));
+    } else if (tester
+        .any(find.ancestor(of: icon, matching: find.byType(IconButton)))) {
+      button = find.byType(IconButton);
+    } else {
+      fail('No TextButton or IconButton found');
+    }
+
+    expect(button, findsOneWidget);
+    await tester.tap(button);
 
     //TODO: The below test works for `flutter run` but not for `flutter test`
     //var data = await Clipboard.getData('text/plain');
@@ -91,13 +106,27 @@ void main() {
       ),
     );
 
-    expect(find.byIcon(Icons.download), findsOneWidget);
-    expect(find.text("Download"), findsOneWidget);
+    final icon = find.byIcon(Icons.download);
+    expect(icon, findsOneWidget);
 
-    final button1 = find.byType(TextButton);
-    expect(button1, findsOneWidget);
-
-    expect(tester.widget<TextButton>(button1).enabled, isFalse);
+    Finder button;
+    if (tester.any(find.ancestor(
+        of: icon,
+        matching: find.byWidgetPredicate((widget) => widget is TextButton)))) {
+      expect(find.text(kLabelDownload), findsOneWidget);
+      button = find.ancestor(
+          of: icon,
+          matching: find.byWidgetPredicate((widget) => widget is TextButton));
+      expect(button, findsOneWidget);
+      expect(tester.widget<TextButton>(button).enabled, isFalse);
+    } else if (tester
+        .any(find.ancestor(of: icon, matching: find.byType(IconButton)))) {
+      button = find.byType(IconButton);
+      expect(button, findsOneWidget);
+      expect(tester.widget<IconButton>(button).onPressed == null, isFalse);
+    } else {
+      fail('No TextButton or IconButton found');
+    }
   });
 
   testWidgets('Testing for Save in Downloads button 2', (tester) async {
@@ -113,13 +142,27 @@ void main() {
       ),
     );
 
-    expect(find.byIcon(Icons.download), findsOneWidget);
-    expect(find.text("Download"), findsOneWidget);
+    final icon = find.byIcon(Icons.download);
+    expect(icon, findsOneWidget);
 
-    final button1 = find.byType(TextButton);
-    expect(button1, findsOneWidget);
-
-    expect(tester.widget<TextButton>(button1).enabled, isTrue);
+    Finder button;
+    if (tester.any(find.ancestor(
+        of: icon,
+        matching: find.byWidgetPredicate((widget) => widget is TextButton)))) {
+      expect(find.text(kLabelDownload), findsOneWidget);
+      button = find.ancestor(
+          of: icon,
+          matching: find.byWidgetPredicate((widget) => widget is TextButton));
+      expect(button, findsOneWidget);
+      expect(tester.widget<TextButton>(button).enabled, isTrue);
+    } else if (tester
+        .any(find.ancestor(of: icon, matching: find.byType(IconButton)))) {
+      button = find.byType(IconButton);
+      expect(button, findsOneWidget);
+      expect(tester.widget<IconButton>(button).onPressed == null, isTrue);
+    } else {
+      fail('No TextButton or IconButton found');
+    }
   });
 
   testWidgets('Testing for Repo button', (tester) async {

--- a/test/widgets/response_widgets_test.dart
+++ b/test/widgets/response_widgets_test.dart
@@ -122,12 +122,26 @@ void main() {
 
     expect(find.text('xyz (2 items)'), findsOneWidget);
 
-    expect(find.byIcon(Icons.content_copy), findsOneWidget);
-    expect(find.text(kLabelCopy), findsOneWidget);
+    final icon = find.byIcon(Icons.content_copy);
+    expect(icon, findsOneWidget);
 
-    final textButton1 = find.byType(TextButton);
-    expect(textButton1, findsOneWidget);
-    await tester.tap(textButton1);
+    Finder button;
+    if (tester.any(find.ancestor(
+        of: icon,
+        matching: find.byWidgetPredicate((widget) => widget is TextButton)))) {
+      expect(find.text(kLabelCopy), findsOneWidget);
+      button = find.ancestor(
+          of: icon,
+          matching: find.byWidgetPredicate((widget) => widget is TextButton));
+    } else if (tester
+        .any(find.ancestor(of: icon, matching: find.byType(IconButton)))) {
+      button = find.byType(IconButton);
+    } else {
+      fail('No TextButton or IconButton found');
+    }
+
+    expect(button, findsOneWidget);
+    await tester.tap(button);
   });
 
   testWidgets('Testing Response Headers', (tester) async {


### PR DESCRIPTION
## PR Description
Fixed renderflex overflow issues in jsonpreviewer buttons and response header buttons.

## Related Issues

- Related Issue #422 
- Closes #422 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
