### PR TITLE
Deprecation Fix for withOpacity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,11 @@
 *.swp
 .DS_Store
 .atom/
+.build/
 .buildlog/
 .history
 .svn/
+.swiftpm/
 migrate_working_dir/
 
 # IntelliJ related

--- a/lib/screens/common_widgets/button_navbar.dart
+++ b/lib/screens/common_widgets/button_navbar.dart
@@ -69,16 +69,13 @@ class NavbarButton extends ConsumerWidget {
                 ? Text(
                     label,
                     style: Theme.of(context).textTheme.labelSmall!.copyWith(
-                          fontWeight: FontWeight.w600,
-                          color: isSelected
-                              ? Theme.of(context)
-                                  .colorScheme
-                                  .onSecondaryContainer
-                              : Theme.of(context)
-                                  .colorScheme
-                                  .onSurface
-                                  .withOpacity(0.65),
-                        ),
+                        fontWeight: FontWeight.w600,
+                        color: isSelected
+                            ? Theme.of(context).colorScheme.onSecondaryContainer
+                            : Theme.of(context)
+                                .colorScheme
+                                .onSurface
+                                .withAlpha((0.65 * 255).round())),
                   )
                 : const SizedBox.shrink(),
           ],

--- a/lib/screens/common_widgets/editor_title.dart
+++ b/lib/screens/common_widgets/editor_title.dart
@@ -32,7 +32,7 @@ class EditorTitle extends StatelessWidget {
               color: Theme.of(context)
                   .colorScheme
                   .secondaryContainer
-                  .withOpacity(0.3),
+                  .withAlpha((0.3 * 255).round()),
               padding:
                   const EdgeInsets.symmetric(horizontal: 12.0, vertical: 6),
               child: Row(

--- a/lib/screens/common_widgets/envfield_cell.dart
+++ b/lib/screens/common_widgets/envfield_cell.dart
@@ -29,17 +29,13 @@ class EnvCellField extends StatelessWidget {
       ),
       decoration: InputDecoration(
         hintStyle: kCodeStyle.copyWith(
-          color: clrScheme.outline.withOpacity(
-            kHintOpacity,
-          ),
+          color: clrScheme.outline.withAlpha((kHintOpacity * 255).round()),
         ),
         hintText: hintText,
         contentPadding: const EdgeInsets.only(bottom: 12),
         focusedBorder: UnderlineInputBorder(
           borderSide: BorderSide(
-            color: clrScheme.primary.withOpacity(
-              kHintOpacity,
-            ),
+            color: clrScheme.primary.withAlpha((kHintOpacity * 255).round()),
           ),
         ),
         enabledBorder: UnderlineInputBorder(

--- a/lib/screens/common_widgets/envfield_url.dart
+++ b/lib/screens/common_widgets/envfield_url.dart
@@ -26,10 +26,8 @@ class EnvURLField extends StatelessWidget {
       decoration: InputDecoration(
         hintText: kHintTextUrlCard,
         hintStyle: kCodeStyle.copyWith(
-          color: Theme.of(context).colorScheme.outline.withOpacity(
-                kHintOpacity,
-              ),
-        ),
+            color: Theme.of(context).colorScheme.outline
+              ..withAlpha((kHintOpacity * 255).round())),
         border: InputBorder.none,
       ),
       onChanged: onChanged,

--- a/lib/screens/history/history_sidebar.dart
+++ b/lib/screens/history/history_sidebar.dart
@@ -109,18 +109,15 @@ class _HistoryExpansionTileState extends ConsumerState<HistoryExpansionTile>
         children: [
           RotationTransition(
               turns: animation,
-              child: Icon(
-                Icons.chevron_right_rounded,
-                size: 20,
-                color: colorScheme.onSurface.withOpacity(0.6),
-              )),
+              child: Icon(Icons.chevron_right_rounded,
+                  size: 20,
+                  color: colorScheme.onSurface.withAlpha((0.6 * 255).round()))),
           kHSpacer5,
           Text(
             humanizeDate(widget.date),
             style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                  fontWeight: FontWeight.bold,
-                  color: colorScheme.onSurface.withOpacity(0.6),
-                ),
+                fontWeight: FontWeight.bold,
+                color: colorScheme.onSurface.withAlpha((0.6 * 255).round())),
           ),
         ],
       ),

