### PR TITLE
Add instructions to run API Dash-generated code in Dart (dio)

### DIFF
--- a/doc/user_guide/instructions_to_run_generated_code.md
+++ b/doc/user_guide/instructions_to_run_generated_code.md
@@ -51,11 +51,100 @@ TODO
 
 ## Dart (http)
 
-TODO
+Here are the detailed instructions for running the generated API Dash code in **Dart (using `http`)** for macOS, Windows, and Linux:  
+
+---
+
+### **1. Install Dart**  
+To run Dart code, you need to install the Dart SDK.  
+
+- Visit the official **[Dart Installation Guide](https://dart.dev/get-dart)** for step-by-step instructions for macOS, Windows, and Linux.  
+- Follow the guide to install Dart globally on your system.  
+
+---
+
+### **2. Add the `http` Package**  
+To use the `http` package in Dart, you need to add it as a dependency in your project.  
+
+1. Create a new Dart project by running the following command in the terminal:  
+   ```bash
+   dart create my_dart_project
+   cd my_dart_project
+   ```  
+2. Open the `pubspec.yaml` file in the project directory.  
+3. Add the following line under the `dependencies` section:  
+   ```yaml
+   dependencies:
+     http: ^1.2.2
+   ```  
+4. Run the following command to fetch the dependency:  
+   ```bash
+   dart pub get
+   ```
+
+---
+
+### **3. Run the Generated Code**  
+After setting up Dart and the `http` package, follow these steps to execute the generated code:  
+
+#### **Using a Text Editor or IDE (e.g., Visual Studio Code):**
+1. Open a text editor or an IDE like Visual Studio Code.  
+2. Create a new Dart file, such as `api_test.dart`.  
+3. Copy the generated code from API Dash and paste it into this file.  
+4. Save the file.  
+5. Run the Dart file using the terminal or the IDE's built-in tools.  
+
+#### **Using the Command Line:**
+1. Save the generated code to a Dart file, e.g., `api_test.dart`.  
+2. Open a terminal and navigate to the directory containing the file.  
+3. Run the Dart file with the following command:  
+   ```bash
+   dart run api_test.dart
+   ```
+
+With these steps, you can successfully run API Dash-generated code in Dart using the `http` package! 🚀
 
 ## Dart (dio)
 
-TODO
+Here are the detailed instructions for running the generated API Dash code in **Dart (using `dio`)** for macOS, Windows, and Linux:
+
+---
+
+### **1. Install Dart**  
+To run Dart code, you need to install the Dart SDK.  
+
+👉 Follow the instructions provided above under **Dart (http)** for detailed steps on how to install Dart on macOS, Windows, and Linux.
+
+---
+
+### **2. Add the `dio` Package**  
+To use the `dio` package in Dart, you need to add it as a dependency in your project.  
+
+1. Create a new Dart project by running the following command in the terminal:  
+   ```bash
+   dart create my_dart_project
+   cd my_dart_project
+   ```  
+2. Open the `pubspec.yaml` file in the project directory.  
+3. Add the following line under the `dependencies` section:  
+   ```yaml
+   dependencies:
+     dio: ^5.7.0
+   ```  
+4. Run the following command to fetch the dependency:  
+   ```bash
+   dart pub get
+   ```
+---
+
+### **3. Run the Generated Code**  
+After setting up Dart and the `dio` package, follow these steps to execute the generated code:
+
+👉 Refer to the instructions under **Dart (http)** for details on how to execute the Dart file using an IDE or the terminal.
+
+---
+
+With these steps, you can successfully run API Dash-generated code in Dart using the `dio` package! 🚀
 
 ## Go (net/http)
 


### PR DESCRIPTION
Add instructions to run API Dash-generated code in Dart (dio)

## PR Description  

This PR adds detailed instructions for running API Dash-generated code in **Dart (using `dio`)** across macOS, Windows, and Linux. It includes steps for adding the `dio` package, setting up the project, and executing the generated code, with references to shared installation steps for Dart.

## Related Issues
#527 

- Closes #

### Checklist
- [X] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [X] I have updated my branch and synced it with project `main` branch before making this PR
- [X] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [X] I have run the tests (`flutter test`) and all tests are passing


- [ ] Yes
- [X] No, and this is why: The changes are purely documentation-related

## OS on which you have developed and tested the feature?

- [X] Windows
- [ ] macOS
- [X] Linux
