### PR TITLE
Fix: Deletion of Global Environment variable causes null error

### DIFF
--- a/lib/screens/envvar/environment_editor.dart
+++ b/lib/screens/envvar/environment_editor.dart
@@ -53,11 +53,14 @@ class EnvironmentEditor extends ConsumerWidget {
                       onDuplicatePressed: () => ref
                           .read(environmentsStateNotifierProvider.notifier)
                           .duplicateEnvironment(id!),
-                      onDeletePressed: () {
-                        ref
-                            .read(environmentsStateNotifierProvider.notifier)
-                            .removeEnvironment(id!);
-                      },
+                      onDeletePressed: id == kGlobalEnvironmentId
+                          ? null
+                          : () {
+                              ref
+                                  .read(environmentsStateNotifierProvider
+                                      .notifier)
+                                  .removeEnvironment(id!);
+                            },
                     ),
                     kHSpacer4,
                   ],


### PR DESCRIPTION
## PR Description
Disabled the delete button when Global environment variable is selected.

## Related Issues

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
- [ ] Yes
- [x] No, and this is why: The change only involves disabling a button, which prevents the delete action. The functionality does not introduce or modify logic that requires testing.

## OS on which you have developed and tested the feature?

- [ ] Windows
- [x] macOS
- [ ] Linux

## UI Update
<img width="852" alt="api-dash-bug-fix" src="https://github.com/user-attachments/assets/edaeefdc-e00c-4c4c-a2c0-6e8911d73420" />