--- a/lib/utils/ui_utils.dart
+++ b/lib/utils/ui_utils.dart
@@ -44,7 +44,7 @@ Color getHTTPMethodColor(HTTPVerb method,
 
 Color getDarkModeColor(Color col) {
   return Color.alphaBlend(
-    col.withOpacity(kOpacityDarkModeBlend),
+    col.withAlpha((kOpacityDarkModeBlend * 255).round()),
     kColorWhite,
   );
 }

--- a/lib/widgets/card_history_request.dart
+++ b/lib/widgets/card_history_request.dart
@@ -21,8 +21,10 @@ class HistoryRequestCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final Color color = Theme.of(context).colorScheme.surface;
-    final Color colorVariant =
-        Theme.of(context).colorScheme.surfaceContainerHighest.withOpacity(0.5);
+    final Color colorVariant = Theme.of(context)
+        .colorScheme
+        .surfaceContainerHighest
+      ..withAlpha((0.5 * 255).round());
     final Color surfaceTint = Theme.of(context).colorScheme.primary;
     return Card(
       shape: const ContinuousRectangleBorder(borderRadius: kBorderRadius12),
@@ -38,7 +40,7 @@ class HistoryRequestCard extends StatelessWidget {
         onTap: onTap,
         borderRadius: kBorderRadius6,
         hoverColor: colorVariant,
-        focusColor: colorVariant.withOpacity(0.5),
+        focusColor: colorVariant.withAlpha((0.5 * 255).round()),
         child: Padding(
           padding: kPv6 + kPh8,
           child: SizedBox(

--- a/lib/widgets/card_sidebar_environment.dart
+++ b/lib/widgets/card_sidebar_environment.dart
@@ -43,8 +43,8 @@ class SidebarEnvironmentCard extends StatelessWidget {
     final colorScheme = Theme.of(context).colorScheme;
     final Color color =
         isGlobal ? colorScheme.secondaryContainer : colorScheme.surface;
-    final Color colorVariant =
-        colorScheme.surfaceContainerHighest.withOpacity(0.5);
+    final Color colorVariant = colorScheme.surfaceContainerHighest
+      ..withAlpha((0.5 * 255).round());
     final Color surfaceTint = colorScheme.primary;
     bool isSelected = selectedId == id;
     bool inEditMode = editRequestId == id;
@@ -68,7 +68,7 @@ class SidebarEnvironmentCard extends StatelessWidget {
         child: InkWell(
           borderRadius: kBorderRadius8,
           hoverColor: colorVariant,
-          focusColor: colorVariant.withOpacity(0.5),
+          focusColor: colorVariant..withAlpha((0.5 * 255).round()),
           onTap: inEditMode ? null : onTap,
           // onSecondaryTap: onSecondaryTap,
           onSecondaryTapUp: (isGlobal)

--- a/lib/widgets/card_sidebar_history.dart
+++ b/lib/widgets/card_sidebar_history.dart
@@ -28,8 +28,10 @@ class SidebarHistoryCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final Color color = Theme.of(context).colorScheme.surface;
-    final Color colorVariant =
-        Theme.of(context).colorScheme.surfaceContainerHighest.withOpacity(0.5);
+    final Color colorVariant = Theme.of(context)
+        .colorScheme
+        .surfaceContainerHighest
+      ..withAlpha((0.5 * 255).round());
     final model = models.first;
     final Color surfaceTint = Theme.of(context).colorScheme.primary;
     final String name = getHistoryRequestName(model);
@@ -53,7 +55,7 @@ class SidebarHistoryCard extends StatelessWidget {
           onTap: onTap,
           borderRadius: kBorderRadius8,
           hoverColor: colorVariant,
-          focusColor: colorVariant.withOpacity(0.5),
+          focusColor: colorVariant.withAlpha((0.5 * 255).round()),
           child: Padding(
             padding: const EdgeInsets.only(
               left: 6,

--- a/lib/widgets/card_sidebar_request.dart
+++ b/lib/widgets/card_sidebar_request.dart
@@ -45,8 +45,10 @@ class SidebarRequestCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final Color color = Theme.of(context).colorScheme.surface;
-    final Color colorVariant =
-        Theme.of(context).colorScheme.surfaceContainerHighest.withOpacity(0.5);
+    final Color colorVariant = Theme.of(context)
+        .colorScheme
+        .surfaceContainerHighest
+        .withAlpha((0.5 * 255).round());
     final Color surfaceTint = Theme.of(context).colorScheme.primary;
     bool isSelected = selectedId == id;
     bool inEditMode = editRequestId == id;
@@ -72,7 +74,7 @@ class SidebarRequestCard extends StatelessWidget {
         child: InkWell(
           borderRadius: kBorderRadius8,
           hoverColor: colorVariant,
-          focusColor: colorVariant.withOpacity(0.5),
+          focusColor: colorVariant.withAlpha((0.5 * 255).round()),
           onTap: inEditMode ? null : onTap,
           // onDoubleTap: inEditMode ? null : onDoubleTap,
           onSecondaryTapUp: (details) {

--- a/lib/widgets/codegen_previewer.dart
+++ b/lib/widgets/codegen_previewer.dart
@@ -122,7 +122,7 @@ class ViewCodePane extends StatelessWidget {
           (Theme.of(context).brightness == Brightness.dark
                   ? Theme.of(context).colorScheme.onPrimaryContainer
                   : Theme.of(context).colorScheme.primaryContainer)
-              .withOpacity(kForegroundOpacity),
+              .withAlpha((kForegroundOpacity * 255).round()),
           Theme.of(context).colorScheme.surface),
       border: Border.all(
           color: Theme.of(context).colorScheme.surfaceContainerHighest),

--- a/lib/widgets/dialog_history_retention.dart
+++ b/lib/widgets/dialog_history_retention.dart
@@ -29,11 +29,10 @@ showHistoryRetentionDialog(
                 child: Text(
                   "Select the duration for which you want to retain your request history",
                   style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: Theme.of(context)
-                            .colorScheme
-                            .onSurface
-                            .withOpacity(0.8),
-                      ),
+                      color: Theme.of(context)
+                          .colorScheme
+                          .onSurface
+                          .withAlpha((0.8 * 255).round())),
                 ),
               ),
               kVSpacer10,
@@ -52,7 +51,7 @@ showHistoryRetentionDialog(
                                 : Theme.of(context)
                                     .colorScheme
                                     .onSurface
-                                    .withOpacity(0.6)),
+                                    .withAlpha((0.6 * 255).round())),
                         value: e,
                         groupValue: selectedRetentionPeriod,
                         onChanged: (value) {

--- a/lib/widgets/editor.dart
+++ b/lib/widgets/editor.dart
@@ -86,16 +86,17 @@ class _TextFieldEditorState extends State<TextFieldEditor> {
         decoration: InputDecoration(
           hintText: widget.hintText ?? kHintContent,
           hintStyle: TextStyle(
-            color: Theme.of(context).colorScheme.outline.withOpacity(
-                  kHintOpacity,
+            color: Theme.of(context).colorScheme.outline.withAlpha(
+                  (kHintOpacity * 255).round(),
                 ),
           ),
           focusedBorder: OutlineInputBorder(
             borderRadius: kBorderRadius8,
             borderSide: BorderSide(
-              color: Theme.of(context).colorScheme.primary.withOpacity(
-                    kHintOpacity,
-                  ),
+              color: Theme.of(context)
+                  .colorScheme
+                  .primary
+                  .withAlpha((kHintOpacity * 255).round()),
             ),
           ),
           enabledBorder: OutlineInputBorder(
@@ -110,7 +111,7 @@ class _TextFieldEditorState extends State<TextFieldEditor> {
               (Theme.of(context).brightness == Brightness.dark
                       ? Theme.of(context).colorScheme.onPrimaryContainer
                       : Theme.of(context).colorScheme.primaryContainer)
-                  .withOpacity(kForegroundOpacity),
+                  .withAlpha((kForegroundOpacity * 255).round()),
               Theme.of(context).colorScheme.surface),
         ),
       ),

--- a/lib/widgets/editor_json.dart
+++ b/lib/widgets/editor_json.dart
@@ -74,9 +74,10 @@ class _JsonTextFieldEditorState extends State<JsonTextFieldEditor> {
           fontWeight: FontWeight.bold,
         ),
         errorContainerDecoration: BoxDecoration(
-          color: Theme.of(context).colorScheme.error.withOpacity(
-                kForegroundOpacity,
-              ),
+          color: Theme.of(context)
+              .colorScheme
+              .error
+              .withAlpha((kForegroundOpacity * 255).round()),
           borderRadius: kBorderRadius8,
         ),
         showErrorMessage: true,
@@ -96,16 +97,18 @@ class _JsonTextFieldEditorState extends State<JsonTextFieldEditor> {
         decoration: InputDecoration(
           hintText: kHintJson,
           hintStyle: TextStyle(
-            color: Theme.of(context).colorScheme.outline.withOpacity(
-                  kHintOpacity,
-                ),
+            color: Theme.of(context)
+                .colorScheme
+                .outline
+                .withAlpha((kHintOpacity * 255).round()),
           ),
           focusedBorder: OutlineInputBorder(
             borderRadius: kBorderRadius8,
             borderSide: BorderSide(
-              color: Theme.of(context).colorScheme.primary.withOpacity(
-                    kHintOpacity,
-                  ),
+              color: Theme.of(context)
+                  .colorScheme
+                  .primary
+                  .withAlpha((kHintOpacity * 255).round()),
             ),
           ),
           enabledBorder: OutlineInputBorder(
@@ -120,7 +123,7 @@ class _JsonTextFieldEditorState extends State<JsonTextFieldEditor> {
               (Theme.of(context).brightness == Brightness.dark
                       ? Theme.of(context).colorScheme.onPrimaryContainer
                       : Theme.of(context).colorScheme.primaryContainer)
-                  .withOpacity(kForegroundOpacity),
+                  .withAlpha((kForegroundOpacity * 255).round()),
               Theme.of(context).colorScheme.surface),
         ),
       ),

--- a/lib/widgets/field_cell_obscurable.dart
+++ b/lib/widgets/field_cell_obscurable.dart
@@ -31,9 +31,7 @@ class ObscurableCellField extends HookWidget {
       obscureText: obscureText.value,
       decoration: InputDecoration(
         hintStyle: kCodeStyle.copyWith(
-          color: clrScheme.outline.withOpacity(
-            kHintOpacity,
-          ),
+          color: clrScheme.outline.withAlpha((kHintOpacity * 255).round()),
         ),
         hintText: hintText,
         suffixIcon: IconButton(
@@ -50,9 +48,7 @@ class ObscurableCellField extends HookWidget {
         contentPadding: const EdgeInsets.only(bottom: 12),
         focusedBorder: UnderlineInputBorder(
           borderSide: BorderSide(
-            color: clrScheme.primary.withOpacity(
-              kHintOpacity,
-            ),
+            color: clrScheme.primary.withAlpha((kHintOpacity * 255).round()),
           ),
         ),
         enabledBorder: UnderlineInputBorder(

--- a/lib/widgets/field_header.dart
+++ b/lib/widgets/field_header.dart
@@ -81,15 +81,14 @@ class _HeaderFieldState extends State<HeaderField> {
         ),
         decoration: InputDecoration(
           hintStyle: kCodeStyle.copyWith(
-              color: colorScheme.outline.withOpacity(kHintOpacity)),
+              color:
+                  colorScheme.outline.withAlpha((kHintOpacity * 255).round())),
           hintText: widget.hintText,
           contentPadding: const EdgeInsets.only(bottom: 12),
           focusedBorder: UnderlineInputBorder(
             borderSide: BorderSide(
-              color: colorScheme.primary.withOpacity(
-                kHintOpacity,
-              ),
-            ),
+                color: colorScheme.primary
+                    .withAlpha((kHintOpacity * 255).round())),
           ),
           enabledBorder: UnderlineInputBorder(
             borderSide: BorderSide(

--- a/lib/widgets/field_url.dart
+++ b/lib/widgets/field_url.dart
@@ -25,10 +25,10 @@ class URLField extends StatelessWidget {
       decoration: InputDecoration(
         hintText: kHintTextUrlCard,
         hintStyle: kCodeStyle.copyWith(
-          color: Theme.of(context).colorScheme.outline.withOpacity(
-                kHintOpacity,
-              ),
-        ),
+            color: Theme.of(context)
+                .colorScheme
+                .outline
+                .withAlpha((kHintOpacity * 255).round())),
         border: InputBorder.none,
       ),
       onChanged: onChanged,

--- a/lib/widgets/overlay_widget.dart
+++ b/lib/widgets/overlay_widget.dart
@@ -16,7 +16,8 @@ class OverlayWidgetTemplate {
       _overlay = OverlayEntry(
         // replace with your own layout
         builder: (context) => ColoredBox(
-            color: kColorBlack.withOpacity(kOverlayBackgroundOpacity),
+            color: kColorBlack
+                .withAlpha((kOverlayBackgroundOpacity * 255).round()),
             child: widget),
       );
       _overlayState!.insert(_overlay!);

--- a/lib/widgets/response_widgets.dart
+++ b/lib/widgets/response_widgets.dart
@@ -409,7 +409,7 @@ class _BodySuccessState extends State<BodySuccess> {
           (Theme.of(context).brightness == Brightness.dark
                   ? Theme.of(context).colorScheme.onPrimaryContainer
                   : Theme.of(context).colorScheme.primaryContainer)
-              .withOpacity(kForegroundOpacity),
+              .withAlpha((kForegroundOpacity * 255).round()),
           Theme.of(context).colorScheme.surface),
       border: Border.all(
           color: Theme.of(context).colorScheme.surfaceContainerHighest),

--- a/lib/widgets/splitview_dashboard.dart
+++ b/lib/widgets/splitview_dashboard.dart
@@ -36,9 +36,10 @@ class DashboardSplitViewState extends State<DashboardSplitView> {
         dividerThickness: 3,
         dividerPainter: DividerPainters.background(
           color: Theme.of(context).colorScheme.surfaceContainerHighest,
-          highlightedColor: Theme.of(context).colorScheme.outline.withOpacity(
-                kHintOpacity,
-              ),
+          highlightedColor: Theme.of(context)
+              .colorScheme
+              .outline
+              .withAlpha((kHintOpacity * 255).round()),
           animationEnabled: false,
         ),
       ),

--- a/lib/widgets/splitview_equal.dart
+++ b/lib/widgets/splitview_equal.dart
@@ -31,9 +31,10 @@ class EqualSplitView extends StatelessWidget {
         dividerThickness: 3,
         dividerPainter: DividerPainters.background(
           color: Theme.of(context).colorScheme.surfaceContainerHighest,
-          highlightedColor: Theme.of(context).colorScheme.outline.withOpacity(
-                kHintOpacity,
-              ),
+          highlightedColor: Theme.of(context)
+              .colorScheme
+              .outline
+              .withAlpha((kHintOpacity * 255).round()),
           animationEnabled: false,
         ),
       ),

--- a/lib/widgets/splitview_history.dart
+++ b/lib/widgets/splitview_history.dart
@@ -36,9 +36,10 @@ class HistorySplitViewState extends State<HistorySplitView> {
         dividerThickness: 3,
         dividerPainter: DividerPainters.background(
           color: Theme.of(context).colorScheme.surfaceContainerHighest,
-          highlightedColor: Theme.of(context).colorScheme.outline.withOpacity(
-                kHintOpacity,
-              ),
+          highlightedColor: Theme.of(context)
+              .colorScheme
+              .outline
+              .withAlpha((kHintOpacity * 255).round()),
           animationEnabled: false,
         ),
       ),

--- a/lib/widgets/tabbar_segmented.dart
+++ b/lib/widgets/tabbar_segmented.dart
@@ -35,8 +35,10 @@ class SegmentedTabbar extends StatelessWidget {
             dividerColor: Colors.transparent,
             indicatorWeight: 0.0,
             indicatorSize: TabBarIndicatorSize.tab,
-            unselectedLabelColor:
-                Theme.of(context).colorScheme.onSurface.withOpacity(0.4),
+            unselectedLabelColor: Theme.of(context)
+                .colorScheme
+                .onSurface
+                .withAlpha((0.4 * 255).round()),
             labelStyle: kTextStyleTab.copyWith(
               fontWeight: FontWeight.bold,
               color: Theme.of(context).colorScheme.onPrimary,

--- a/lib/widgets/table_request.dart
+++ b/lib/widgets/table_request.dart
@@ -45,9 +45,7 @@ class RequestDataTable extends StatelessWidget {
       contentPadding: const EdgeInsets.only(bottom: 12),
       focusedBorder: UnderlineInputBorder(
         borderSide: BorderSide(
-          color: clrScheme.primary.withOpacity(
-            kHintOpacity,
-          ),
+          color: clrScheme.primary.withAlpha((kHintOpacity * 255).round()),
         ),
       ),
       enabledBorder: UnderlineInputBorder(

--- a/lib/widgets/table_request_form.dart
+++ b/lib/widgets/table_request_form.dart
@@ -47,10 +47,7 @@ class RequestFormDataTable extends StatelessWidget {
       contentPadding: const EdgeInsets.only(bottom: 12),
       focusedBorder: UnderlineInputBorder(
         borderSide: BorderSide(
-          color: clrScheme.primary.withOpacity(
-            kHintOpacity,
-          ),
-        ),
+            color: clrScheme.primary.withAlpha((kHintOpacity * 255).round())),
       ),
       enabledBorder: UnderlineInputBorder(
         borderSide: BorderSide(

--- a/lib/widgets/video_previewer.dart
+++ b/lib/widgets/video_previewer.dart
@@ -65,8 +65,8 @@ class _VideoPreviewerState extends State<VideoPreviewer> {
     final iconColor = Theme.of(context).iconTheme.color;
     final progressBarColors = VideoProgressColors(
       playedColor: iconColor!,
-      bufferedColor: iconColor.withOpacity(0.5),
-      backgroundColor: iconColor.withOpacity(0.3),
+      bufferedColor: iconColor.withAlpha((0.5 * 255).round()),
+      backgroundColor: iconColor.withAlpha((0.3 * 255).round()),
     );
     return Scaffold(
       body: MouseRegion(

--- a/packages/apidash_design_system/lib/tokens/colors.dart
+++ b/packages/apidash_design_system/lib/tokens/colors.dart
@@ -6,7 +6,7 @@ const kColorTransparent = Colors.transparent;
 const kColorWhite = Colors.white;
 const kColorBlack = Colors.black;
 const kColorRed = Colors.red;
-final kColorLightDanger = Colors.red.withOpacity(0.9);
+final kColorLightDanger = Colors.red.withAlpha((0.9 * 255).round());
 const kColorDarkDanger = Color(0xffcf6679);
 
 const kColorSchemeSeed = Colors.blue;

--- a/packages/apidash_design_system/lib/widgets/textfield_outlined.dart
+++ b/packages/apidash_design_system/lib/widgets/textfield_outlined.dart
@@ -72,18 +72,14 @@ class ADOutlinedTextField extends StatelessWidget {
             kCodeStyle.copyWith(
               fontSize: hintTextFontSize,
               color: hintTextColor ??
-                  clrScheme.outline.withOpacity(
-                    kHintOpacity,
-                  ),
+                  clrScheme.outline.withAlpha((kHintOpacity * 255).round()),
             ),
         hintText: hintText,
         contentPadding: contentPadding ?? kP10,
         focusedBorder: OutlineInputBorder(
           borderSide: BorderSide(
             color: focussedBorderColor ??
-                clrScheme.primary.withOpacity(
-                  kHintOpacity,
-                ),
+                clrScheme.primary.withAlpha((kHintOpacity * 255).round()),
           ),
         ),
         enabledBorder: OutlineInputBorder(

--- a/packages/json_explorer/README.md
+++ b/packages/json_explorer/README.md
@@ -88,7 +88,7 @@ JsonExplorer(
       fontSize: 16,
     ),
     propertyKeyTextStyle: GoogleFonts.inconsolata(
-      color: Colors.black.withOpacity(0.7),
+      color: Colors.black.withAlpha((0.7 * 255).round()),
       fontWeight: FontWeight.bold,
       fontSize: 16,
     ),

--- a/packages/json_explorer/example/lib/main.dart
+++ b/packages/json_explorer/example/lib/main.dart
@@ -284,7 +284,7 @@ class _JsonExplorerPageState extends State<JsonExplorerPage> {
                         fontSize: 16,
                       ),
                       propertyKeyTextStyle: GoogleFonts.inconsolata(
-                        color: Colors.black.withOpacity(0.7),
+                        color: Colors.black.withAlpha((0.7 * 255).round()),
                         fontWeight: FontWeight.bold,
                         fontSize: 16,
                       ),

--- a/packages/json_explorer/test/golden/multi_size_test.dart
+++ b/packages/json_explorer/test/golden/multi_size_test.dart
@@ -47,7 +47,7 @@ void main() {
                     fontSize: 18,
                   ),
                   propertyKeyTextStyle: TextStyle(
-                    color: Colors.black.withOpacity(0.7),
+                    color: Colors.black.withAlpha((0.7 * 255).round()),
                     fontWeight: FontWeight.bold,
                     fontSize: 18,
                   ),

--- a/packages/multi_trigger_autocomplete_plus/example/pubspec.lock
+++ b/packages/multi_trigger_autocomplete_plus/example/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   crypto:
     dependency: transitive
     description:
@@ -135,18 +135,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -270,7 +270,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -283,10 +283,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
@@ -299,10 +299,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
@@ -315,10 +315,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   typed_data:
     dependency: transitive
     description:
@@ -339,10 +339,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.0"
   web:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,23 +5,23 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: f256b0c0ba6c7577c15e2e4e114755640a875e885099367bf6e012b19314c834
+      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
       url: "https://pub.dev"
     source: hosted
-    version: "72.0.0"
+    version: "76.0.0"
   _macros:
     dependency: transitive
     description: dart
     source: sdk
-    version: "0.3.2"
+    version: "0.3.3"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: b652861553cd3990d8ed361f7979dc6d7053a9ac8843fa73820ab68ce5410139
+      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.7.0"
+    version: "6.11.0"
   ansi_styles:
     dependency: transitive
     description:
@@ -240,10 +240,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   conventional_commit:
     dependency: transitive
     description:
@@ -876,18 +876,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -924,10 +924,10 @@ packages:
     dependency: transitive
     description:
       name: macros
-      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
+      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.2-main.4"
+    version: "0.1.3-main.0"
   markdown:
     dependency: "direct main"
     description:
@@ -1482,7 +1482,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_gen:
     dependency: transitive
     description:
@@ -1543,10 +1543,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   state_notifier:
     dependency: transitive
     description:
@@ -1575,10 +1575,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   sync_http:
     dependency: transitive
     description:
@@ -1599,26 +1599,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "7ee44229615f8f642b68120165ae4c2a75fe77ae2065b1e55ae4711f6cf0899e"
+      sha256: "713a8789d62f3233c46b4a90b174737b2c04cb6ae4500f2aa8b1be8f03f5e67f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.7"
+    version: "1.25.8"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "55ea5a652e38a1dfb32943a7973f3681a60f872f8c3a05a14664ad54ef9c6696"
+      sha256: "12391302411737c176b0b5d6491f466b0dd56d4763e347b6714efbaa74d7953d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   textwrap:
     dependency: transitive
     description:
@@ -1815,10 +1815,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "14.3.0"
   watcher:
     dependency: transitive
     description:
@@ -1855,10 +1855,10 @@ packages:
     dependency: transitive
     description:
       name: webdriver
-      sha256: "003d7da9519e1e5f329422b36c4dcdf18d7d2978d1ba099ea4e45ba490ed845e"
+      sha256: "3d773670966f02a646319410766d3b5e1037efb7f07cc68f844d5e06cd4d61c8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.4"
   webkit_inspection_protocol:
     dependency: transitive
     description:

--- a/test/screens/common_widgets/button_navbar_test.dart
+++ b/test/screens/common_widgets/button_navbar_test.dart
@@ -116,6 +116,6 @@ void main() {
         equals(Theme.of(tester.element(find.byKey(testKey)))
             .colorScheme
             .onSurface
-            .withOpacity(0.65)));
+            .withAlpha((0.65 * 255).round())));
   });
 }


### PR DESCRIPTION
**Fix: Replaced deprecated `withOpacity()` with `withAlpha()`**  

## PR Description

This PR updates all instances of `.withOpacity()` (48 occurrences across 32 pages) to `.withAlpha((opacity * 255).toInt())` to resolve deprecation warnings in Flutter 3.27.2+. This ensures proper alpha handling and aligns with the latest API changes.  


## Related Issues

- Closes # https://github.com/foss42/apidash/issues/585#issue-2865940105

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [X] No, and this is why: _please replace this line with details on why tests have not been included_

## OS on which you have developed and tested the feature?

- [ ] Windows
- [x] macOS
- [ ] Linux
