### PR TITLE
feat(cookie): Added the support for http cookie

### DIFF
--- a/lib/codegen/java/httpclient.dart
+++ b/lib/codegen/java/httpclient.dart
@@ -70,6 +70,9 @@ multipart/form-data; boundary={{boundary}}''';
   String kTemplateHeader = """
       requestBuilder = requestBuilder.headers({% for header, value in headers %}
         "{{header}}", "{{value}}"{% if not loop.last %},{% endif %}{% endfor %}
+      {% if cookieHeader %}
+        , "Cookie", "{{cookieHeader}}"
+      {% endif %}
       );
 
 """;
@@ -122,6 +125,8 @@ multipart/form-data; boundary={{boundary}}''';
         "hasFormData": requestModel.hasFormData,
       });
 
+      String? cookieHeader = requestModel.cookie;
+
       var rec = getValidRequestUri(
         url,
         requestModel.enabledParams,
@@ -162,6 +167,9 @@ multipart/form-data; boundary={{boundary}}''';
         var headersList = requestModel.enabledHeaders;
         if (headersList != null || requestModel.hasBody) {
           var headers = requestModel.enabledHeadersMap;
+          if (cookieHeader != null) {
+            headers["Cookie"] = cookieHeader;
+          }
           if (requestModel.hasJsonData || requestModel.hasTextData) {
             headers.putIfAbsent(
                 kHeaderContentType, () => requestModel.bodyContentType.header);
@@ -178,6 +186,7 @@ multipart/form-data; boundary={{boundary}}''';
             var templateHeader = jj.Template(kTemplateHeader);
             result += templateHeader.render({
               "headers": headers,
+              "cookieHeader": cookieHeader,
             });
           }
         }

--- a/lib/models/http_request_model.dart
+++ b/lib/models/http_request_model.dart
@@ -68,4 +68,11 @@ class HttpRequestModel with _$HttpRequestModel {
   bool get hasFileInFormData => formDataList
       .map((e) => e.type == FormDataType.file)
       .any((element) => element);
+
+  // New getter for cookie
+  String? get cookie {
+    // Retrieve the cookie from the enabled headers
+    final cookieHeader = enabledHeadersMap['Cookie'];
+    return cookieHeader; // Return the cookie value or null
+  }
 }


### PR DESCRIPTION
## PR Description
This PR introduces support for sending HTTP cookies with API requests. The new functionality allows users to include cookies in their headers, which is especially useful when interacting with endpoints that rely on session tokens or other cookie-based authentication.

## Related Issues
- Closes #465 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
