### PR TITLE
Added content type parsing feature while importing from a curl.

### DIFF
--- a/lib/importer/curl/curl.dart
+++ b/lib/importer/curl/curl.dart
@@ -23,18 +23,123 @@ class CurlFileImport {
               ))
           .toList();
 
-      // TODO: parse curl data to determine the type of body
-      final body = curl.data;
+      ContentType bodyContentType = ContentType.json;
+      bool isFormData = false;
+      List<FormDataModel>? formDataList;
+
+      // Check if the content type is specified in the headers
+      if (headers != null) {
+        final contentTypeHeader = curl.headers?.entries
+            .firstWhere(
+              (entry) => entry.key.toLowerCase() == 'content-type',
+              orElse: () => const MapEntry('', ''),
+            )
+            .value;
+        if (contentTypeHeader!.isNotEmpty) {
+          switch (contentTypeHeader) {
+            case 'application/json':
+              bodyContentType = ContentType.json;
+              break;
+            case 'multipart/form-data':
+              bodyContentType = ContentType.formdata;
+              isFormData = true;
+              break;
+            case 'text/plain':
+              bodyContentType = ContentType.text;
+              break;
+            default:
+              bodyContentType = ContentType.json;
+              break;
+          }
+        }
+      }
+
+      // Parse form data if present
+      if (curl.data != null) {
+        // This is url-encoded form data if it contains '=' and '&'
+        if (curl.data!.contains('=') && curl.data!.contains('&')) {
+          final pairs = curl.data!.split('&');
+          if (pairs.every((pair) => pair.contains('='))) {
+            bodyContentType = ContentType.formdata;
+            isFormData = true;
+            formDataList = _parseUrlEncodedFormData(curl.data!);
+          }
+        }
+
+        // Try parsing as JSON if not form data
+        if (!isFormData) {
+          try {
+            final _ = kJsonDecoder.convert(curl.data!);
+            bodyContentType = ContentType.json;
+          } catch (e) {
+            bodyContentType = ContentType.text;
+          }
+        }
+      } else if (curl.form) {
+        // Check for multipart form data (-F flag) as when the curl.form flag is set
+        // to true, it means that the request is a form data request of formdata/multipart type
+
+        bodyContentType = ContentType.formdata;
+        formDataList = _parseMultipartFormData(content);
+      }
 
       return HttpRequestModel(
         method: method,
         url: url,
         headers: headers,
         params: params,
-        body: body,
+        formData: formDataList,
+        body: curl.data,
+        bodyContentType: bodyContentType,
       );
     } catch (e) {
       return null;
     }
+  }
+
+  // Manually parsing the form data
+  List<FormDataModel> _parseMultipartFormData(String data) {
+    final List<FormDataModel> formData = [];
+
+    // Regex for parsing -F fields we are creating a group for the field name and value
+    final RegExp regex = RegExp(r'-F\s*"([^=]+)=([^"]+)"');
+
+    final Map<String, String> parsedData = {};
+
+    for (final Match match in regex.allMatches(data)) {
+      final String key = match.group(1)!;
+      String value = match.group(2)!;
+      parsedData[key] = value;
+    }
+
+    parsedData.forEach((key, value) {
+      // Check if the value is a file
+      if (value.startsWith('@')) {
+        formData.add(FormDataModel(
+          name: key,
+          value: value.substring(1),
+          type: FormDataType.file,
+        ));
+      } else {
+        formData.add(FormDataModel(
+          name: key,
+          value: value,
+          type: FormDataType.text,
+        ));
+      }
+    });
+
+    return formData;
+  }
+
+  List<FormDataModel> _parseUrlEncodedFormData(String data) {
+    return data.split('&').map((pair) {
+      final parts = pair.split('=');
+      return FormDataModel(
+        name: parts[0],
+        value: Uri.decodeComponent(parts[1]),
+        type: FormDataType.text,
+      );
+    }).toList();
   }
 }

