### PR TITLE
feat: Add API Key Authentication support

### DIFF
--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -440,6 +440,7 @@ const kLabelViewCode = "View Code";
 const kLabelURLParams = "URL Params";
 const kLabelHeaders = "Headers";
 const kLabelBody = "Body";
+const kLabelAuthentication = "Authentication";
 const kLabelQuery = "Query";
 const kNameCheckbox = "Checkbox";
 const kNameURLParam = "URL Parameter";

--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -223,6 +223,8 @@ class CollectionStateNotifier
     int? responseStatus,
     String? message,
     HttpResponseModel? httpResponseModel,
+    AuthType? authType,
+    Map<String, dynamic>? authParams,
   }) {
     final rId = id ?? ref.read(selectedIdStateProvider);
     if (rId == null) {
@@ -250,6 +252,8 @@ class CollectionStateNotifier
         body: body ?? currentHttpRequestModel.body,
         query: query ?? currentHttpRequestModel.query,
         formData: formData ?? currentHttpRequestModel.formData,
+        authType: authType ?? currentHttpRequestModel.authType,
+        authParams: authParams ?? currentHttpRequestModel.authParams,
       ),
       responseStatus: responseStatus ?? currentModel.responseStatus,
       message: message ?? currentModel.message,

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_authorization.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_authorization.dart
@@ -1,0 +1,336 @@
+import 'package:apidash_core/apidash_core.dart';
+import 'package:apidash_design_system/apidash_design_system.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:apidash/providers/providers.dart';
+import 'package:apidash/consts.dart';
+
+class EditRequestAuthentication extends ConsumerWidget {
+  const EditRequestAuthentication({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selectedId = ref.watch(selectedIdStateProvider);
+    if (selectedId == null) {
+      return const Center(
+        child: Text("No request selected"),
+      );
+    }
+
+    final authType = ref.watch(selectedRequestModelProvider
+        .select((value) => value?.httpRequestModel?.authType ?? AuthType.none));
+
+    return Column(
+      children: [
+        const SizedBox(
+          height: kHeaderHeight,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                "Select Authentication Type:",
+              ),
+              SizedBox(width: 8),
+              DropdownButtonAuthType(),
+            ],
+          ),
+        ),
+        Expanded(
+          child: authType == AuthType.apiKey 
+              ? const ApiKeyAuthForm()
+              : const Center(
+                  child: Text(
+                    "No authentication selected",
+                    style: TextStyle(fontStyle: FontStyle.italic),
+                  ),
+                ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Dropdown widget for selecting the authentication type
+class DropdownButtonAuthType extends ConsumerWidget {
+  const DropdownButtonAuthType({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selectedId = ref.watch(selectedIdStateProvider);
+    if (selectedId == null) return const SizedBox.shrink();
+
+    final authType = ref.watch(selectedRequestModelProvider
+        .select((value) => value?.httpRequestModel?.authType ?? AuthType.none));
+
+    return ADDropdownButton<AuthType>(
+      value: authType,
+      values: [AuthType.none, AuthType.apiKey].map((e) => (e, e.name)),
+      onChanged: (AuthType? value) {
+        if (value != null) {
+          Map<String, dynamic> initialParams = {};
+          if (value == AuthType.apiKey) {
+            initialParams = {
+              'key': '',
+              'name': '',
+              'addTo': 'header',
+            };
+          }
+          ref.read(collectionStateNotifierProvider.notifier).update(
+                id: selectedId,
+                authType: value,
+                authParams: initialParams,
+              );
+        }
+      },
+      iconSize: 16,
+    );
+  }
+}
+
+/// Custom TextField widget to manage TextEditingController lifecycle
+class AuthTextField extends StatefulWidget {
+  final String initialValue;
+  final ValueChanged<String> onChanged;
+  final String labelText;
+  final String hintText;
+  final bool obscureText;
+  final int? minLines;
+  final int? maxLines;
+
+  const AuthTextField({
+    required this.initialValue,
+    required this.onChanged,
+    required this.labelText,
+    required this.hintText,
+    this.obscureText = false,
+    this.minLines,
+    this.maxLines,
+    super.key,
+  });
+
+  @override
+  State<AuthTextField> createState() => _AuthTextFieldState();
+}
+
+class _AuthTextFieldState extends State<AuthTextField> {
+  late TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialValue);
+  }
+
+  @override
+  void didUpdateWidget(covariant AuthTextField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.initialValue != oldWidget.initialValue &&
+        widget.initialValue != _controller.text) {
+      _controller.text = widget.initialValue;
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: _controller,
+      onChanged: widget.onChanged,
+      decoration: InputDecoration(
+        labelText: widget.labelText,
+        hintText: widget.hintText,
+        border: const OutlineInputBorder(),
+        contentPadding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+      ),
+      obscureText: widget.obscureText,
+      minLines: widget.minLines,
+      maxLines: widget.maxLines ?? 1,
+    );
+  }
+}
+
+/// Form for API Key Authentication
+class ApiKeyAuthForm extends ConsumerWidget {
+  const ApiKeyAuthForm({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selectedId = ref.watch(selectedIdStateProvider);
+    final authParams = ref.watch(selectedRequestModelProvider
+            .select((value) => value?.httpRequestModel?.authParams)) ?? {};
+    final keyValue = authParams['key'] as String? ?? '';
+    final keyName = authParams['name'] as String? ?? '';
+    final addTo = authParams['addTo'] as String? ?? 'header';
+
+    return SingleChildScrollView(
+      child: Padding(
+        padding: kPh4,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const SizedBox(height: 16),
+            const Text(
+              'API Key Authentication',
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
+            ),
+            const SizedBox(height: 16),
+            AuthTextField(
+              key: Key('$selectedId-apikey-key'),
+              initialValue: keyValue,
+              onChanged: (value) {
+                final newParams = Map<String, dynamic>.from(authParams);
+                newParams['key'] = value;
+                if (addTo == 'header') {
+                  final List<NameValueModel> headerRows = [
+                    NameValueModel(name: keyName, value: value)
+                  ];
+                  final List<bool> isHeaderEnabledList = [true];
+                  ref.read(collectionStateNotifierProvider.notifier).update(
+                    headers: headerRows,
+                    isHeaderEnabledList: isHeaderEnabledList,
+                  );
+                } else if (addTo == 'query') {
+                  final List<NameValueModel> paramRows = [
+                    NameValueModel(name: keyName, value: value)
+                  ];
+                  final List<bool> isParamEnabledList = [true];
+                  ref.read(collectionStateNotifierProvider.notifier).update(
+                    params: paramRows,
+                    isParamEnabledList: isParamEnabledList,
+                  );
+                }
+                ref.read(collectionStateNotifierProvider.notifier).update(
+                  id: selectedId,
+                  authParams: newParams,
+                );
+              },
+              labelText: 'Key',
+              hintText: 'Enter your API key',
+            ),
+            const SizedBox(height: 16),
+            AuthTextField(
+              key: Key('$selectedId-apikey-name'),
+              initialValue: keyName,
+              onChanged: (value) {
+                final newParams = Map<String, dynamic>.from(authParams);
+                newParams['name'] = value;
+                if (addTo == 'header') {
+                  final List<NameValueModel> headerRows = [
+                    NameValueModel(name: value, value: keyValue)
+                  ];
+                  final List<bool> isHeaderEnabledList = [true];
+                  ref.read(collectionStateNotifierProvider.notifier).update(
+                    headers: headerRows,
+                    isHeaderEnabledList: isHeaderEnabledList,
+                  );
+                } else if (addTo == 'query') {
+                  final List<NameValueModel> paramRows = [
+                    NameValueModel(name: value, value: keyValue)
+                  ];
+                  final List<bool> isParamEnabledList = [true];
+                  ref.read(collectionStateNotifierProvider.notifier).update(
+                    params: paramRows,
+                    isParamEnabledList: isParamEnabledList,
+                  );
+                }
+                ref.read(collectionStateNotifierProvider.notifier).update(
+                  id: selectedId,
+                  authParams: newParams,
+                );
+              },
+              labelText: 'Key Name',
+              hintText: 'e.g. X-API-Key, api_key',
+            ),
+            const SizedBox(height: 16),
+            DropdownButtonFormField<String>(
+              key: Key('$selectedId-apikey-addto'),
+              decoration: const InputDecoration(
+                labelText: 'Add to',
+                border: OutlineInputBorder(),
+              ),
+              value: addTo,
+              items: const [
+                DropdownMenuItem(value: 'header', child: Text('Header')),
+                DropdownMenuItem(value: 'query', child: Text('Query Parameter')),
+              ],
+              onChanged: (value) {
+                if (value != null) {
+                  final newParams = Map<String, dynamic>.from(authParams);
+                  newParams['addTo'] = value;
+                  if (value == 'header') {
+                    final List<NameValueModel> headerRows = [
+                      NameValueModel(name: keyName, value: keyValue)
+                    ];
+                    final List<bool> isHeaderEnabledList = [true];
+                    ref.read(collectionStateNotifierProvider.notifier).update(
+                      headers: headerRows,
+                      isHeaderEnabledList: isHeaderEnabledList,
+                      params: [],
+                      isParamEnabledList: [],
+                    );
+                  } else if (value == 'query') {
+                    final List<NameValueModel> paramRows = [
+                      NameValueModel(name: keyName, value: keyValue)
+                    ];
+                    final List<bool> isParamEnabledList = [true];
+                    ref.read(collectionStateNotifierProvider.notifier).update(
+                      params: paramRows,
+                      isParamEnabledList: isParamEnabledList,
+                      headers: [],
+                      isHeaderEnabledList: [],
+                    );
+                  }
+                  ref.read(collectionStateNotifierProvider.notifier).update(
+                    id: selectedId,
+                    authParams: newParams,
+                  );
+                }
+              },
+            ),
+            const SizedBox(height: 24),
+            const Divider(),
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: Theme.of(context).brightness == Brightness.dark
+                    ? Colors.grey[800]
+                    : Colors.grey[200],
+                borderRadius: BorderRadius.circular(4),
+                border: Border.all(
+                  color: Theme.of(context).brightness == Brightness.dark
+                      ? Colors.grey[700]!
+                      : Colors.grey[300]!,
+                ),
+              ),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.info_outline,
+                    size: 16,
+                    color: Theme.of(context).brightness == Brightness.dark
+                        ? Colors.grey[400]
+                        : Colors.grey[700],
+                  ),
+                  const SizedBox(width: 8),
+                  const Expanded(
+                    child: Text(
+                      'The API key will be automatically added to your request.',
+                      style: TextStyle(
+                        fontSize: 13,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_body.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_body.dart
@@ -21,21 +21,6 @@ class EditRequestBody extends ConsumerWidget {
     final apiType = ref
         .watch(selectedRequestModelProvider.select((value) => value?.apiType));
 
-    // TODO: #178 GET->POST Currently switches to POST everytime user edits body even if the user intentionally chooses GET
-    // final sm = ScaffoldMessenger.of(context);
-    // void changeToPostMethod() {
-    //   if (requestModel?.httpRequestModel!.method == HTTPVerb.get) {
-    //     ref
-    //         .read(collectionStateNotifierProvider.notifier)
-    //         .update(selectedId, method: HTTPVerb.post);
-    //     sm.hideCurrentSnackBar();
-    //     sm.showSnackBar(getSnackBar(
-    //       "Switched to POST method",
-    //       small: false,
-    //     ));
-    //   }
-    // }
-
     return Column(
       children: [
         (apiType == APIType.rest)
@@ -55,12 +40,8 @@ class EditRequestBody extends ConsumerWidget {
         switch (apiType) {
           APIType.rest => Expanded(
               child: switch (contentType) {
-                ContentType.formdata => const Padding(
-                    padding: kPh4,
-                    child: FormDataWidget(
-                        // TODO: See changeToPostMethod above
-                        // changeMethodToPost: changeToPostMethod,
-                        )),
+                ContentType.formdata =>
+                  const Padding(padding: kPh4, child: FormDataWidget()),
                 // TODO: Fix JsonTextFieldEditor & plug it here
                 ContentType.json => Padding(
                     padding: kPt5o10,
@@ -69,7 +50,6 @@ class EditRequestBody extends ConsumerWidget {
                       fieldKey: "$selectedId-json-body-editor",
                       initialValue: requestModel?.httpRequestModel?.body,
                       onChanged: (String value) {
-                        // changeToPostMethod();
                         ref
                             .read(collectionStateNotifierProvider.notifier)
                             .update(body: value);
@@ -84,7 +64,6 @@ class EditRequestBody extends ConsumerWidget {
                       fieldKey: "$selectedId-body-editor",
                       initialValue: requestModel?.httpRequestModel?.body,
                       onChanged: (String value) {
-                        // changeToPostMethod();
                         ref
                             .read(collectionStateNotifierProvider.notifier)
                             .update(body: value);

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_pane_rest.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_pane_rest.dart
@@ -1,4 +1,5 @@
 import 'package:apidash/consts.dart';
+import 'request_authorization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:apidash/providers/providers.dart';
@@ -26,6 +27,10 @@ class EditRestRequestPane extends ConsumerWidget {
     final hasBody = ref.watch(selectedRequestModelProvider
             .select((value) => value?.httpRequestModel?.hasBody)) ??
         false;
+    final hasAuth  = ref.watch(selectedRequestModelProvider
+            .select((value) => value?.httpRequestModel?.hasAuthorization)) ??
+        false;
+    ;
 
     return RequestPane(
       selectedId: selectedId,
@@ -44,16 +49,19 @@ class EditRestRequestPane extends ConsumerWidget {
         paramLength > 0,
         headerLength > 0,
         hasBody,
+        hasAuth,
       ],
       tabLabels: const [
         kLabelURLParams,
         kLabelHeaders,
         kLabelBody,
+        kLabelAuthentication,
       ],
       children: const [
         EditRequestURLParams(),
         EditRequestHeaders(),
         EditRequestBody(),
+        EditRequestAuthentication(),
       ],
     );
   }

--- a/lib/widgets/request_pane.dart
+++ b/lib/widgets/request_pane.dart
@@ -14,7 +14,7 @@ class RequestPane extends StatefulHookWidget {
     this.onTapTabBar,
     required this.tabLabels,
     required this.children,
-    this.showIndicators = const [false, false, false],
+    this.showIndicators = const [false, false, false , false],
     this.showViewCodeButton,
   });
 

--- a/packages/apidash_core/lib/consts.dart
+++ b/packages/apidash_core/lib/consts.dart
@@ -85,6 +85,17 @@ enum ContentType {
   final String header;
 }
 
+enum AuthType{
+  none,
+  basic,
+  bearer,
+  jwtBearer,
+  apiKey,
+  digest,
+  oauth1,
+  oauth2,
+}
+
 const JsonEncoder kJsonEncoder = JsonEncoder.withIndent('  ');
 const JsonDecoder kJsonDecoder = JsonDecoder();
 const LineSplitter kSplitter = LineSplitter();

--- a/packages/apidash_core/lib/models/http_request_model.dart
+++ b/packages/apidash_core/lib/models/http_request_model.dart
@@ -28,6 +28,8 @@ class HttpRequestModel with _$HttpRequestModel {
     String? body,
     String? query,
     List<FormDataModel>? formData,
+    @Default(AuthType.none) AuthType authType,
+    Map<String, dynamic>? authParams,
   }) = _HttpRequestModel;
 
   factory HttpRequestModel.fromJson(Map<String, Object?> json) =>
@@ -68,4 +70,5 @@ class HttpRequestModel with _$HttpRequestModel {
   bool get hasFileInFormData => formDataList
       .map((e) => e.type == FormDataType.file)
       .any((element) => element);
+  bool get hasAuthorization => authType != AuthType.none && (authParams?.isNotEmpty ?? false);
 }

--- a/packages/apidash_core/lib/models/http_request_model.freezed.dart
+++ b/packages/apidash_core/lib/models/http_request_model.freezed.dart
@@ -30,6 +30,8 @@ mixin _$HttpRequestModel {
   String? get body => throw _privateConstructorUsedError;
   String? get query => throw _privateConstructorUsedError;
   List<FormDataModel>? get formData => throw _privateConstructorUsedError;
+  AuthType get authType => throw _privateConstructorUsedError;
+  Map<String, dynamic>? get authParams => throw _privateConstructorUsedError;
 
   /// Serializes this HttpRequestModel to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -57,7 +59,9 @@ abstract class $HttpRequestModelCopyWith<$Res> {
       ContentType bodyContentType,
       String? body,
       String? query,
-      List<FormDataModel>? formData});
+      List<FormDataModel>? formData,
+      AuthType authType,
+      Map<String, dynamic>? authParams});
 }
 
 /// @nodoc
@@ -85,6 +89,8 @@ class _$HttpRequestModelCopyWithImpl<$Res, $Val extends HttpRequestModel>
     Object? body = freezed,
     Object? query = freezed,
     Object? formData = freezed,
+    Object? authType = null,
+    Object? authParams = freezed,
   }) {
     return _then(_value.copyWith(
       method: null == method
@@ -127,6 +133,14 @@ class _$HttpRequestModelCopyWithImpl<$Res, $Val extends HttpRequestModel>
           ? _value.formData
           : formData // ignore: cast_nullable_to_non_nullable
               as List<FormDataModel>?,
+      authType: null == authType
+          ? _value.authType
+          : authType // ignore: cast_nullable_to_non_nullable
+              as AuthType,
+      authParams: freezed == authParams
+          ? _value.authParams
+          : authParams // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>?,
     ) as $Val);
   }
 }
@@ -149,7 +163,9 @@ abstract class _$$HttpRequestModelImplCopyWith<$Res>
       ContentType bodyContentType,
       String? body,
       String? query,
-      List<FormDataModel>? formData});
+      List<FormDataModel>? formData,
+      AuthType authType,
+      Map<String, dynamic>? authParams});
 }
 
 /// @nodoc
@@ -175,6 +191,8 @@ class __$$HttpRequestModelImplCopyWithImpl<$Res>
     Object? body = freezed,
     Object? query = freezed,
     Object? formData = freezed,
+    Object? authType = null,
+    Object? authParams = freezed,
   }) {
     return _then(_$HttpRequestModelImpl(
       method: null == method
@@ -217,6 +235,14 @@ class __$$HttpRequestModelImplCopyWithImpl<$Res>
           ? _value._formData
           : formData // ignore: cast_nullable_to_non_nullable
               as List<FormDataModel>?,
+      authType: null == authType
+          ? _value.authType
+          : authType // ignore: cast_nullable_to_non_nullable
+              as AuthType,
+      authParams: freezed == authParams
+          ? _value._authParams
+          : authParams // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>?,
     ));
   }
 }
@@ -235,12 +261,15 @@ class _$HttpRequestModelImpl extends _HttpRequestModel {
       this.bodyContentType = ContentType.json,
       this.body,
       this.query,
-      final List<FormDataModel>? formData})
+      final List<FormDataModel>? formData,
+      this.authType = AuthType.none,
+      final Map<String, dynamic>? authParams})
       : _headers = headers,
         _params = params,
         _isHeaderEnabledList = isHeaderEnabledList,
         _isParamEnabledList = isParamEnabledList,
         _formData = formData,
+        _authParams = authParams,
         super._();
 
   factory _$HttpRequestModelImpl.fromJson(Map<String, dynamic> json) =>
@@ -312,8 +341,21 @@ class _$HttpRequestModelImpl extends _HttpRequestModel {
   }
 
   @override
+  @JsonKey()
+  final AuthType authType;
+  final Map<String, dynamic>? _authParams;
+  @override
+  Map<String, dynamic>? get authParams {
+    final value = _authParams;
+    if (value == null) return null;
+    if (_authParams is EqualUnmodifiableMapView) return _authParams;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(value);
+  }
+
+  @override
   String toString() {
-    return 'HttpRequestModel(method: $method, url: $url, headers: $headers, params: $params, isHeaderEnabledList: $isHeaderEnabledList, isParamEnabledList: $isParamEnabledList, bodyContentType: $bodyContentType, body: $body, query: $query, formData: $formData)';
+    return 'HttpRequestModel(method: $method, url: $url, headers: $headers, params: $params, isHeaderEnabledList: $isHeaderEnabledList, isParamEnabledList: $isParamEnabledList, bodyContentType: $bodyContentType, body: $body, query: $query, formData: $formData, authType: $authType, authParams: $authParams)';
   }
 
   @override
@@ -333,7 +375,11 @@ class _$HttpRequestModelImpl extends _HttpRequestModel {
                 other.bodyContentType == bodyContentType) &&
             (identical(other.body, body) || other.body == body) &&
             (identical(other.query, query) || other.query == query) &&
-            const DeepCollectionEquality().equals(other._formData, _formData));
+            const DeepCollectionEquality().equals(other._formData, _formData) &&
+            (identical(other.authType, authType) ||
+                other.authType == authType) &&
+            const DeepCollectionEquality()
+                .equals(other._authParams, _authParams));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
@@ -349,7 +395,9 @@ class _$HttpRequestModelImpl extends _HttpRequestModel {
       bodyContentType,
       body,
       query,
-      const DeepCollectionEquality().hash(_formData));
+      const DeepCollectionEquality().hash(_formData),
+      authType,
+      const DeepCollectionEquality().hash(_authParams));
 
   /// Create a copy of HttpRequestModel
   /// with the given fields replaced by the non-null parameter values.
