### PR TITLE
Initial working xwwwurlencoded body type

### DIFF
--- a/lib/codegen/dart/dio.dart
+++ b/lib/codegen/dart/dio.dart
@@ -84,6 +84,8 @@ class DartDioCodeGen {
         // when add new type of [ContentType], need update [dataExp].
         case ContentType.formdata:
           dataExp = declareFinal('data').assign(refer('dio.FormData()'));
+        case ContentType.xwwwformurlencoded:
+          dataExp = declareFinal('data').assign(refer('dio.FormData()'));
       }
     }
     final responseExp = declareFinal('response').assign(InvokeExpression.newOf(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,6 +49,7 @@ Future<bool> initApp(
     if (openBoxesStatus) {
       await autoClearHistory(settingsModel: settingsModel);
     }
+    debugPrint("autoClearHistory done");
     return openBoxesStatus;
   } catch (e) {
     debugPrint("initApp failed due to $e");

--- a/lib/screens/history/history_widgets/his_request_pane.dart
+++ b/lib/screens/history/history_widgets/his_request_pane.dart
@@ -133,10 +133,11 @@ class HisRequestBody extends ConsumerWidget {
             kVSpacer5,
             Expanded(
               child: switch (contentType) {
-                ContentType.formdata => Padding(
-                    padding: kPh4,
-                    child: RequestFormDataTable(
-                        rows: requestModel?.formData ?? [])),
+                (ContentType.formdata || ContentType.xwwwformurlencoded) =>
+                  Padding(
+                      padding: kPh4,
+                      child: RequestFormDataTable(
+                          rows: requestModel?.formData ?? [])),
                 // TODO: Fix JsonTextFieldEditor & plug it here
                 ContentType.json => Padding(
                     padding: kPt5o10,

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_body.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_body.dart
@@ -6,6 +6,7 @@ import 'package:apidash/providers/providers.dart';
 import 'package:apidash/widgets/widgets.dart';
 import 'package:apidash/consts.dart';
 import 'request_form_data.dart';
+import 'request_urlencoded.dart';
 
 class EditRequestBody extends ConsumerWidget {
   const EditRequestBody({super.key});
@@ -58,6 +59,12 @@ class EditRequestBody extends ConsumerWidget {
                 ContentType.formdata => const Padding(
                     padding: kPh4,
                     child: FormDataWidget(
+                        // TODO: See changeToPostMethod above
+                        // changeMethodToPost: changeToPostMethod,
+                        )),
+                ContentType.xwwwformurlencoded => const Padding(
+                    padding: kPh4,
+                    child: UrlEncodedFormDataWidget(
                         // TODO: See changeToPostMethod above
                         // changeMethodToPost: changeToPostMethod,
                         )),

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_body.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_body.dart
@@ -62,12 +62,8 @@ class EditRequestBody extends ConsumerWidget {
                         // TODO: See changeToPostMethod above
                         // changeMethodToPost: changeToPostMethod,
                         )),
-                ContentType.xwwwformurlencoded => const Padding(
-                    padding: kPh4,
-                    child: UrlEncodedFormDataWidget(
-                        // TODO: See changeToPostMethod above
-                        // changeMethodToPost: changeToPostMethod,
-                        )),
+                ContentType.xwwwformurlencoded =>
+                  const Padding(padding: kPh4, child: FormDataWidget()),
                 // TODO: Fix JsonTextFieldEditor & plug it here
                 ContentType.json => Padding(
                     padding: kPt5o10,
@@ -124,6 +120,7 @@ class EditRequestBody extends ConsumerWidget {
   }
 }
 
+// We are merging the two dropdown buttons into one ie: Form Data and urlencoded
 class DropdownButtonBodyContentType extends ConsumerWidget {
   const DropdownButtonBodyContentType({
     super.key,
@@ -134,12 +131,28 @@ class DropdownButtonBodyContentType extends ConsumerWidget {
     ref.watch(selectedIdStateProvider);
     final requestBodyContentType = ref.watch(selectedRequestModelProvider
         .select((value) => value?.httpRequestModel?.bodyContentType));
+
     return DropdownButtonContentType(
-      contentType: requestBodyContentType,
+      contentType: requestBodyContentType == ContentType.xwwwformurlencoded
+          ? ContentType.formdata
+          : requestBodyContentType,
       onChanged: (ContentType? value) {
-        ref
-            .read(collectionStateNotifierProvider.notifier)
-            .update(bodyContentType: value);
+        if (value == ContentType.formdata) {
+          final currentType = requestBodyContentType;
+          if (currentType == ContentType.xwwwformurlencoded) {
+            ref
+                .read(collectionStateNotifierProvider.notifier)
+                .update(bodyContentType: ContentType.xwwwformurlencoded);
+          } else {
+            ref
+                .read(collectionStateNotifierProvider.notifier)
+                .update(bodyContentType: ContentType.formdata);
+          }
+        } else {
+          ref
+              .read(collectionStateNotifierProvider.notifier)
+              .update(bodyContentType: value);
+        }
       },
     );
   }

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_urlencoded.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_urlencoded.dart
@@ -1,0 +1,198 @@
+import 'dart:math';
+import 'package:apidash_core/apidash_core.dart';
+import 'package:apidash_design_system/apidash_design_system.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:data_table_2/data_table_2.dart';
+import 'package:apidash/providers/providers.dart';
+import 'package:apidash/widgets/widgets.dart';
+import 'package:apidash/utils/utils.dart';
+import 'package:apidash/consts.dart';
+
+class UrlEncodedFormDataWidget extends ConsumerStatefulWidget {
+  const UrlEncodedFormDataWidget({super.key});
+  @override
+  ConsumerState<UrlEncodedFormDataWidget> createState() => _FormDataBodyState();
+}
+
+class _FormDataBodyState extends ConsumerState<UrlEncodedFormDataWidget> {
+  late int seed;
+  final random = Random.secure();
+  late List<FormDataModel> formRows;
+  bool isAddingRow = false;
+
+  @override
+  void initState() {
+    super.initState();
+    seed = random.nextInt(kRandMax);
+  }
+
+  void _onFieldChange() {
+    ref.read(collectionStateNotifierProvider.notifier).update(
+          formData: formRows.sublist(0, formRows.length - 1),
+        );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    dataTableShowLogs = false;
+    final selectedId = ref.watch(selectedIdStateProvider);
+    ref.watch(selectedRequestModelProvider
+        .select((value) => value?.httpRequestModel?.formData?.length));
+    var rF = ref.read(selectedRequestModelProvider)?.httpRequestModel?.formData;
+    bool isFormDataEmpty = rF == null || rF.isEmpty;
+    formRows = isFormDataEmpty
+        ? [
+            kFormDataEmptyModel,
+          ]
+        : rF +
+            [
+              kFormDataEmptyModel,
+            ];
+    isAddingRow = false;
+
+    List<DataColumn> columns = const [
+      DataColumn2(
+        label: Text(kNameField),
+        size: ColumnSize.M,
+      ),
+      DataColumn2(
+        label: Text('='),
+        fixedWidth: 20,
+      ),
+      // DataColumn2(
+      //   label: Text(''),
+      //   fixedWidth: 70,
+      // ),
+      DataColumn2(
+        label: Text(kNameValue),
+        size: ColumnSize.L,
+      ),
+      DataColumn2(
+        label: Text(''),
+        fixedWidth: 32,
+      ),
+    ];
+
+    List<DataRow> dataRows = List<DataRow>.generate(
+      formRows.length,
+      (index) {
+        bool isLast = index + 1 == formRows.length;
+        return DataRow(
+          key: ValueKey("$selectedId-$index-form-row-$seed"),
+          cells: <DataCell>[
+            DataCell(
+              CellField(
+                keyId: "$selectedId-$index-form-k-$seed",
+                initialValue: formRows[index].name,
+                hintText: kHintAddFieldName,
+                onChanged: (value) {
+                  formRows[index] = formRows[index].copyWith(name: value);
+                  if (isLast && !isAddingRow) {
+                    isAddingRow = true;
+                    formRows.add(kFormDataEmptyModel);
+                  }
+                  _onFieldChange();
+                },
+                colorScheme: Theme.of(context).colorScheme,
+              ),
+            ),
+            DataCell(
+              Center(
+                child: Text(
+                  "=",
+                  style: kCodeStyle,
+                ),
+              ),
+            ),
+            DataCell(
+              CellField(
+                keyId: "$selectedId-$index-form-v-$seed",
+                initialValue: formRows[index].value,
+                hintText: kHintAddValue,
+                onChanged: (value) {
+                  formRows[index] = formRows[index].copyWith(value: value);
+                  if (isLast && !isAddingRow) {
+                    isAddingRow = true;
+                    formRows.add(kFormDataEmptyModel);
+                  }
+                  _onFieldChange();
+                },
+                colorScheme: Theme.of(context).colorScheme,
+              ),
+            ),
+            DataCell(
+              InkWell(
+                onTap: isLast
+                    ? null
+                    : () {
+                        seed = random.nextInt(kRandMax);
+                        if (formRows.length == 2) {
+                          setState(() {
+                            formRows = [
+                              kFormDataEmptyModel,
+                            ];
+                          });
+                        } else {
+                          formRows.removeAt(index);
+                        }
+                        _onFieldChange();
+                      },
+                child: Theme.of(context).brightness == Brightness.dark
+                    ? kIconRemoveDark
+                    : kIconRemoveLight,
+              ),
+            ),
+          ],
+        );
+      },
+    );
+
+    return Stack(
+      children: [
+        Container(
+          margin: kP10,
+          child: Column(
+            children: [
+              Expanded(
+                child: Theme(
+                  data: Theme.of(context)
+                      .copyWith(scrollbarTheme: kDataTableScrollbarTheme),
+                  child: DataTable2(
+                    columnSpacing: 12,
+                    dividerThickness: 0,
+                    horizontalMargin: 0,
+                    headingRowHeight: 0,
+                    dataRowHeight: kDataTableRowHeight,
+                    bottomMargin: kDataTableBottomPadding,
+                    isVerticalScrollBarVisible: true,
+                    columns: columns,
+                    rows: dataRows,
+                  ),
+                ),
+              ),
+              kVSpacer40,
+            ],
+          ),
+        ),
+        Align(
+          alignment: Alignment.bottomCenter,
+          child: Padding(
+            padding: kPb15,
+            child: ElevatedButton.icon(
+              onPressed: () {
+                formRows.add(kFormDataEmptyModel);
+                _onFieldChange();
+              },
+              icon: const Icon(Icons.add),
+              label: const Text(
+                kLabelAddFormField,
+                style: kTextStyleButton,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/dropdown_content_type.dart
+++ b/lib/widgets/dropdown_content_type.dart
@@ -12,11 +12,23 @@ class DropdownButtonContentType extends StatelessWidget {
   final ContentType? contentType;
   final void Function(ContentType?)? onChanged;
 
+  String? _getDisplayName(ContentType type) {
+    if (type == ContentType.formdata ||
+        type == ContentType.xwwwformurlencoded) {
+      return "Form Data";
+    }
+    return type.name;
+  }
+
   @override
   Widget build(BuildContext context) {
+    final filteredTypes = ContentType.values
+        .where((type) => type != ContentType.xwwwformurlencoded)
+        .toList();
+
     return ADDropdownButton<ContentType>(
       value: contentType,
-      values: ContentType.values.map((e) => (e, e.name)),
+      values: filteredTypes.map((e) => (e, _getDisplayName(e))).toList(),
       onChanged: onChanged,
       iconSize: 16,
     );

--- a/packages/apidash_core/lib/consts.dart
+++ b/packages/apidash_core/lib/consts.dart
@@ -77,7 +77,8 @@ const kSubTypeDefaultViewOptions = 'all';
 enum ContentType {
   json("$kTypeApplication/$kSubTypeJson"),
   text("$kTypeText/$kSubTypePlain"),
-  formdata("$kTypeMultipart/$kSubTypeFormData");
+  formdata("$kTypeMultipart/$kSubTypeFormData"),
+  xwwwformurlencoded("$kTypeApplication/$kSubTypeXWwwFormUrlencoded");
 
   const ContentType(this.header);
   final String header;

--- a/packages/apidash_core/lib/models/http_request_model.dart
+++ b/packages/apidash_core/lib/models/http_request_model.dart
@@ -45,6 +45,8 @@ class HttpRequestModel with _$HttpRequestModel {
 
   bool get hasContentTypeHeader => enabledHeadersMap.hasKeyContentType();
   bool get hasFormDataContentType => bodyContentType == ContentType.formdata;
+  bool get hasUrlEncodedContentType =>
+      bodyContentType == ContentType.xwwwformurlencoded;
   bool get hasJsonContentType => bodyContentType == ContentType.json;
   bool get hasTextContentType => bodyContentType == ContentType.text;
   int get contentLength => utf8.encode(body ?? "").length;


### PR DESCRIPTION
## PR Description

Implemented a basic POC for the xwwwurlencoded body content by adding an option to send it seperate from already implemented formdata. I think doing it this way is better as the discussed way of sending by default url encoded and sending multipart when a file is attached can lead to confusions and also if the user specificly wants to send a multipart. If we are adding a toggle for these 2 it will create a sort of divide in the type of the body type where you will have a different variable of sorts to know what kind of body this is. Anyways open to suggestions.


## Related Issues

https://github.com/user-attachments/assets/d3c3dd7a-77ce-4bc7-81fd-7cf8c2d5b827



- Closes #337 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
I'll add tests in further development after the POC is approved

- [ ] Yes
- [x] No, and this is why:I'll add tests in further development after the POC is approved
 ## OS on which you have developed and tested the feature?

- [ ] Windows
- [x] macOS
- [ ] Linux
