### PR TITLE
#438 - Fix Typo in README.md: Update "mimetypes" to "MIME types"

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ API Dash can be downloaded from the links below:
 
 - Inspect the API Response (HTTP status code, error message, headers, body, time taken).
 - View formatted code previews for responses of various content types like `JSON`, `XML`, `YAML`, `HTML`, `SQL`, etc.
-- API Dash helps explore, test & preview Multimedia API responses which is **not supported by any other API client**. You can directly test APIs that return images, PDF, audio & more. Check out the [full list of supported mimetypes/formats here](https://github.com/foss42/apidash?tab=readme-ov-file#mime-types-supported-by-api-dash-response-previewer).
+- API Dash helps explore, test & preview Multimedia API responses which is **not supported by any other API client**. You can directly test APIs that return images, PDF, audio & more. Check out the [full list of supported MIME types/formats here](https://github.com/foss42/apidash?tab=readme-ov-file#mime-types-supported-by-api-dash-response-previewer).
 - Save 💾 response body of any mimetype (`image`, `text`, etc.) directly in the `Downloads` folder of your system by clicking on the `Download` button.
 
 **👩🏻‍💻 Code Generation**
@@ -148,7 +148,7 @@ We welcome contributions to support other programming languages/libraries/framew
 
 API Dash is a next-gen API client that supports exploring, testing & previewing various data & multimedia API responses which is limited/not supported by other API clients. You can directly test APIs that return images, PDF, audio & more.
 
-Here is the complete list of mimetypes that can be directly previewed in API Dash:
+Here is the complete list of MIME types that can be directly previewed in API Dash:
 
 | File Type | Mimetype                   | Extension         | Comment  |
 | --------- | -------------------------- | ----------------- | -------- |
@@ -195,15 +195,15 @@ Here is the complete list of mimetypes that can be directly previewed in API Das
 | Audio     | `audio/wave`               | `.wav`            |          |
 | CSV       | `text/csv`                 | `.csv`            | Can be improved |
 
-We welcome PRs to add support for previewing other multimedia mimetypes. Please go ahead and raise an issue so that we can discuss the approach.
-We are adding support for other mimetypes with each release. But, if you are looking for any particular mimetype support, please go ahead and open an issue. We will prioritize it's addition.
+We welcome PRs to add support for previewing other multimedia MIME types. Please go ahead and raise an issue so that we can discuss the approach.
+We are adding support for other MIME types with each release. But, if you are looking for any particular mimetype support, please go ahead and open an issue. We will prioritize it's addition.
 
-Here is the complete list of mimetypes that are syntax highlighted in API Dash:
+Here is the complete list of MIME types that are syntax highlighted in API Dash:
 
 | Mimetype           | Extension | Comment                                                                                                            |
 | ------------------ | --------- | ------------------------------------------------------------------------------------------------------------------ |
-| `application/json` | `.json`   | Other mimetypes like `application/geo+json`, `application/vcard+json` that are based on `json` are also supported. |
-| `application/xml`  | `.xml`    | Other mimetypes like `application/xhtml+xml`, `application/vcard+xml` that are based on `xml` are also supported.  |
+| `application/json` | `.json`   | Other MIME types like `application/geo+json`, `application/vcard+json` that are based on `json` are also supported. |
+| `application/xml`  | `.xml`    | Other MIME types like `application/xhtml+xml`, `application/vcard+xml` that are based on `xml` are also supported.  |
 | `text/xml`         | `.xml`    |  |
 | `application/yaml` | `.yaml`   | Others - `application/x-yaml` or `application/x-yml` |
 | `text/yaml`        | `.yaml`   | Others - `text/yml` |


### PR DESCRIPTION
#438 Issue

### Summary
This pull request addresses a minor typographical error in the `README.md` file of API Dash. The term "mimetypes" has been updated to "MIME types" for consistency and improved clarity.

### Details
The term "mimetypes" was used in the documentation, which could be confusing or inconsistent with standard terminology. Changing it to "MIME types" ensures that the documentation aligns with common practices and provides a clearer understanding for users.

### Changes Made
- Updated the term "mimetypes" to "MIME types" in the relevant section of the `README.md`.

### Additional Information
No functional changes were made to the codebase. This PR focuses solely on improving the documentation.