@@ -379,7 +427,9 @@ abstract class _HttpRequestModel extends HttpRequestModel {
       final ContentType bodyContentType,
       final String? body,
       final String? query,
-      final List<FormDataModel>? formData}) = _$HttpRequestModelImpl;
+      final List<FormDataModel>? formData,
+      final AuthType authType,
+      final Map<String, dynamic>? authParams}) = _$HttpRequestModelImpl;
   const _HttpRequestModel._() : super._();
 
   factory _HttpRequestModel.fromJson(Map<String, dynamic> json) =
@@ -405,6 +455,10 @@ abstract class _HttpRequestModel extends HttpRequestModel {
   String? get query;
   @override
   List<FormDataModel>? get formData;
+  @override
+  AuthType get authType;
+  @override
+  Map<String, dynamic>? get authParams;
 
   /// Create a copy of HttpRequestModel
   /// with the given fields replaced by the non-null parameter values.

--- a/packages/apidash_core/lib/models/http_request_model.g.dart
+++ b/packages/apidash_core/lib/models/http_request_model.g.dart
@@ -34,6 +34,11 @@ _$HttpRequestModelImpl _$$HttpRequestModelImplFromJson(Map json) =>
           ?.map((e) =>
               FormDataModel.fromJson(Map<String, Object?>.from(e as Map)))
           .toList(),
+      authType: $enumDecodeNullable(_$AuthTypeEnumMap, json['authType']) ??
+          AuthType.none,
+      authParams: (json['authParams'] as Map?)?.map(
+        (k, e) => MapEntry(k as String, e),
+      ),
     );
 
 Map<String, dynamic> _$$HttpRequestModelImplToJson(
@@ -49,6 +54,8 @@ Map<String, dynamic> _$$HttpRequestModelImplToJson(
       'body': instance.body,
       'query': instance.query,
       'formData': instance.formData?.map((e) => e.toJson()).toList(),
+      'authType': _$AuthTypeEnumMap[instance.authType]!,
+      'authParams': instance.authParams,
     };
 
 const _$HTTPVerbEnumMap = {
@@ -64,4 +71,15 @@ const _$ContentTypeEnumMap = {
   ContentType.json: 'json',
   ContentType.text: 'text',
   ContentType.formdata: 'formdata',
+};
+
+const _$AuthTypeEnumMap = {
+  AuthType.none: 'none',
+  AuthType.basic: 'basic',
+  AuthType.bearer: 'bearer',
+  AuthType.jwtBearer: 'jwtBearer',
+  AuthType.apiKey: 'apiKey',
+  AuthType.digest: 'digest',
+  AuthType.oauth1: 'oauth1',
+  AuthType.oauth2: 'oauth2',
 };

--- a/test/widgets/request_pane_test.dart
+++ b/test/widgets/request_pane_test.dart
@@ -15,9 +15,14 @@ void main() {
           body: RequestPane(
             selectedId: '1',
             codePaneVisible: true,
-            tabLabels: const ['URL Params', 'Headers', 'Body'],
+            tabLabels: const ['URL Params', 'Headers', 'Authentication', 'Body'],
             onPressedCodeButton: () {},
-            children: const [Text('abc'), Text('xyz'), Text('mno')],
+            children: const [
+              Text('abc'),  // URL Params
+              Text('xyz'),  // Headers
+              Text('auth'), // Authentication
+              Text('mno')   // Body
+            ],
           ),
         ),
       ),
@@ -29,9 +34,11 @@ void main() {
     expect(find.text('URL Params'), findsOneWidget);
     expect(find.text('Headers'), findsOneWidget);
     expect(find.text('Body'), findsOneWidget);
+    expect(find.text('Authentication'), findsOneWidget);
     expect(find.text('abc'), findsOneWidget);
     expect(find.text('mno'), findsNothing);
     expect(find.text('xyz'), findsNothing);
+    expect(find.text('auth'), findsNothing);  // Authentication tab not selected
 
     expect(find.byIcon(Icons.code_off_rounded), findsOneWidget);
     expect(find.byIcon(Icons.code_rounded), findsNothing);
@@ -48,8 +55,13 @@ void main() {
             codePaneVisible: true,
             onPressedCodeButton: () {},
             tabIndex: 1,
-            tabLabels: const ['URL Params', 'Headers', 'Body'],
-            children: const [Text('abc'), Text('xyz'), Text('mno')],
+            tabLabels: const ['URL Params', 'Headers', 'Authentication', 'Body'],
+            children: const [
+              Text('abc'),  // URL Params
+              Text('xyz'),  // Headers
+              Text('auth'), // Authentication
+              Text('mno')   // Body
+            ],
           ),
         ),
       ),
