### PR TITLE
fix: environment field trigger field is not initializing with empty value

### DIFF
--- a/lib/screens/common_widgets/env_trigger_field.dart
+++ b/lib/screens/common_widgets/env_trigger_field.dart
@@ -51,6 +51,7 @@ class EnvironmentTriggerFieldState extends State<EnvironmentTriggerField> {
   @override
   void didUpdateWidget(EnvironmentTriggerField oldWidget) {
     super.didUpdateWidget(oldWidget);
+    controller.clear();
     if (oldWidget.initialValue != widget.initialValue) {
       controller.text = widget.initialValue ?? "";
       controller.selection =

--- a/lib/screens/common_widgets/env_trigger_field.dart
+++ b/lib/screens/common_widgets/env_trigger_field.dart
@@ -51,8 +51,8 @@ class EnvironmentTriggerFieldState extends State<EnvironmentTriggerField> {
   @override
   void didUpdateWidget(EnvironmentTriggerField oldWidget) {
     super.didUpdateWidget(oldWidget);
-    controller.clear();
-    if (oldWidget.initialValue != widget.initialValue) {
+    if ((oldWidget.keyId != widget.keyId) ||
+        (oldWidget.initialValue != widget.initialValue)) {
       controller.text = widget.initialValue ?? "";
       controller.selection =
           TextSelection.collapsed(offset: controller.text.length);

--- a/test/screens/common_widgets/env_trigger_field_test.dart
+++ b/test/screens/common_widgets/env_trigger_field_test.dart
@@ -45,4 +45,46 @@ void main() {
 
     expect(fieldKey.currentState!.controller.text, updatedValue);
   });
+
+  testWidgets(
+      'Testing EnvironmentTriggerField with empty initialValue clears the controller text',
+      (WidgetTester tester) async {
+    final fieldKey = GlobalKey<EnvironmentTriggerFieldState>();
+    const initialValue = 'initial';
+    const emptyValue = '';
+
+    await tester.pumpWidget(
+      Portal(
+        child: MaterialApp(
+          home: Scaffold(
+            body: EnvironmentTriggerField(
+              key: fieldKey,
+              keyId: 'testKey',
+              initialValue: initialValue,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    Finder field = find.byType(ExtendedTextField);
+    expect(field, findsOneWidget);
+    expect(fieldKey.currentState!.controller.text, initialValue);
+
+    await tester.pumpWidget(
+      Portal(
+        child: MaterialApp(
+          home: Scaffold(
+            body: EnvironmentTriggerField(
+              key: fieldKey,
+              keyId: 'testKey',
+              initialValue: emptyValue,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(fieldKey.currentState!.controller.text, emptyValue);
+  });
 }


### PR DESCRIPTION
## PR Description

It's related to #479 . It initialize environment field trigger empty when clicking "New" button.

https://github.com/user-attachments/assets/e4e896de-735c-4e99-9250-e584d2555dba



## Related Issues

- #479 


### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
