### PR TITLE
docs(installation): add installation instructions for Arch based linu…

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -85,3 +85,32 @@ sudo yum localinstall ./apidash-<fullname>.rpm
 ```
 
 Launch API Dash via `apidash` command or by clicking on the API Dash app icon.
+
+### Arch-based Linux Distributions (Manjaro, Arch Linux, etc.)
+
+Download the `.deb` file from the [latest release](https://github.com/foss42/apidash/releases/latest) corresponding to you CPU architecture (x64/amd64 or arm64).
+
+First we have to convert the .deb file to .tar.xz file using the following commands.
+
+1. Install debtap using the following command.
+    ```
+    yay -S debtap
+    ```
+
+2. Initialize `debtap` using the following command.
+    ```
+    sudo debtap -u
+    ```
+
+3. Convert the .deb file to .tar.xz file using the following command.
+    ```
+    sudo debtap /path/to/apidash-<fullname>.deb
+    ```
+4. Once converted, install the resulting .tar.xz file using the following command.
+    ```
+    sudo pacman -U apidash-<fullname>.tar.xz
+    ```
+
+Note: Replace `/path/to/apidash-<fullname>.deb` with the path to the downloaded .deb file.
+
+Launch API Dash via `apidash` command or by clicking on the API Dash app icon.

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -88,7 +88,7 @@ Launch API Dash via `apidash` command or by clicking on the API Dash app icon.
 
 ### Arch-based Linux Distributions (Manjaro, Arch Linux, etc.)
 
-Download the `.deb` file from the [latest release](https://github.com/foss42/apidash/releases/latest) corresponding to you CPU architecture (x64/amd64 or arm64).
+Download the `.deb` file from the [latest release](https://github.com/foss42/apidash/releases/latest) corresponding to your CPU architecture (x86_64/amd64 or arm64/aarch64).
 
 First we have to convert the .deb file to .tar.xz file using the following commands.
 


### PR DESCRIPTION
## PR Description
Updated the **INSTALLATION.md** file to include installation instructions for Arch-based Linux distributions. This ensures that users of Arch Linux and its derivatives (like Manjaro) can easily install API Dash.

## Related Issues
- None

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [ ] I have run the tests (`flutter test`) and all tests are passing  (Not applicable as the changes are documentation-related)


## Added/updated tests?
- [ ] Yes
- [x] No, and this is why: The changes are documentation-related, and no tests are needed.