@@ -64,11 +76,47 @@ void main() {
     expect(find.text('abc'), findsNothing);
     expect(find.text('mno'), findsNothing);
     expect(find.text('xyz'), findsOneWidget);
+    expect(find.text('Authentication'), findsOneWidget);
+    expect(find.text('auth'), findsNothing);  // Authentication tab not selected
 
     expect(find.byIcon(Icons.code_off_rounded), findsOneWidget);
     expect(find.byIcon(Icons.code_rounded), findsNothing);
   });
-  testWidgets('Testing Request Pane for 3rd tab', (tester) async {
+  testWidgets('Testing Request Pane for 3rd tab (Authentication)', (tester) async {
+    await tester.setScreenSize(largeWidthDevice);
+    await tester.pumpWidget(
+      MaterialApp(
+        title: 'Request Pane',
+        theme: kThemeDataLight,
+        home: Scaffold(
+          body: RequestPane(
+            selectedId: '1',
+            codePaneVisible: true,
+            onPressedCodeButton: () {},
+            tabIndex: 2,
+            tabLabels: const ['URL Params', 'Headers', 'Authentication', 'Body'],
+            children: const [
+              Text('abc'),  // URL Params
+              Text('xyz'),  // Headers
+              Text('auth'), // Authentication
+              Text('mno')   // Body
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(Center), findsAtLeastNWidgets(1));
+    expect(find.text('Authentication'), findsOneWidget);
+    expect(find.text('auth'), findsOneWidget);  // Authentication tab selected
+    expect(find.text('abc'), findsNothing);
+    expect(find.text('xyz'), findsNothing);
+    expect(find.text('mno'), findsNothing);
+
+    expect(find.byIcon(Icons.code_off_rounded), findsOneWidget);
+    expect(find.byIcon(Icons.code_rounded), findsNothing);
+  });
+  testWidgets('Testing Request Pane for 4th tab (Body)', (tester) async {
     await tester.setScreenSize(largeWidthDevice);
     await tester.pumpWidget(
       MaterialApp(
@@ -79,9 +127,14 @@ void main() {
             selectedId: '1',
             codePaneVisible: false,
             onPressedCodeButton: () {},
-            tabIndex: 2,
-            tabLabels: const ['URL Params', 'Headers', 'Body'],
-            children: const [Text('abc'), Text('xyz'), Text('mno')],
+            tabIndex: 3,
+            tabLabels: const ['URL Params', 'Headers', 'Authentication', 'Body'],
+            children: const [
+              Text('abc'),  // URL Params
+              Text('xyz'),  // Headers
+              Text('auth'), // Authentication
+              Text('mno')   // Body
+            ],
           ),
         ),
       ),
@@ -96,6 +149,8 @@ void main() {
     expect(find.text('abc'), findsNothing);
     expect(find.text('mno'), findsOneWidget);
     expect(find.text('xyz'), findsNothing);
+    expect(find.text('Authentication'), findsOneWidget);
+    expect(find.text('auth'), findsNothing);  // Authentication tab not selected
 
     expect(find.byIcon(Icons.code_off_rounded), findsNothing);
     expect(find.byIcon(Icons.code_rounded), findsOneWidget);
@@ -114,8 +169,13 @@ void main() {
             onTapTabBar: (value) {
               computedTabIndex = value;
             },
-            tabLabels: const ['URL Params', 'Headers', 'Body'],
-            children: const [Text('abc'), Text('xyz'), Text('mno')],
+            tabLabels: const ['URL Params', 'Headers', 'Authentication', 'Body'],
+            children: const [
+              Text('abc'),  // URL Params
+              Text('xyz'),  // Headers
+              Text('auth'), // Authentication
+              Text('mno')   // Body
+            ],
           ),
         ),
       ),
@@ -125,6 +185,7 @@ void main() {
     expect(find.text('URL Params'), findsOneWidget);
     expect(find.text('Headers'), findsOneWidget);
     expect(find.text('Body'), findsOneWidget);
+    expect(find.text('Authentication'), findsOneWidget);
 
     await tester.tap(find.text('Headers'));
     await tester.pumpAndSettle();
@@ -136,7 +197,7 @@ void main() {
 
     await tester.tap(find.text('Body'));
     await tester.pumpAndSettle();
-    expect(computedTabIndex, 2);
+    expect(computedTabIndex, 3);
 
     expect(find.text('abc'), findsNothing);
     expect(find.text('mno'), findsOneWidget);
@@ -149,5 +210,13 @@ void main() {
     expect(find.text('abc'), findsOneWidget);
     expect(find.text('mno'), findsNothing);
     expect(find.text('xyz'), findsNothing);
+
+    await tester.tap(find.text('Authentication'));
+    await tester.pumpAndSettle();
+    expect(computedTabIndex, 2);
+    expect(find.text('auth'), findsOneWidget);
+    expect(find.text('abc'), findsNothing);
+    expect(find.text('xyz'), findsNothing);
+    expect(find.text('mno'), findsNothing);
   });
 }


### PR DESCRIPTION
## PR Description

Added API Key Authentication support to allow users to authenticate their API requests using API keys. This implementation includes:

- New Authorization UI component for configuring API keys
- Support for both header and query parameter authentication methods
- Reusable AuthTextField widget for form inputs
- State management for authentication parameters
- Integration with existing request system

## Related Issues

- Closes ##611 #609

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [x] Yes
- [] No

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux