### PR TITLE
Add platform setup instructions for macOS, Windows, and Linux 

### DIFF
--- a/doc/dev_guide/setup_run.md
+++ b/doc/dev_guide/setup_run.md
@@ -1,10 +1,16 @@
 # How to run API Dash locally?
 
-1. Fork the project.
-2. Create a clone of the forked project on your computer to run it locally.
-3. Based on your desktop environment, enable Windows, macOS or Linux for the project. Select the same target device.
+#### 1. Fork the project.
+#### 2. Create a clone of the forked project on your computer to run it locally.
+#### 3. Based on your desktop environment, enable Windows, macOS, or Linux for the project. Select the same target device.  
+   Choose any of the following platforms: `windows`, `macos`, or `linux`.
 
-#### 4. Setup melos
+   ```bash
+   flutter create --platforms=<platform> .
+   ```
+#### 4. Check [platform_specific_instructions.md](https://github.com/imukulgehlot/apidash/blob/setup-run-platform-guide/doc/dev_guide/platform_specific_instructions.md) to add required platform specific configurations.   
+
+#### 5. Setup melos
 
 As API Dash is a monorepo with multi-package architecture we use [melos](https://pub.dev/packages/melos). 
 

--- a/doc/dev_guide/setup_run.md
+++ b/doc/dev_guide/setup_run.md
@@ -5,7 +5,7 @@
 #### 2. Create a clone of the forked project on your computer to run it locally.
 
 #### 3. Based on your desktop environment, enable Windows, macOS, or Linux for the project. Select the same target device.  
-Choose any of the following platforms: `windows`, `macos`, or `linux`.
+Choose any of the following platforms: `windows`, `macos`, `linux`, `android` or `ios`.
 
 ```bash
 flutter create --platforms=<platform> .

--- a/doc/dev_guide/setup_run.md
+++ b/doc/dev_guide/setup_run.md
@@ -1,13 +1,16 @@
 # How to run API Dash locally?
 
 #### 1. Fork the project.
-#### 2. Create a clone of the forked project on your computer to run it locally.
-#### 3. Based on your desktop environment, enable Windows, macOS, or Linux for the project. Select the same target device.  
-   Choose any of the following platforms: `windows`, `macos`, or `linux`.
 
-   ```bash
-   flutter create --platforms=<platform> .
-   ```
+#### 2. Create a clone of the forked project on your computer to run it locally.
+
+#### 3. Based on your desktop environment, enable Windows, macOS, or Linux for the project. Select the same target device.  
+Choose any of the following platforms: `windows`, `macos`, or `linux`.
+
+```bash
+flutter create --platforms=<platform> .
+```
+
 #### 4. Check [platform_specific_instructions.md](https://github.com/imukulgehlot/apidash/blob/setup-run-platform-guide/doc/dev_guide/platform_specific_instructions.md) to add required platform specific configurations.   
 
 #### 5. Setup melos

--- a/doc/dev_guide/setup_run.md
+++ b/doc/dev_guide/setup_run.md
@@ -30,13 +30,13 @@ Get all dependencies of packages
 melos pub-get
 ```
 
-Get all dependencies of app
+#### 6. Get all dependencies of the app
 
 ```
 flutter pub get
 ```
 
-Run the project by executing the following command:
+#### 7. Run the project by executing the below command
 
 ```
 flutter run

--- a/doc/dev_guide/setup_run.md
+++ b/doc/dev_guide/setup_run.md
@@ -1,19 +1,19 @@
 # How to run API Dash locally?
 
-#### 1. Fork the project.
+**Step 1 -** Fork the project.
 
-#### 2. Create a clone of the forked project on your computer to run it locally.
+**Step 2 -** Create a clone of the forked project on your computer to run it locally.
 
-#### 3. Based on your desktop environment, enable Windows, macOS, or Linux for the project. Select the same target device.  
+**Step 3 -** Based on your desktop environment, enable Windows, macOS, or Linux for the project. Select the same target device.  
 Choose any of the following platforms: `windows`, `macos`, `linux`, `android` or `ios`.
 
 ```bash
 flutter create --platforms=<platform> .
 ```
 
-#### 4. Check [platform_specific_instructions.md](https://github.com/imukulgehlot/apidash/blob/setup-run-platform-guide/doc/dev_guide/platform_specific_instructions.md) to add required platform specific configurations.   
+**Step 4 -** Check [Platform Specific Instructions](https://github.com/imukulgehlot/apidash/blob/setup-run-platform-guide/doc/dev_guide/platform_specific_instructions.md) to add required platform specific configurations.   
 
-#### 5. Setup melos
+**Step 5 -** Setup melos
 
 As API Dash is a monorepo with multi-package architecture we use [melos](https://pub.dev/packages/melos). 
 
@@ -33,13 +33,13 @@ Get all dependencies of packages
 melos pub-get
 ```
 
-#### 6. Get all dependencies of the app
+**Step 6 -** Get all dependencies of the app
 
 ```
 flutter pub get
 ```
 
-#### 7. Run the project by executing the below command
+**Step 7 -** Run the project by executing the below command
 
 ```
 flutter run


### PR DESCRIPTION
## PR Description

Add platform setup instructions for macOS, Windows, and Linux

- Updated step 3 in setup_run.md to include platform-specific instructions for enabling Windows, macOS, or Linux based on the user’s desktop environment.
- Added `flutter create --platforms=<platform>` command example for clarity.
- Added a reference to `platform_specific_instructions.md` to guide users on configuring platform-specific requirements after setup.

This update clarifies setup steps and reduces confusion for new contributors  by centralizing necessary setup instructions in one place.

## Related Issues

- Related Issue #494 
- Closes #494 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [x] No, and this is why: _No functional changes were made to the codebase. This PR focuses solely on improving the documentation._
