### PR TITLE
Added url encoded format for sending the data in request

### DIFF
--- a/lib/codegen/dart/dio.dart
+++ b/lib/codegen/dart/dio.dart
@@ -84,6 +84,14 @@ class DartDioCodeGen {
         // when add new type of [ContentType], need update [dataExp].
         case ContentType.formdata:
           dataExp = declareFinal('data').assign(refer('dio.FormData()'));
+        case ContentType.urlencoded:
+          // Convert form data to URL-encoded format
+          final urlEncodedData = formData.map((item) => 
+            '${Uri.encodeComponent(item['name'] ?? '')}'
+            '='
+            '${Uri.encodeComponent(item['value'] ?? '')}'
+          ).join('&');
+          dataExp = declareFinal('data').assign(literalString(urlEncodedData));
       }
     }
     final responseExp = declareFinal('response').assign(InvokeExpression.newOf(

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_body.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_body.dart
@@ -6,6 +6,7 @@ import 'package:apidash/providers/providers.dart';
 import 'package:apidash/widgets/widgets.dart';
 import 'package:apidash/consts.dart';
 import 'request_form_data.dart';
+import 'package:apidash/widgets/form_data_toggle.dart';
 
 class EditRequestBody extends ConsumerWidget {
   const EditRequestBody({super.key});
@@ -52,6 +53,8 @@ class EditRequestBody extends ConsumerWidget {
                 ),
               )
             : kSizedBoxEmpty,
+        const FormDataToggle(),
+        const SizedBox(height: 16),
         switch (apiType) {
           APIType.rest => Expanded(
               child: switch (contentType) {

--- a/lib/widgets/form_data_toggle.dart
+++ b/lib/widgets/form_data_toggle.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:apidash_core/apidash_core.dart';
+import '../providers/providers.dart';
+
+class FormDataToggle extends ConsumerWidget {
+  const FormDataToggle({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selectedId = ref.watch(selectedIdStateProvider);
+    final contentType = ref.watch(selectedRequestModelProvider
+        .select((value) => value?.httpRequestModel?.bodyContentType));
+    final formData = ref.watch(selectedRequestModelProvider
+        .select((value) => value?.httpRequestModel?.formData));
+    
+    final hasFiles = formData?.any((item) => item.type == FormDataType.file) ?? false;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 2),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            const SizedBox(width: 6),
+            const Text('Form Data Type:'),
+            SegmentedButton<ContentType>(
+              segments: const [
+                ButtonSegment<ContentType>(
+                  value: ContentType.urlencoded,
+                  label: Text('Text Only'),
+                  icon: Icon(Icons.text_fields),
+                ),
+                ButtonSegment<ContentType>(
+                  value: ContentType.formdata,
+                  label: Text('Include Files'),
+                  icon: Icon(Icons.attach_file),
+                ),
+              ],
+              selected: {contentType == ContentType.formdata ? ContentType.formdata : ContentType.urlencoded},
+              onSelectionChanged: (Set<ContentType> newSelection) {
+                final newContentType = newSelection.first;
+                if (newContentType == ContentType.urlencoded && hasFiles) {
+                  // Show warning dialog when switching to urlencoded with files
+                  showDialog(
+                    context: context,
+                    builder: (context) => AlertDialog(
+                      title: const Text('Warning'),
+                      content: const Text(
+                        'Switching to "Text Only" mode will remove any file attachments. '
+                        'Are you sure you want to continue?'
+                      ),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.of(context).pop(),
+                          child: const Text('Cancel'),
+                        ),
+                        TextButton(
+                          onPressed: () {
+                            Navigator.of(context).pop();
+                            ref
+                                .read(collectionStateNotifierProvider.notifier)
+                                .update(id: selectedId!, bodyContentType: newContentType);
+                          },
+                          child: const Text('Continue'),
+                        ),
+                      ],
+                    ),
+                  );
+                } else {
+                  ref
+                      .read(collectionStateNotifierProvider.notifier)
+                      .update(id: selectedId!, bodyContentType: newContentType);
+                }
+              },
+            ),
+            const SizedBox(width: 6),
+          ],
+        ),
+        if (hasFiles && contentType == ContentType.urlencoded)
+          Padding(
+            padding: const EdgeInsets.only(top: 8.0),
+            child: Container(
+              padding: const EdgeInsets.all(8.0),
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.errorContainer,
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.warning,
+                    color: Theme.of(context).colorScheme.error,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      'Files detected. Switch to "Include Files" mode to support file uploads.',
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.error,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/packages/apidash_core/lib/consts.dart
+++ b/packages/apidash_core/lib/consts.dart
@@ -77,11 +77,19 @@ const kSubTypeDefaultViewOptions = 'all';
 enum ContentType {
   json("$kTypeApplication/$kSubTypeJson"),
   text("$kTypeText/$kSubTypePlain"),
-  formdata("$kTypeMultipart/$kSubTypeFormData");
+  formdata("$kTypeMultipart/$kSubTypeFormData"),
+  urlencoded("$kTypeApplication/$kSubTypeXWwwFormUrlencoded");
 
   const ContentType(this.header);
   final String header;
 }
+
+Map<ContentType, String> kContentTypeMap = {
+  ContentType.json: ContentType.json.header,
+  ContentType.text: ContentType.text.header,
+  ContentType.formdata: ContentType.formdata.header,
+  ContentType.urlencoded: ContentType.urlencoded.header,
+};
 
 const JsonEncoder kJsonEncoder = JsonEncoder.withIndent('  ');
 const JsonDecoder kJsonDecoder = JsonDecoder();


### PR DESCRIPTION
## PR Description

This PR implements a toggle switch feature in the form-data section of the API Dash application. The toggle allows users to switch between application/x-www-form-urlencoded and multipart/form-data content types. The feature automatically selects the appropriate content type based on whether files are included in the form data, enhancing user experience and ensuring correct data submission.

## Related Issues

- Closes #337 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: I am currently waiting for my approach to get completely verified.

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux
