### PR TITLE
feat: Implement HTML rendering with browser interactivity using webview_flutter resolving issue #155

### DIFF
--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -773,6 +773,7 @@ const kLabelAddFormField = "Add Form Field";
 const kLabelNotSent = "Not Sent";
 const kLabelResponse = "Response";
 const kLabelResponseBody = "Response Body";
+const kLabelPreview = "Preview";
 const kTooltipClearResponse = "Clear Response";
 const kHeaderRow = ["Header Name", "Header Value"];
 const kLabelRequestHeaders = "Request Headers";

--- a/lib/screens/history/history_widgets/his_response_pane.dart
+++ b/lib/screens/history/history_widgets/his_response_pane.dart
@@ -37,6 +37,9 @@ class HistoryResponsePane extends ConsumerWidget {
                   requestHeaders:
                       historyHttpResponseModel?.requestHeaders ?? {},
                 ),
+                ResponsePreview(
+                  responseModel: historyHttpResponseModel ?? {},
+                ),
               ],
             ),
           ),

--- a/lib/screens/home_page/editor_pane/details_card/response_pane.dart
+++ b/lib/screens/home_page/editor_pane/details_card/response_pane.dart
@@ -77,6 +77,7 @@ class ResponseTabs extends ConsumerWidget {
       children: const [
         ResponseBodyTab(),
         ResponseHeadersTab(),
+        ResponsePreviewTab(),
       ],
     );
   }
@@ -108,6 +109,19 @@ class ResponseHeadersTab extends ConsumerWidget {
     return ResponseHeaders(
       responseHeaders: responseHeaders,
       requestHeaders: requestHeaders,
+    );
+  }
+}
+
+class ResponsePreviewTab extends ConsumerWidget {
+  const ResponsePreviewTab({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selectedRequestModel = ref.watch(selectedRequestModelProvider);
+    final responseModel = selectedRequestModel?.httpResponseModel;
+    return ResponsePreview(
+      responseModel: responseModel,
     );
   }
 }

--- a/lib/widgets/response_widgets.dart
+++ b/lib/widgets/response_widgets.dart
@@ -529,6 +529,13 @@ class ResponsePreview extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (responseModel == {} ||
+        responseModel == null ||
+        responseModel.body == null) {
+      return const ErrorMessage(
+          message: '$kNullResponseModelError $kUnexpectedRaiseIssue');
+    }
+
     final controller = WebViewController()
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
       ..setNavigationDelegate(
@@ -538,8 +545,13 @@ class ResponsePreview extends StatelessWidget {
           },
         ),
       );
-
-    // Load HTML content
+    controller.setNavigationDelegate(
+      NavigationDelegate(
+        onWebResourceError: (WebResourceError error) {
+          ErrorMessage(message: error.description);
+        },
+      ),
+    );
     WidgetsBinding.instance.addPostFrameCallback((_) {
       controller.loadHtmlString(responseModel!.body!);
     });

--- a/lib/widgets/response_widgets.dart
+++ b/lib/widgets/response_widgets.dart
@@ -7,6 +7,7 @@ import 'package:apidash/utils/utils.dart';
 import 'package:apidash/widgets/widgets.dart';
 import 'package:apidash/models/models.dart';
 import 'package:apidash/consts.dart';
+import 'package:webview_flutter/webview_flutter.dart';
 
 class NotSentWidget extends StatelessWidget {
   const NotSentWidget({super.key});
@@ -193,7 +194,7 @@ class _ResponseTabViewState extends State<ResponseTabView>
   void initState() {
     super.initState();
     _controller = TabController(
-      length: 2,
+      length: 3,
       animationDuration: kTabAnimationDuration,
       vsync: this,
     );
@@ -215,6 +216,9 @@ class _ResponseTabViewState extends State<ResponseTabView>
             ),
             TabLabel(
               text: kLabelHeaders,
+            ),
+            TabLabel(
+              text: kLabelPreview,
             ),
           ],
         ),
@@ -515,6 +519,33 @@ class _BodySuccessState extends State<BodySuccess> {
           ),
         );
       },
+    );
+  }
+}
+
+class ResponsePreview extends StatelessWidget {
+  const ResponsePreview({super.key, required this.responseModel});
+  final responseModel;
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..setNavigationDelegate(
+        NavigationDelegate(
+          onWebResourceError: (WebResourceError error) {
+            ErrorMessage(message: error.description);
+          },
+        ),
+      );
+
+    // Load HTML content
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      controller.loadHtmlString(responseModel!.body!);
+    });
+
+    return Scaffold(
+      body: WebViewWidget(controller: controller),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1700,6 +1700,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  webview_flutter:
+    dependency: "direct main"
+    description:
+      name: webview_flutter
+      sha256: "889a0a678e7c793c308c68739996227c9661590605e70b1f6cf6b9a6634f7aec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.10.0"
+  webview_flutter_android:
+    dependency: transitive
+    description:
+      name: webview_flutter_android
+      sha256: "74693a212d990b32e0b7055d27db973a18abf31c53942063948cdfaaef9787ba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      sha256: d937581d6e558908d7ae3dc1989c4f87b786891ab47bb9df7de548a151779d8d
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.10.0"
+  webview_flutter_wkwebview:
+    dependency: transitive
+    description:
+      name: webview_flutter_wkwebview
+      sha256: d4034901d96357beb1b6717ebf7d583c88e40cfc6eb85fe76dd1bf0979a9f251
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.16.0"
   win32:
     dependency: transitive
     description:
@@ -1750,5 +1782,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.5.0-259.0.dev <3.999.0"
+  dart: ">=3.5.0 <3.999.0"
   flutter: ">=3.24.2"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,6 +75,7 @@ dependencies:
       url: https://github.com/google/flutter-desktop-embedding.git
       path: plugins/window_size
   xml: ^6.3.0
+  webview_flutter: ^4.10.0
 
 dependency_overrides:
   extended_text_field: ^16.0.0

--- a/test/widgets/response_widgets_test.dart
+++ b/test/widgets/response_widgets_test.dart
@@ -88,7 +88,8 @@ void main() {
         theme: kThemeDataLight,
         home: const Scaffold(
           body: ResponseTabView(
-              selectedId: '1', children: [Text('first'), Text('second')]),
+              selectedId: '1',
+              children: [Text('first'), Text('second'), Text('third')]),
         ),
       ),
     );


### PR DESCRIPTION
## PR Description

This PR adds the HTML rendering functionality using the webview_flutter package, which allows users to interact with API responses as if they were viewing them in a regular web browser. This enhancement provides dynamic content rendering, enabling users to click links, submit forms, and navigate between pages seamlessly within the response pane.

## Related Issues

- Related Issue #155 
- Closes #155 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
- [x] Yes

I have added the required test cases in [response_widgets_test.dart](https://github.com/foss42/apidash/blob/main/test/widgets/response_widgets_test.dart) to verify the new web render tab in the ResponseTabView. These updates ensure that the new tab is correctly displayed and functions as expected.