### PR TITLE
feat:  open ItemCardMenu with a right click

### DIFF
--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -172,6 +172,7 @@ const kPb15 = EdgeInsets.only(
 const kPb70 = EdgeInsets.only(
   bottom: 70,
 );
+const kSizedBoxEmpty = SizedBox();
 const kHSpacer2 = SizedBox(width: 2);
 const kHSpacer4 = SizedBox(width: 4);
 const kHSpacer5 = SizedBox(width: 5);

--- a/lib/screens/envvar/environments_pane.dart
+++ b/lib/screens/envvar/environments_pane.dart
@@ -193,6 +193,9 @@ class EnvironmentItem extends ConsumerWidget {
         ref.read(selectedEnvironmentIdStateProvider.notifier).state = id;
         kEnvScaffoldKey.currentState?.closeDrawer();
       },
+      onSecondaryTap: () {
+        ref.read(selectedEnvironmentIdStateProvider.notifier).state = id;
+      },
       focusNode: ref.watch(nameTextFieldFocusNodeProvider),
       onChangedNameEditor: (value) {
         value = value.trim();

--- a/lib/screens/home_page/collection_pane.dart
+++ b/lib/screens/home_page/collection_pane.dart
@@ -223,6 +223,9 @@ class RequestItem extends ConsumerWidget {
         ref.read(selectedIdStateProvider.notifier).state = id;
         kHomeScaffoldKey.currentState?.closeDrawer();
       },
+      onSecondaryTap: () {
+        ref.read(selectedIdStateProvider.notifier).state = id;
+      },
       // onDoubleTap: () {
       //   ref.read(selectedIdStateProvider.notifier).state = id;
       //   ref.read(selectedIdEditStateProvider.notifier).state = id;

--- a/lib/widgets/card_sidebar_environment.dart
+++ b/lib/widgets/card_sidebar_environment.dart
@@ -48,76 +48,83 @@ class SidebarEnvironmentCard extends StatelessWidget {
     bool isSelected = selectedId == id;
     bool inEditMode = editRequestId == id;
     String nm = getEnvironmentTitle(name);
-    return Tooltip(
-      message: nm,
-      triggerMode: TooltipTriggerMode.manual,
-      waitDuration: const Duration(seconds: 1),
-      child: Card(
-        shape: const RoundedRectangleBorder(
-          borderRadius: kBorderRadius8,
-        ),
-        elevation: isSelected ? 1 : 0,
-        surfaceTintColor: isSelected ? surfaceTint : null,
-        color: isSelected && !isGlobal
-            ? colorScheme.brightness == Brightness.dark
-                ? colorVariant
-                : color
-            : color,
-        margin: EdgeInsets.zero,
-        child: InkWell(
-          borderRadius: kBorderRadius8,
-          hoverColor: colorVariant,
-          focusColor: colorVariant.withOpacity(0.5),
-          onTap: inEditMode ? null : onTap,
-          onSecondaryTap: onSecondaryTap,
-          child: Padding(
-            padding: EdgeInsets.only(
-              left: 6,
-              right: isSelected ? 6 : 10,
-              top: 5,
-              bottom: 5,
-            ),
-            child: SizedBox(
-              height: 20,
-              child: Row(
-                children: [
-                  kHSpacer4,
-                  Expanded(
-                    child: inEditMode
-                        ? TextFormField(
-                            key: ValueKey("$id-name"),
-                            initialValue: name,
-                            focusNode: focusNode,
-                            style: Theme.of(context).textTheme.bodyMedium,
-                            onTapOutside: (_) {
-                              onTapOutsideNameEditor?.call();
-                            },
-                            onFieldSubmitted: (value) {
-                              onTapOutsideNameEditor?.call();
-                            },
-                            onChanged: onChangedNameEditor,
-                            decoration: const InputDecoration(
-                              isCollapsed: true,
-                              contentPadding: EdgeInsets.zero,
-                              border: InputBorder.none,
+    return GestureDetector(
+      onSecondaryTapUp: (isGlobal)
+          ? null
+          : (TapUpDetails details) {
+              showItemCardMenu(context, details, onMenuSelected);
+            },
+      child: Tooltip(
+        message: nm,
+        triggerMode: TooltipTriggerMode.manual,
+        waitDuration: const Duration(seconds: 1),
+        child: Card(
+          shape: const RoundedRectangleBorder(
+            borderRadius: kBorderRadius8,
+          ),
+          elevation: isSelected ? 1 : 0,
+          surfaceTintColor: isSelected ? surfaceTint : null,
+          color: isSelected && !isGlobal
+              ? colorScheme.brightness == Brightness.dark
+                  ? colorVariant
+                  : color
+              : color,
+          margin: EdgeInsets.zero,
+          child: InkWell(
+            borderRadius: kBorderRadius8,
+            hoverColor: colorVariant,
+            focusColor: colorVariant.withOpacity(0.5),
+            onTap: inEditMode ? null : onTap,
+            onSecondaryTap: onSecondaryTap,
+            child: Padding(
+              padding: EdgeInsets.only(
+                left: 6,
+                right: isSelected ? 6 : 10,
+                top: 5,
+                bottom: 5,
+              ),
+              child: SizedBox(
+                height: 20,
+                child: Row(
+                  children: [
+                    kHSpacer4,
+                    Expanded(
+                      child: inEditMode
+                          ? TextFormField(
+                              key: ValueKey("$id-name"),
+                              initialValue: name,
+                              focusNode: focusNode,
+                              style: Theme.of(context).textTheme.bodyMedium,
+                              onTapOutside: (_) {
+                                onTapOutsideNameEditor?.call();
+                              },
+                              onFieldSubmitted: (value) {
+                                onTapOutsideNameEditor?.call();
+                              },
+                              onChanged: onChangedNameEditor,
+                              decoration: const InputDecoration(
+                                isCollapsed: true,
+                                contentPadding: EdgeInsets.zero,
+                                border: InputBorder.none,
+                              ),
+                            )
+                          : Text(
+                              nm,
+                              softWrap: false,
+                              overflow: TextOverflow.fade,
                             ),
-                          )
-                        : Text(
-                            nm,
-                            softWrap: false,
-                            overflow: TextOverflow.fade,
-                          ),
-                  ),
-                  Visibility(
-                    visible: isSelected && !inEditMode && !isGlobal,
-                    child: SizedBox(
-                      width: 28,
-                      child: ItemCardMenu(
-                        onSelected: onMenuSelected,
+                    ),
+                    Visibility(
+                      visible: isSelected && !inEditMode && !isGlobal,
+                      child: SizedBox(
+                        width: 28,
+                        child: ItemCardMenu(
+                          onSelected: onMenuSelected,
+                        ),
                       ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/widgets/card_sidebar_environment.dart
+++ b/lib/widgets/card_sidebar_environment.dart
@@ -96,6 +96,7 @@ class SidebarEnvironmentCard extends StatelessWidget {
                             focusNode: focusNode,
                             style: Theme.of(context).textTheme.bodyMedium,
                             onTapOutside: (_) {
+                              FocusScope.of(context).unfocus();
                               onTapOutsideNameEditor?.call();
                             },
                             onFieldSubmitted: (value) {

--- a/lib/widgets/card_sidebar_environment.dart
+++ b/lib/widgets/card_sidebar_environment.dart
@@ -48,83 +48,82 @@ class SidebarEnvironmentCard extends StatelessWidget {
     bool isSelected = selectedId == id;
     bool inEditMode = editRequestId == id;
     String nm = getEnvironmentTitle(name);
-    return GestureDetector(
-      onSecondaryTapUp: (isGlobal)
-          ? null
-          : (TapUpDetails details) {
-              showItemCardMenu(context, details, onMenuSelected);
-            },
-      child: Tooltip(
-        message: nm,
-        triggerMode: TooltipTriggerMode.manual,
-        waitDuration: const Duration(seconds: 1),
-        child: Card(
-          shape: const RoundedRectangleBorder(
-            borderRadius: kBorderRadius8,
-          ),
-          elevation: isSelected ? 1 : 0,
-          surfaceTintColor: isSelected ? surfaceTint : null,
-          color: isSelected && !isGlobal
-              ? colorScheme.brightness == Brightness.dark
-                  ? colorVariant
-                  : color
-              : color,
-          margin: EdgeInsets.zero,
-          child: InkWell(
-            borderRadius: kBorderRadius8,
-            hoverColor: colorVariant,
-            focusColor: colorVariant.withOpacity(0.5),
-            onTap: inEditMode ? null : onTap,
-            onSecondaryTap: onSecondaryTap,
-            child: Padding(
-              padding: EdgeInsets.only(
-                left: 6,
-                right: isSelected ? 6 : 10,
-                top: 5,
-                bottom: 5,
-              ),
-              child: SizedBox(
-                height: 20,
-                child: Row(
-                  children: [
-                    kHSpacer4,
-                    Expanded(
-                      child: inEditMode
-                          ? TextFormField(
-                              key: ValueKey("$id-name"),
-                              initialValue: name,
-                              focusNode: focusNode,
-                              style: Theme.of(context).textTheme.bodyMedium,
-                              onTapOutside: (_) {
-                                onTapOutsideNameEditor?.call();
-                              },
-                              onFieldSubmitted: (value) {
-                                onTapOutsideNameEditor?.call();
-                              },
-                              onChanged: onChangedNameEditor,
-                              decoration: const InputDecoration(
-                                isCollapsed: true,
-                                contentPadding: EdgeInsets.zero,
-                                border: InputBorder.none,
-                              ),
-                            )
-                          : Text(
-                              nm,
-                              softWrap: false,
-                              overflow: TextOverflow.fade,
+    return Tooltip(
+      message: nm,
+      triggerMode: TooltipTriggerMode.manual,
+      waitDuration: const Duration(seconds: 1),
+      child: Card(
+        shape: const RoundedRectangleBorder(
+          borderRadius: kBorderRadius8,
+        ),
+        elevation: isSelected ? 1 : 0,
+        surfaceTintColor: isSelected ? surfaceTint : null,
+        color: isSelected && !isGlobal
+            ? colorScheme.brightness == Brightness.dark
+                ? colorVariant
+                : color
+            : color,
+        margin: EdgeInsets.zero,
+        child: InkWell(
+          borderRadius: kBorderRadius8,
+          hoverColor: colorVariant,
+          focusColor: colorVariant.withOpacity(0.5),
+          onTap: inEditMode ? null : onTap,
+          // onSecondaryTap: onSecondaryTap,
+          onSecondaryTapUp: (isGlobal)
+              ? null
+              : (details) {
+                  onSecondaryTap?.call();
+                  showItemCardMenu(context, details, onMenuSelected);
+                },
+          child: Padding(
+            padding: EdgeInsets.only(
+              left: 6,
+              right: isSelected ? 6 : 10,
+              top: 5,
+              bottom: 5,
+            ),
+            child: SizedBox(
+              height: 20,
+              child: Row(
+                children: [
+                  kHSpacer4,
+                  Expanded(
+                    child: inEditMode
+                        ? TextFormField(
+                            key: ValueKey("$id-name"),
+                            initialValue: name,
+                            focusNode: focusNode,
+                            style: Theme.of(context).textTheme.bodyMedium,
+                            onTapOutside: (_) {
+                              onTapOutsideNameEditor?.call();
+                            },
+                            onFieldSubmitted: (value) {
+                              onTapOutsideNameEditor?.call();
+                            },
+                            onChanged: onChangedNameEditor,
+                            decoration: const InputDecoration(
+                              isCollapsed: true,
+                              contentPadding: EdgeInsets.zero,
+                              border: InputBorder.none,
                             ),
-                    ),
-                    Visibility(
-                      visible: isSelected && !inEditMode && !isGlobal,
-                      child: SizedBox(
-                        width: 28,
-                        child: ItemCardMenu(
-                          onSelected: onMenuSelected,
-                        ),
+                          )
+                        : Text(
+                            nm,
+                            softWrap: false,
+                            overflow: TextOverflow.fade,
+                          ),
+                  ),
+                  Visibility(
+                    visible: isSelected && !inEditMode && !isGlobal,
+                    child: SizedBox(
+                      width: 28,
+                      child: ItemCardMenu(
+                        onSelected: onMenuSelected,
                       ),
                     ),
-                  ],
-                ),
+                  ),
+                ],
               ),
             ),
           ),

--- a/lib/widgets/card_sidebar_request.dart
+++ b/lib/widgets/card_sidebar_request.dart
@@ -49,81 +49,86 @@ class SidebarRequestCard extends StatelessWidget {
     String nm = (name != null && name!.trim().isNotEmpty)
         ? name!
         : getRequestTitleFromUrl(url);
-    return Tooltip(
-      message: nm,
-      triggerMode: TooltipTriggerMode.manual,
-      waitDuration: const Duration(seconds: 1),
-      child: Card(
-        shape: const RoundedRectangleBorder(
-          borderRadius: kBorderRadius8,
-        ),
-        elevation: isSelected ? 1 : 0,
-        surfaceTintColor: isSelected ? surfaceTint : null,
-        color: isSelected
-            ? Theme.of(context).colorScheme.brightness == Brightness.dark
-                ? colorVariant
-                : color
-            : color,
-        margin: EdgeInsets.zero,
-        child: InkWell(
-          borderRadius: kBorderRadius8,
-          hoverColor: colorVariant,
-          focusColor: colorVariant.withOpacity(0.5),
-          onTap: inEditMode ? null : onTap,
-          // onDoubleTap: inEditMode ? null : onDoubleTap,
-          onSecondaryTap: onSecondaryTap,
-          child: Padding(
-            padding: EdgeInsets.only(
-              left: 6,
-              right: isSelected ? 6 : 10,
-              top: 5,
-              bottom: 5,
-            ),
-            child: SizedBox(
-              height: 20,
-              child: Row(
-                children: [
-                  MethodBox(method: method),
-                  kHSpacer4,
-                  Expanded(
-                    child: inEditMode
-                        ? TextFormField(
-                            key: ValueKey("$id-name"),
-                            initialValue: name,
-                            // controller: controller,
-                            focusNode: focusNode,
-                            //autofocus: true,
-                            style: Theme.of(context).textTheme.bodyMedium,
-                            onTapOutside: (_) {
-                              onTapOutsideNameEditor?.call();
-                              //FocusScope.of(context).unfocus();
-                            },
-                            onFieldSubmitted: (value) {
-                              onTapOutsideNameEditor?.call();
-                            },
-                            onChanged: onChangedNameEditor,
-                            decoration: const InputDecoration(
-                              isCollapsed: true,
-                              contentPadding: EdgeInsets.zero,
-                              border: InputBorder.none,
+    return GestureDetector(
+      onSecondaryTapUp: (details) {
+        showItemCardMenu(context, details, onMenuSelected);
+      },
+      child: Tooltip(
+        message: nm,
+        triggerMode: TooltipTriggerMode.manual,
+        waitDuration: const Duration(seconds: 1),
+        child: Card(
+          shape: const RoundedRectangleBorder(
+            borderRadius: kBorderRadius8,
+          ),
+          elevation: isSelected ? 1 : 0,
+          surfaceTintColor: isSelected ? surfaceTint : null,
+          color: isSelected
+              ? Theme.of(context).colorScheme.brightness == Brightness.dark
+                  ? colorVariant
+                  : color
+              : color,
+          margin: EdgeInsets.zero,
+          child: InkWell(
+            borderRadius: kBorderRadius8,
+            hoverColor: colorVariant,
+            focusColor: colorVariant.withOpacity(0.5),
+            onTap: inEditMode ? null : onTap,
+            // onDoubleTap: inEditMode ? null : onDoubleTap,
+            onSecondaryTap: onSecondaryTap,
+            child: Padding(
+              padding: EdgeInsets.only(
+                left: 6,
+                right: isSelected ? 6 : 10,
+                top: 5,
+                bottom: 5,
+              ),
+              child: SizedBox(
+                height: 20,
+                child: Row(
+                  children: [
+                    MethodBox(method: method),
+                    kHSpacer4,
+                    Expanded(
+                      child: inEditMode
+                          ? TextFormField(
+                              key: ValueKey("$id-name"),
+                              initialValue: name,
+                              // controller: controller,
+                              focusNode: focusNode,
+                              //autofocus: true,
+                              style: Theme.of(context).textTheme.bodyMedium,
+                              onTapOutside: (_) {
+                                onTapOutsideNameEditor?.call();
+                                //FocusScope.of(context).unfocus();
+                              },
+                              onFieldSubmitted: (value) {
+                                onTapOutsideNameEditor?.call();
+                              },
+                              onChanged: onChangedNameEditor,
+                              decoration: const InputDecoration(
+                                isCollapsed: true,
+                                contentPadding: EdgeInsets.zero,
+                                border: InputBorder.none,
+                              ),
+                            )
+                          : Text(
+                              nm,
+                              softWrap: false,
+                              overflow: TextOverflow.fade,
                             ),
-                          )
-                        : Text(
-                            nm,
-                            softWrap: false,
-                            overflow: TextOverflow.fade,
-                          ),
-                  ),
-                  Visibility(
-                    visible: isSelected && !inEditMode,
-                    child: SizedBox(
-                      width: 28,
-                      child: ItemCardMenu(
-                        onSelected: onMenuSelected,
+                    ),
+                    Visibility(
+                      visible: isSelected && !inEditMode,
+                      child: SizedBox(
+                        width: 28,
+                        child: ItemCardMenu(
+                          onSelected: onMenuSelected,
+                        ),
                       ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/widgets/card_sidebar_request.dart
+++ b/lib/widgets/card_sidebar_request.dart
@@ -98,8 +98,8 @@ class SidebarRequestCard extends StatelessWidget {
                             //autofocus: true,
                             style: Theme.of(context).textTheme.bodyMedium,
                             onTapOutside: (_) {
+                              FocusScope.of(context).unfocus();
                               onTapOutsideNameEditor?.call();
-                              //FocusScope.of(context).unfocus();
                             },
                             onFieldSubmitted: (value) {
                               onTapOutsideNameEditor?.call();

--- a/lib/widgets/card_sidebar_request.dart
+++ b/lib/widgets/card_sidebar_request.dart
@@ -49,86 +49,84 @@ class SidebarRequestCard extends StatelessWidget {
     String nm = (name != null && name!.trim().isNotEmpty)
         ? name!
         : getRequestTitleFromUrl(url);
-    return GestureDetector(
-      onSecondaryTapUp: (details) {
-        showItemCardMenu(context, details, onMenuSelected);
-      },
-      child: Tooltip(
-        message: nm,
-        triggerMode: TooltipTriggerMode.manual,
-        waitDuration: const Duration(seconds: 1),
-        child: Card(
-          shape: const RoundedRectangleBorder(
-            borderRadius: kBorderRadius8,
-          ),
-          elevation: isSelected ? 1 : 0,
-          surfaceTintColor: isSelected ? surfaceTint : null,
-          color: isSelected
-              ? Theme.of(context).colorScheme.brightness == Brightness.dark
-                  ? colorVariant
-                  : color
-              : color,
-          margin: EdgeInsets.zero,
-          child: InkWell(
-            borderRadius: kBorderRadius8,
-            hoverColor: colorVariant,
-            focusColor: colorVariant.withOpacity(0.5),
-            onTap: inEditMode ? null : onTap,
-            // onDoubleTap: inEditMode ? null : onDoubleTap,
-            onSecondaryTap: onSecondaryTap,
-            child: Padding(
-              padding: EdgeInsets.only(
-                left: 6,
-                right: isSelected ? 6 : 10,
-                top: 5,
-                bottom: 5,
-              ),
-              child: SizedBox(
-                height: 20,
-                child: Row(
-                  children: [
-                    MethodBox(method: method),
-                    kHSpacer4,
-                    Expanded(
-                      child: inEditMode
-                          ? TextFormField(
-                              key: ValueKey("$id-name"),
-                              initialValue: name,
-                              // controller: controller,
-                              focusNode: focusNode,
-                              //autofocus: true,
-                              style: Theme.of(context).textTheme.bodyMedium,
-                              onTapOutside: (_) {
-                                onTapOutsideNameEditor?.call();
-                                //FocusScope.of(context).unfocus();
-                              },
-                              onFieldSubmitted: (value) {
-                                onTapOutsideNameEditor?.call();
-                              },
-                              onChanged: onChangedNameEditor,
-                              decoration: const InputDecoration(
-                                isCollapsed: true,
-                                contentPadding: EdgeInsets.zero,
-                                border: InputBorder.none,
-                              ),
-                            )
-                          : Text(
-                              nm,
-                              softWrap: false,
-                              overflow: TextOverflow.fade,
+    return Tooltip(
+      message: nm,
+      triggerMode: TooltipTriggerMode.manual,
+      waitDuration: const Duration(seconds: 1),
+      child: Card(
+        shape: const RoundedRectangleBorder(
+          borderRadius: kBorderRadius8,
+        ),
+        elevation: isSelected ? 1 : 0,
+        surfaceTintColor: isSelected ? surfaceTint : null,
+        color: isSelected
+            ? Theme.of(context).colorScheme.brightness == Brightness.dark
+                ? colorVariant
+                : color
+            : color,
+        margin: EdgeInsets.zero,
+        child: InkWell(
+          borderRadius: kBorderRadius8,
+          hoverColor: colorVariant,
+          focusColor: colorVariant.withOpacity(0.5),
+          onTap: inEditMode ? null : onTap,
+          // onDoubleTap: inEditMode ? null : onDoubleTap,
+          onSecondaryTapUp: (details) {
+            onSecondaryTap?.call();
+            showItemCardMenu(context, details, onMenuSelected);
+          },
+          child: Padding(
+            padding: EdgeInsets.only(
+              left: 6,
+              right: isSelected ? 6 : 10,
+              top: 5,
+              bottom: 5,
+            ),
+            child: SizedBox(
+              height: 20,
+              child: Row(
+                children: [
+                  MethodBox(method: method),
+                  kHSpacer4,
+                  Expanded(
+                    child: inEditMode
+                        ? TextFormField(
+                            key: ValueKey("$id-name"),
+                            initialValue: name,
+                            // controller: controller,
+                            focusNode: focusNode,
+                            //autofocus: true,
+                            style: Theme.of(context).textTheme.bodyMedium,
+                            onTapOutside: (_) {
+                              onTapOutsideNameEditor?.call();
+                              //FocusScope.of(context).unfocus();
+                            },
+                            onFieldSubmitted: (value) {
+                              onTapOutsideNameEditor?.call();
+                            },
+                            onChanged: onChangedNameEditor,
+                            decoration: const InputDecoration(
+                              isCollapsed: true,
+                              contentPadding: EdgeInsets.zero,
+                              border: InputBorder.none,
                             ),
-                    ),
-                    Visibility(
-                      visible: isSelected && !inEditMode,
-                      child: SizedBox(
-                        width: 28,
-                        child: ItemCardMenu(
-                          onSelected: onMenuSelected,
-                        ),
+                          )
+                        : Text(
+                            nm,
+                            softWrap: false,
+                            overflow: TextOverflow.fade,
+                          ),
+                  ),
+                  Visibility(
+                    visible: isSelected && !inEditMode,
+                    child: SizedBox(
+                      width: 28,
+                      child: ItemCardMenu(
+                        onSelected: onMenuSelected,
                       ),
                     ),
-                  ],
-                ),
+                  ),
+                ],
               ),
             ),
           ),

--- a/lib/widgets/card_sidebar_request.dart
+++ b/lib/widgets/card_sidebar_request.dart
@@ -117,17 +117,15 @@ class SidebarRequestCard extends StatelessWidget {
                             overflow: TextOverflow.fade,
                           ),
                   ),
-                  kIsMobile
-                      ? Visibility(
-                          visible: isSelected && !inEditMode,
-                          child: SizedBox(
-                            width: 28,
-                            child: ItemCardMenu(
-                              onSelected: onMenuSelected,
-                            ),
-                          ),
-                        )
-                      : kSizedBoxEmpty,
+                  Visibility(
+                    visible: isSelected && !inEditMode,
+                    child: SizedBox(
+                      width: 28,
+                      child: ItemCardMenu(
+                        onSelected: onMenuSelected,
+                      ),
+                    ),
+                  ),
                 ],
               ),
             ),

--- a/lib/widgets/card_sidebar_request.dart
+++ b/lib/widgets/card_sidebar_request.dart
@@ -117,15 +117,17 @@ class SidebarRequestCard extends StatelessWidget {
                             overflow: TextOverflow.fade,
                           ),
                   ),
-                  Visibility(
-                    visible: isSelected && !inEditMode,
-                    child: SizedBox(
-                      width: 28,
-                      child: ItemCardMenu(
-                        onSelected: onMenuSelected,
-                      ),
-                    ),
-                  ),
+                  kIsMobile
+                      ? Visibility(
+                          visible: isSelected && !inEditMode,
+                          child: SizedBox(
+                            width: 28,
+                            child: ItemCardMenu(
+                              onSelected: onMenuSelected,
+                            ),
+                          ),
+                        )
+                      : kSizedBoxEmpty,
                 ],
               ),
             ),

--- a/lib/widgets/menu_item_card.dart
+++ b/lib/widgets/menu_item_card.dart
@@ -41,3 +41,29 @@ class ItemCardMenu extends StatelessWidget {
     );
   }
 }
+
+/// Open the item card menu where the right click has been released
+Future<void> showItemCardMenu(
+  BuildContext context,
+  TapUpDetails details,
+  Function(ItemMenuOption)? onSelected,
+) async {
+  showMenu(
+    context: context,
+    position: RelativeRect.fromLTRB(
+      details.globalPosition.dx,
+      details.globalPosition.dy,
+      details.globalPosition.dx,
+      details.globalPosition.dy,
+    ),
+    items: ItemMenuOption.values
+        .map<PopupMenuEntry<ItemMenuOption>>(
+          (e) => PopupMenuItem<ItemMenuOption>(
+            onTap: () => onSelected?.call(e),
+            value: e,
+            child: Text(e.label),
+          ),
+        )
+        .toList(),
+  );
+}

--- a/test/providers/ui_providers_test.dart
+++ b/test/providers/ui_providers_test.dart
@@ -13,6 +13,7 @@ import 'package:apidash/screens/settings_page.dart';
 import 'package:apidash/screens/history/history_page.dart';
 import 'package:apidash/widgets/widgets.dart';
 import 'package:extended_text_field/extended_text_field.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_portal/flutter_portal.dart';
@@ -279,7 +280,7 @@ void main() {
     });
 
     testWidgets(
-        'selectedIdEditStateProvider should not be null after rename button has been tapped',
+        'selectedIdEditStateProvider should not be null after Duplicate button has been tapped',
         (tester) async {
       await tester.pumpWidget(
         ProviderScope(
@@ -304,7 +305,11 @@ void main() {
       await tester.pump();
       await tester.tap(find.byType(RequestItem));
       await tester.pump();
-      await tester.tap(find.byIcon(Icons.more_vert).at(1));
+      //await tester.tap(find.byIcon(Icons.more_vert).at(1));
+      await tester.tap(
+        find.byType(RequestItem),
+        buttons: kSecondaryButton,
+      );
       await tester.pumpAndSettle();
 
       // Tap on the "Duplicate" option in the menu
@@ -344,7 +349,11 @@ void main() {
       await tester.pump();
       await tester.tap(find.byType(RequestItem));
       await tester.pump();
-      await tester.tap(find.byIcon(Icons.more_vert).at(1));
+      // await tester.tap(find.byIcon(Icons.more_vert).at(1));
+      await tester.tap(
+        find.byType(RequestItem),
+        buttons: kSecondaryButton,
+      );
       await tester.pumpAndSettle();
 
       // Tap on the "Rename" option in the menu

--- a/test/providers/ui_providers_test.dart
+++ b/test/providers/ui_providers_test.dart
@@ -349,11 +349,7 @@ void main() {
       await tester.pump();
       await tester.tap(find.byType(RequestItem));
       await tester.pump();
-      // await tester.tap(find.byIcon(Icons.more_vert).at(1));
-      await tester.tap(
-        find.byType(RequestItem),
-        buttons: kSecondaryButton,
-      );
+      await tester.tap(find.byIcon(Icons.more_vert).at(1));
       await tester.pumpAndSettle();
 
       // Tap on the "Rename" option in the menu

--- a/test/widgets/menu_item_card_test.dart
+++ b/test/widgets/menu_item_card_test.dart
@@ -1,9 +1,7 @@
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:apidash/widgets/menu_item_card.dart';
 import 'package:apidash/consts.dart';
-import 'package:path/path.dart';
 import '../test_consts.dart';
 
 void main() {

--- a/test/widgets/menu_item_card_test.dart
+++ b/test/widgets/menu_item_card_test.dart
@@ -1,7 +1,9 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:apidash/widgets/menu_item_card.dart';
 import 'package:apidash/consts.dart';
+import 'package:path/path.dart';
 import '../test_consts.dart';
 
 void main() {
@@ -48,5 +50,33 @@ void main() {
     await tester.pump(const Duration(seconds: 1));
 
     expect(changedValue, ItemMenuOption.duplicate);
+  });
+
+  testWidgets('showItemCardMenu shows the menu at the right position',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (BuildContext context) {
+              return GestureDetector(
+                onTapUp: (details) {
+                  showItemCardMenu(
+                      context, details, (ItemMenuOption option) {});
+                },
+                child: const Text('Show Menu'),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Show Menu'));
+    await tester.pumpAndSettle();
+
+    for (var option in ItemMenuOption.values) {
+      expect(find.text(option.label), findsOneWidget);
+    }
   });
 }


### PR DESCRIPTION
## PR Description

It's related to #476. You can open the ItemCardMenu with a right click.

[Screencast from 2024-10-05 23-50-35.webm](https://github.com/user-attachments/assets/4ce52a43-fe90-4bdc-8eef-720a4cd08f22)


## Related Issues

- #476 
- #476

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
