### PR TITLE
Feat/env var text body

### DIFF
--- a/lib/utils/envvar_utils.dart
+++ b/lib/utils/envvar_utils.dart
@@ -86,7 +86,11 @@ HttpRequestModel substituteHttpRequestModel(
         value: substituteVariables(param.value, envMap, activeEnvironmentId),
       );
     }).toList(),
-    body: substituteVariables(httpRequestModel.body, envMap, activeEnvironmentId),
+    body: substituteVariables(
+      httpRequestModel.body,
+      envMap,
+      activeEnvironmentId,
+    ),
   );
   return newRequestModel;
 }

--- a/lib/utils/envvar_utils.dart
+++ b/lib/utils/envvar_utils.dart
@@ -86,6 +86,7 @@ HttpRequestModel substituteHttpRequestModel(
         value: substituteVariables(param.value, envMap, activeEnvironmentId),
       );
     }).toList(),
+    body: substituteVariables(httpRequestModel.body, envMap, activeEnvironmentId),
   );
   return newRequestModel;
 }

--- a/test/utils/envvar_utils_test.dart
+++ b/test/utils/envvar_utils_test.dart
@@ -211,10 +211,12 @@ void main() {
           NameValueModel(name: "num", value: "{{num}}"),
         ],
       );
+
       Map<String?, List<EnvironmentVariableModel>> envMap = {
         kGlobalEnvironmentId: globalVars,
         "activeEnvId": activeEnvVars,
       };
+
       String? activeEnvironmentId = "activeEnvId";
       const expected = HttpRequestModel(
         url: "api.apidash.dev/humanize/social",
@@ -227,7 +229,10 @@ void main() {
       );
       expect(
           substituteHttpRequestModel(
-              httpRequestModel, envMap, activeEnvironmentId),
+            httpRequestModel,
+            envMap,
+            activeEnvironmentId,
+          ),
           expected);
     });
 
@@ -260,7 +265,10 @@ void main() {
               httpRequestModel, envMap, activeEnvironmentId),
           expected);
     });
-    test("Testing substituteHttpRequestModel with environment variables in body", () {
+
+    test(
+        "Testing substituteHttpRequestModel with environment variables in body",
+        () {
       const httpRequestModel = HttpRequestModel(
         url: "{{url}}/humanize/social",
         headers: [
@@ -287,7 +295,8 @@ void main() {
         body: "The API key is token and the number is 8940000",
       );
       expect(
-          substituteHttpRequestModel(httpRequestModel, envMap, activeEnvironmentId),
+          substituteHttpRequestModel(
+              httpRequestModel, envMap, activeEnvironmentId),
           expected);
     });
   });

--- a/test/utils/envvar_utils_test.dart
+++ b/test/utils/envvar_utils_test.dart
@@ -260,6 +260,36 @@ void main() {
               httpRequestModel, envMap, activeEnvironmentId),
           expected);
     });
+    test("Testing substituteHttpRequestModel with environment variables in body", () {
+      const httpRequestModel = HttpRequestModel(
+        url: "{{url}}/humanize/social",
+        headers: [
+          NameValueModel(name: "Authorization", value: "Bearer {{token}}"),
+        ],
+        params: [
+          NameValueModel(name: "num", value: "{{num}}"),
+        ],
+        body: "The API key is {{token}} and the number is {{num}}",
+      );
+      Map<String?, List<EnvironmentVariableModel>> envMap = {
+        kGlobalEnvironmentId: globalVars,
+        "activeEnvId": activeEnvVars,
+      };
+      String? activeEnvironmentId = "activeEnvId";
+      const expected = HttpRequestModel(
+        url: "api.apidash.dev/humanize/social",
+        headers: [
+          NameValueModel(name: "Authorization", value: "Bearer token"),
+        ],
+        params: [
+          NameValueModel(name: "num", value: "8940000"),
+        ],
+        body: "The API key is token and the number is 8940000",
+      );
+      expect(
+          substituteHttpRequestModel(httpRequestModel, envMap, activeEnvironmentId),
+          expected);
+    });
   });
 
   group("Testing getEnvironmentTriggerSuggestions function", () {


### PR DESCRIPTION
## PR Description

This PR adds support for environment variable substitution in text request bodies. Previously, environment variables were supported only for URLs, URL params, and headers. With this update, users can now use environment variables in plain text request bodies
## Related Issues

- Closes #
#591 

### Checklist
- [ ] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_

## OS on which you have developed and tested the feature?

- [ ] Windows
- [x] macOS
- [ ] Linux