--- a/test/importer/curl_file_import.dart
+++ b/test/importer/curl_file_import.dart
@@ -1,0 +1,197 @@
+import 'package:apidash/importer/curl/curl.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:apidash_core/apidash_core.dart';
+
+void main() {
+  late CurlFileImport curlImport;
+
+  setUp(() {
+    curlImport = CurlFileImport();
+  });
+
+  group('CurlFileImport Tests', () {
+    test('should parse basic GET request', () {
+      const curl = 'curl http://example.com';
+      final result = curlImport.getHttpRequestModel(curl);
+
+      expect(result, isNotNull);
+      expect(result!.method, equals(HTTPVerb.get));
+      expect(result.url, equals('http://example.com'));
+      expect(result.headers, isNull);
+      expect(result.params, isEmpty);
+      expect(result.body, isNull);
+      expect(result.bodyContentType, equals(ContentType.json));
+    });
+
+    test('should parse POST request with JSON body and content-type header',
+        () {
+      const curl = '''
+        curl -X POST http://example.com/api 
+        -H "Content-Type: application/json" 
+        -d '{"key": "value"}'
+      ''';
+      final result = curlImport.getHttpRequestModel(curl);
+
+      expect(result, isNotNull);
+      expect(result!.method, equals(HTTPVerb.post));
+      expect(result.url, equals('http://example.com/api'));
+      expect(result.headers!.length, equals(1));
+      expect(result.headers!.first.name, equals('Content-Type'));
+      expect(result.headers!.first.value, equals('application/json'));
+      expect(result.body, equals('{"key": "value"}'));
+      expect(result.bodyContentType, equals(ContentType.json));
+    });
+
+    test(
+        'should parse POST request with url-encoded form data without content-type',
+        () {
+      const curl = '''
+    curl -X POST http://example.com/upload 
+    -d "param1=value1&param2=value2" 
+  ''';
+      final result = curlImport.getHttpRequestModel(curl);
+
+      expect(result, isNotNull);
+      expect(result!.method, equals(HTTPVerb.post));
+      expect(result.bodyContentType, equals(ContentType.formdata));
+      expect(
+          result.formDataList,
+          equals([
+            const FormDataModel(
+                name: 'param1', value: 'value1', type: FormDataType.text),
+            const FormDataModel(
+                name: 'param2', value: 'value2', type: FormDataType.text),
+          ]));
+    });
+
+    test('should parse POST request with form-data', () {
+      const curl = '''
+       curl -X POST https://example.com/upload \\
+  -F "file=@/path/to/image.jpg" \\
+  -F "username=john"
+
+      ''';
+      final result = curlImport.getHttpRequestModel(curl);
+
+      expect(result, isNotNull);
+      expect(result!.method, equals(HTTPVerb.post));
+      expect(result.bodyContentType, equals(ContentType.formdata));
+      expect(result.formDataList.length, equals(2));
+      expect(result.formDataList[0].name, equals('file'));
+      expect(result.formDataList[0].value, equals('/path/to/image.jpg'));
+      expect(result.formDataList[0].type, equals(FormDataType.file));
+    });
+
+    test('should parse request with query parameters', () {
+      const curl = 'curl "http://example.com/api?param1=value1&param2=value2"';
+      final result = curlImport.getHttpRequestModel(curl);
+
+      expect(result, isNotNull);
+      expect(result!.params!.length, equals(2));
+      expect(result.params![0].name, equals('param1'));
+      expect(result.params![0].value, equals('value1'));
+      expect(result.params![1].name, equals('param2'));
+      expect(result.params![1].value, equals('value2'));
+    });
+
+    test('should detect JSON body without content-type header', () {
+      const curl = '''
+        curl -X POST http://example.com/api 
+        -d '{"key": "value"}'
+      ''';
+      final result = curlImport.getHttpRequestModel(curl);
+
+      expect(result, isNotNull);
+      expect(result!.bodyContentType, equals(ContentType.json));
+      expect(result.body, equals('{"key": "value"}'));
+    });
+
+    test('should detect text body when JSON is invalid', () {
+      const curl = '''
+        curl -X POST http://example.com/api 
+        -d 'invalid json data'
+      ''';
+      final result = curlImport.getHttpRequestModel(curl);
+
+      expect(result, isNotNull);
+      expect(result!.bodyContentType, equals(ContentType.text));
+      expect(result.body, equals('invalid json data'));
+    });
+
+    test('should handle text/plain content-type', () {
+      const curl = '''
+        curl -X POST http://example.com/api 
+        -H "Content-Type: text/plain" 
+        -d 'Hello World'
+      ''';
+      final result = curlImport.getHttpRequestModel(curl);
+
+      expect(result, isNotNull);
+      expect(result!.bodyContentType, equals(ContentType.text));
+      expect(result.body, equals('Hello World'));
+    });
+
+    test('should handle multiple headers', () {
+      const curl = '''
+        curl http://example.com/api 
+        -H "Authorization: Bearer token123" 
+        -H "Accept: application/json"
+      ''';
+      final result = curlImport.getHttpRequestModel(curl);
+
+      expect(result, isNotNull);
+      expect(result!.headers!.length, equals(2));
+      expect(result.headers![0].name, equals('Authorization'));
+      expect(result.headers![0].value, equals('Bearer token123'));
+      expect(result.headers![1].name, equals('Accept'));
+      expect(result.headers![1].value, equals('application/json'));
+    });
+
+    test('should parse URL-encoded form data', () {
+      const curl = '''
+        curl -X POST http://example.com/upload 
+        -d "name=john&age=25&description=test%20value" 
+      ''';
+      final result = curlImport.getHttpRequestModel(curl);
+
+      expect(result, isNotNull);
+      expect(result!.method, equals(HTTPVerb.post));
+      expect(result.bodyContentType, equals(ContentType.formdata));
+      expect(result.formData, isNotNull);
+      expect(result.formData!.length, equals(3));
+
+      expect(result.formData![0].name, equals('name'));
+      expect(result.formData![0].value, equals('john'));
+      expect(result.formData![0].type, equals(FormDataType.text));
+
+      expect(result.formData![1].name, equals('age'));
+      expect(result.formData![1].value, equals('25'));
+      expect(result.formData![1].type, equals(FormDataType.text));
+
+      expect(result.formData![2].name, equals('description'));
+      expect(result.formData![2].value, equals('test value')); // URL decoded
+      expect(result.formData![2].type, equals(FormDataType.text));
+    });
+
+    test('should return null for invalid curl command', () {
+      const curl = 'invalid curl command';
+      final result = curlImport.getHttpRequestModel(curl);
+
+      expect(result, isNull);
+    });
+
+    test('should handle empty content', () {
+      const curl = '';
+      final result = curlImport.getHttpRequestModel(curl);
+
+      expect(result, isNull);
+    });
+
+    test('should handle whitespace-only content', () {
+      const curl = '   \n   \t   ';
+      final result = curlImport.getHttpRequestModel(curl);
+
+      expect(result, isNull);
+    });
+  });
+}


### PR DESCRIPTION

## PR Description

Added the feature of getting the request content type when we are importing curl.
- JSON
- multipart/formdata
- urlencoded formdata


## Related Issues

- Closes #

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

<img width="622" alt="image" src="https://github.com/user-attachments/assets/be99a2b1-d5ba-4f31-9601-cf9b78e454d2">


## Added/updated tests?
_We encourage you to add relevant test cases._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_

## OS on which you have developed and tested the feature?

- [ ] Windows
- [x] macOS
- [ ] Linux
