### PR TITLE
feat(uriScheme): Added the support for url without http/https prefix

### DIFF
--- a/packages/apidash_core/lib/consts.dart
+++ b/packages/apidash_core/lib/consts.dart
@@ -4,8 +4,13 @@ enum HTTPVerb { get, head, post, put, patch, delete }
 
 enum FormDataType { text, file }
 
-const kSupportedUriSchemes = ["https", "http"];
+enum SupportedUriSchemes { https, http }
+
+final kSupportedUriSchemes =
+    SupportedUriSchemes.values.map((i) => i.name).toList();
 const kDefaultUriScheme = "https";
+final kLocalhostRegex = RegExp(r'^localhost(:\d+)?(/.*)?$');
+
 const kMethodsWithBody = [
   HTTPVerb.post,
   HTTPVerb.put,

--- a/packages/apidash_core/lib/utils/uri_utils.dart
+++ b/packages/apidash_core/lib/utils/uri_utils.dart
@@ -29,9 +29,9 @@ String stripUrlParams(String url) {
   if (url == null || url == "") {
     return (null, "URL is missing!");
   }
-  final localhostRegex = RegExp(r'^localhost(:\d+)?(/.*)?$');
-  if (localhostRegex.hasMatch(url)) {
-    url = 'http://$url';
+
+  if (kLocalhostRegex.hasMatch(url)) {
+    url = '${SupportedUriSchemes.http.name}://$url';
   }
   Uri? uri = Uri.tryParse(url);
   if (uri == null) {

--- a/packages/apidash_core/lib/utils/uri_utils.dart
+++ b/packages/apidash_core/lib/utils/uri_utils.dart
@@ -1,4 +1,5 @@
 import 'package:collection/collection.dart' show mergeMaps;
+import 'package:flutter/foundation.dart';
 import '../consts.dart';
 import '../models/name_value_model.dart';
 import 'http_request_utils.dart';
@@ -28,6 +29,10 @@ String stripUrlParams(String url) {
   url = url?.trim();
   if (url == null || url == "") {
     return (null, "URL is missing!");
+  }
+  final localhostRegex = RegExp(r'^localhost(:\d+)?(/.*)?$');
+  if (localhostRegex.hasMatch(url)) {
+    url = 'http://$url';
   }
   Uri? uri = Uri.tryParse(url);
   if (uri == null) {

--- a/packages/apidash_core/lib/utils/uri_utils.dart
+++ b/packages/apidash_core/lib/utils/uri_utils.dart
@@ -1,5 +1,4 @@
 import 'package:collection/collection.dart' show mergeMaps;
-import 'package:flutter/foundation.dart';
 import '../consts.dart';
 import '../models/name_value_model.dart';
 import 'http_request_utils.dart';

--- a/test/utils/http_utils_test.dart
+++ b/test/utils/http_utils_test.dart
@@ -183,23 +183,39 @@ void main() {
           queryParameters: {'code': 'US'});
       expect(getValidRequestUri(url1, [kvRow1]), (uri1Expected, null));
     });
-    test('Testing getValidRequestUri with localhost URL', () {
-      // Test case for localhost without port or path
+    test('Testing getValidRequestUri with localhost URL without port or path',
+        () {
       String url1 = "localhost";
       Uri uri1Expected = Uri(scheme: 'http', host: 'localhost');
       expect(getValidRequestUri(url1, []), (uri1Expected, null));
-
-      // Test case for localhost with port
-      String url2 = "localhost:8080";
-      Uri uri2Expected = Uri(scheme: 'http', host: 'localhost', port: 8080);
-      expect(getValidRequestUri(url2, []), (uri2Expected, null));
-
-      // Test case for localhost with port and path
-      String url3 = "localhost:8080/hello";
-      Uri uri3Expected =
-          Uri(scheme: 'http', host: 'localhost', port: 8080, path: '/hello');
-      expect(getValidRequestUri(url3, []), (uri3Expected, null));
     });
+
+    test('Testing getValidRequestUri with localhost URL with port', () {
+      String url1 = "localhost:8080";
+      Uri uri1Expected = Uri(scheme: 'http', host: 'localhost', port: 8080);
+      expect(getValidRequestUri(url1, []), (uri1Expected, null));
+    });
+
+    test('Testing getValidRequestUri with localhost URL with port and path',
+        () {
+      String url1 = "localhost:8080/hello";
+      Uri uri1Expected =
+          Uri(scheme: 'http', host: 'localhost', port: 8080, path: '/hello');
+      expect(getValidRequestUri(url1, []), (uri1Expected, null));
+    });
+
+    test('Testing getValidRequestUri with localhost URL with http prefix', () {
+      String url1 = "http://localhost:3080";
+      Uri uri1Expected = Uri(scheme: 'http', host: 'localhost', port: 3080);
+      expect(getValidRequestUri(url1, []), (uri1Expected, null));
+    });
+
+    test('Testing getValidRequestUri with localhost URL with https prefix', () {
+      String url1 = "https://localhost:8080";
+      Uri uri1Expected = Uri(scheme: 'https', host: 'localhost', port: 8080);
+      expect(getValidRequestUri(url1, []), (uri1Expected, null));
+    });
+
     test('Testing getValidRequestUri for null url value', () {
       const kvRow2 = NameValueModel(name: "code", value: "US");
       expect(getValidRequestUri(null, [kvRow2]), (null, "URL is missing!"));

--- a/test/utils/http_utils_test.dart
+++ b/test/utils/http_utils_test.dart
@@ -183,6 +183,23 @@ void main() {
           queryParameters: {'code': 'US'});
       expect(getValidRequestUri(url1, [kvRow1]), (uri1Expected, null));
     });
+    test('Testing getValidRequestUri with localhost URL', () {
+      // Test case for localhost without port or path
+      String url1 = "localhost";
+      Uri uri1Expected = Uri(scheme: 'http', host: 'localhost');
+      expect(getValidRequestUri(url1, []), (uri1Expected, null));
+
+      // Test case for localhost with port
+      String url2 = "localhost:8080";
+      Uri uri2Expected = Uri(scheme: 'http', host: 'localhost', port: 8080);
+      expect(getValidRequestUri(url2, []), (uri2Expected, null));
+
+      // Test case for localhost with port and path
+      String url3 = "localhost:8080/hello";
+      Uri uri3Expected =
+          Uri(scheme: 'http', host: 'localhost', port: 8080, path: '/hello');
+      expect(getValidRequestUri(url3, []), (uri3Expected, null));
+    });
     test('Testing getValidRequestUri for null url value', () {
       const kvRow2 = NameValueModel(name: "code", value: "US");
       expect(getValidRequestUri(null, [kvRow2]), (null, "URL is missing!"));


### PR DESCRIPTION
## PR Description
This PR addresses the issue where URLs without an explicit HTTP or HTTPS scheme (such as localhost:3000) were not being recognized as valid requests. Previously, users needed to specify a full URL with a prefix (http:// or https://) to ensure the application processed it correctly. This PR implements a fallback mechanism to add a default scheme (HTTP) when a URL scheme is missing, improving usability and supporting more flexible URL inputs.
_Add your description_

## Related Issues
- Closes #487 

## Screenshot
<img width="1440" alt="Screenshot 2024-11-01 at 3 56 52 PM" src="https://github.com/user-attachments/assets/bbb3c3a3-d80d-493e-845b-c70484456bbb">

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I have run the tests (`flutter test`) and all tests are passing
