### PR TITLE
Fix: Paste not working on iOS and desktop (Right Click -> Paste)

### DIFF
--- a/lib/screens/common_widgets/env_text_controller.dart
+++ b/lib/screens/common_widgets/env_text_controller.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+class VarTextEditingController extends TextEditingController {
+  final TextStyle normalStyle;
+  final TextStyle highlightStyle;
+
+  VarTextEditingController({
+    required this.normalStyle,
+    required this.highlightStyle,
+    super.text,
+  });
+
+  @override
+  TextSpan buildTextSpan({
+    required BuildContext context,
+    TextStyle? style,
+    bool withComposing = false,
+  }) {
+    // Pattern to match any text between {{ and }}
+    final pattern = RegExp(r'(\{\{.*?\}\})');
+    final children = <TextSpan>[];
+    int start = 0;
+
+    // Find matches and style them
+    for (final match in pattern.allMatches(text)) {
+      if (match.start > start) {
+        children.add(TextSpan(
+          text: text.substring(start, match.start),
+          style: normalStyle,
+        ));
+      }
+      children.add(TextSpan(
+        text: match.group(0),
+        style: highlightStyle,
+      ));
+      start = match.end;
+    }
+
+    // Add any remaining text after the last match
+    if (start < text.length) {
+      children.add(TextSpan(
+        text: text.substring(start),
+        style: normalStyle,
+      ));
+    }
+
+    return TextSpan(style: style, children: children);
+  }
+}

--- a/lib/screens/common_widgets/env_trigger_field.dart
+++ b/lib/screens/common_widgets/env_trigger_field.dart
@@ -1,7 +1,6 @@
+import 'package:apidash/screens/common_widgets/env_text_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:multi_trigger_autocomplete/multi_trigger_autocomplete.dart';
-import 'package:extended_text_field/extended_text_field.dart';
-import 'env_regexp_span_builder.dart';
 import 'env_trigger_options.dart';
 
 class EnvironmentTriggerField extends StatefulWidget {
@@ -30,12 +29,17 @@ class EnvironmentTriggerField extends StatefulWidget {
 }
 
 class EnvironmentTriggerFieldState extends State<EnvironmentTriggerField> {
-  final TextEditingController controller = TextEditingController();
+  late final VarTextEditingController controller;
   final FocusNode focusNode = FocusNode();
 
   @override
   void initState() {
     super.initState();
+    controller = VarTextEditingController(
+      normalStyle: widget.style ?? const TextStyle(color: Colors.black),
+      highlightStyle: const TextStyle(color: Colors.red),
+      text: widget.initialValue,
+    );
     controller.text = widget.initialValue ?? '';
     controller.selection =
         TextSelection.collapsed(offset: controller.text.length);
@@ -99,14 +103,13 @@ class EnvironmentTriggerFieldState extends State<EnvironmentTriggerField> {
             }),
       ],
       fieldViewBuilder: (context, textEditingController, focusnode) {
-        return ExtendedTextField(
+        return TextField(
           controller: textEditingController,
           focusNode: focusnode,
           decoration: widget.decoration,
           style: widget.style,
           onChanged: widget.onChanged,
           onSubmitted: widget.onFieldSubmitted,
-          specialTextSpanBuilder: EnvRegExpSpanBuilder(),
           onTapOutside: (event) {
             focusNode.unfocus();
           },


### PR DESCRIPTION
## PR Description
In iOS and Desktop, right click paste (double tap paste) was not working, along with no error was fired during the event.

Expected behaviour
The copied text should be pasted into the text field on right click paste event.

## Related Issues
#490 

## Reason
ExtendedTextField used for highlighting the variables in the fields like url, header value, param value etc, but the widget does not have a default function like right click paste. Normal TextField works as intended but the text highlighting of variables to red like {{url}}/endpoint is not possible. 

## Added/updated tests?

- Edited and extended the default TextEditingController class for highlighting the variables, and enabling the default Ctrl+V along with right click paste option.
- Changed the ExtendedTextField to default TextField for fixing the issue.

## Output

https://github.com/user-attachments/assets/a66f3126-6eb7-4381-97ca-45b6ca16000d


