### PR TITLE
feat: Add support for importing requests from OpenAPI 3 JSON/YAML

### DIFF
--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -140,7 +140,8 @@ enum CodegenLanguage {
 enum ImportFormat {
   curl("cURL"),
   postman("Postman Collection v2.1"),
-  insomnia("Insomnia v4");
+  insomnia("Insomnia v4"),
+  openapi("OpenAPI/Swagger");
 
   const ImportFormat(this.label);
   final String label;

--- a/lib/importer/import_dialog.dart
+++ b/lib/importer/import_dialog.dart
@@ -1,8 +1,11 @@
+import 'package:apidash_core/apidash_core.dart';
+import 'package:apidash/consts.dart';  // Add this import for ImportFormat  // Make sure this is included
 import 'package:apidash_design_system/apidash_design_system.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:apidash/providers/providers.dart';
 import 'package:apidash/widgets/widgets.dart';
+import 'package:apidash/widgets/openapi_selection_dialog.dart'; // Add this import
 import 'importer.dart';
 
 void importToCollectionPane(
@@ -25,35 +28,55 @@ void importToCollectionPane(
       final importFormatType = ref.read(importFormatStateProvider);
       sm.hideCurrentSnackBar();
       file.readAsString().then(
-        (content) {
-          kImporter
-              .getHttpRequestModelList(importFormatType, content)
-              .then((importedRequestModels) {
-            if (importedRequestModels != null) {
-              if (importedRequestModels.isEmpty) {
-                sm.showSnackBar(
-                    getSnackBar("No requests imported", small: false));
-              } else {
-                for (var model in importedRequestModels.reversed) {
-                  ref
-                      .read(collectionStateNotifierProvider.notifier)
-                      .addRequestModel(
-                        model.$2,
-                        name: model.$1,
-                      );
-                }
-                sm.showSnackBar(getSnackBar(
-                    "Successfully imported ${importedRequestModels.length} requests",
-                    small: false));
-              }
-              // Solves - Do not use BuildContexts across async gaps
-              if (!context.mounted) return;
-              Navigator.of(context).pop();
+        (content) async { 
+          final importedRequestModels = await kImporter
+              .getHttpRequestModelList(importFormatType, content);
+              
+          if (importedRequestModels != null) {
+            if (importedRequestModels.isEmpty) {
+              sm.showSnackBar(
+                  getSnackBar("No requests imported", small: false));
             } else {
-              var err = "Unable to parse ${file.name}";
-              sm.showSnackBar(getSnackBar(err, small: false));
+              // for OpenAPI selection the dialog box will be shown
+              // to select the endpoints to import
+              List<(String?, HttpRequestModel)> requestsToImport = importedRequestModels;
+              
+              if (importFormatType == ImportFormat.openapi && importedRequestModels.length > 1) {
+                final selectedRequests = await showOpenApiSelectionDialog(
+                  context: context,
+                  requests: importedRequestModels,
+                );
+                
+                if (selectedRequests == null || selectedRequests.isEmpty) {
+                  // User cancelled or selected none
+                  sm.showSnackBar(getSnackBar("Import cancelled", small: false));
+                  return;
+                }
+                
+                requestsToImport = selectedRequests;
+              }
+            
+              
+              // requestsToImport instead of importedRequestModels
+              for (var model in requestsToImport.reversed) {
+                ref
+                    .read(collectionStateNotifierProvider.notifier)
+                    .addRequestModel(
+                      model.$2,
+                      name: model.$1,
+                    );
+              }
+              sm.showSnackBar(getSnackBar(
+                  "Successfully imported ${requestsToImport.length} requests", // Update this
+                  small: false));
             }
-          });
+            // Solves - Do not use BuildContexts across async gaps
+            if (!context.mounted) return;
+            Navigator.of(context).pop();
+          } else {
+            var err = "Unable to parse ${file.name}";
+            sm.showSnackBar(getSnackBar(err, small: false));
+          }
         },
         onError: (e) {
           var err = "Unable to import ${file.name}";

--- a/lib/importer/importer.dart
+++ b/lib/importer/importer.dart
@@ -1,5 +1,6 @@
 import 'package:apidash/consts.dart';
 import 'package:apidash_core/apidash_core.dart';
+import 'package:openapi_spec/openapi_spec.dart';
 
 class Importer {
   Future<List<(String?, HttpRequestModel)>?> getHttpRequestModelList(
@@ -13,6 +14,8 @@ class Importer {
           .toList(),
       ImportFormat.postman => PostmanIO().getHttpRequestModelList(content),
       ImportFormat.insomnia => InsomniaIO().getHttpRequestModelList(content),
+      ImportFormat.openapi =>  OpenApiIO().getHttpRequestModelList(content), 
+
     };
   }
 }

--- a/lib/widgets/openapi_selection_dialog.dart
+++ b/lib/widgets/openapi_selection_dialog.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:apidash_core/apidash_core.dart';
+
+Future<List<(String?, HttpRequestModel)>?> showOpenApiSelectionDialog({
+  required BuildContext context,
+  required List<(String?, HttpRequestModel)> requests,
+}) async {
+  // Start with all selected
+  final selectedItems = List<bool>.filled(requests.length, true);
+  bool selectAll = true;
+  
+  final result = await showDialog<bool>(
+    context: context,
+    builder: (context) => StatefulBuilder(  // Use StatefulBuilder to handle state
+      builder: (context, setState) {
+        return AlertDialog(
+          title: const Text('Select API Endpoints'),
+          content: SizedBox(
+            width: double.maxFinite,
+            height: 400,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Found ${requests.length} endpoints in the OpenAPI specification.',
+                  style: Theme.of(context).textTheme.bodyLarge,
+                ),
+                const SizedBox(height: 8),
+                const Text('Select the endpoints you want to import:'),
+                const SizedBox(height: 16),
+                // Add a "Select All" checkbox
+                CheckboxListTile(
+                  title: const Text('Select All'),
+                  value: selectAll,
+                  onChanged: (value) {
+                    setState(() {
+                      selectAll = value ?? false;
+                      for (int i = 0; i < selectedItems.length; i++) {
+                        selectedItems[i] = selectAll;
+                      }
+                    });
+                  },
+                ),
+                const Divider(),
+                Expanded(
+                  child: ListView.builder(
+                    shrinkWrap: true,
+                    itemCount: requests.length,
+                    itemBuilder: (context, index) {
+                      final request = requests[index];
+                      final name = request.$1 ?? 'Unnamed Request';
+                      final method = request.$2.method;
+                      
+                      return CheckboxListTile(
+                        title: Text(name),
+                        subtitle: Text('${method.name} ${request.$2.url}'),
+                        value: selectedItems[index],
+                        onChanged: (value) {
+                          setState(() {  // This updates the UI when checkbox changes
+                            selectedItems[index] = value ?? false;
+                            // Update "Select All" checkbox state
+                            selectAll = selectedItems.every((element) => element);
+                          });
+                        },
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop(false);
+              },
+              child: const Text('Cancel'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).pop(true);
+              },
+              child: const Text('Import Selected'),
+            ),
+          ],
+        );
+      }
+    ),
+  );
+  
+  if (result == true) {
+    return [
+      for (int i = 0; i < requests.length; i++)
+        if (selectedItems[i]) requests[i]
+    ];
+  }
+  
+  return null;
+}

--- a/packages/openapi_spec/.gitignore
+++ b/packages/openapi_spec/.gitignore
@@ -1,0 +1,33 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock
+pubspec_overrides.yaml
+**/doc/api/
+.dart_tool/
+.packages
+build/
+**/golden/**/failures/
+coverage/
+

--- a/packages/openapi_spec/lib/openapi_spec.dart
+++ b/packages/openapi_spec/lib/openapi_spec.dart
@@ -1,0 +1,3 @@
+library openapi_spec;
+
+export 'src/utils/openapi_utils.dart';

--- a/packages/openapi_spec/lib/src/utils/openapi_utils.dart
+++ b/packages/openapi_spec/lib/src/utils/openapi_utils.dart
@@ -1,0 +1,190 @@
+
+import 'dart:convert';
+import 'package:apidash_core/apidash_core.dart';
+import 'package:yaml/yaml.dart';
+import 'package:seed/models/name_value_model.dart';
+
+class OpenApiIO {
+  List<(String?, HttpRequestModel)>? getHttpRequestModelList(String content)  {
+    try {
+      // Try to parse the content as JSON first
+      Map<String, dynamic> jsonData;
+      
+      try {
+        // Try JSON format
+        jsonData = json.decode(content) as Map<String, dynamic>;
+      } catch (e) {
+        try {
+          // If JSON fails, try YAML format
+          final yamlMap = loadYaml(content) as Map;
+          // Convert YAML to JSON format
+          jsonData = json.decode(json.encode(yamlMap)) as Map<String, dynamic>;
+        } catch (e) {
+          print('Error parsing YAML: $e');
+          return null;
+        }
+      }
+
+      // Basic validation to check if it's an OpenAPI spec
+      if (!jsonData.containsKey('paths')) {
+        print('Not a valid OpenAPI spec: missing paths');
+        return null;
+      }
+
+      final List<(String?, HttpRequestModel)> result = [];
+      
+      // Get base URL from servers if available
+      String baseUrl = 'https://example.com';
+      if (jsonData.containsKey('servers') && 
+          jsonData['servers'] is List && 
+          (jsonData['servers'] as List).isNotEmpty &&
+          (jsonData['servers'][0] is Map) &&
+          (jsonData['servers'][0] as Map).containsKey('url')) {
+        baseUrl = jsonData['servers'][0]['url'] as String;
+      }
+      
+      // Process paths and operations
+      final paths = jsonData['paths'] as Map<String, dynamic>;
+      paths.forEach((path, pathData) {
+        if (pathData is Map<String, dynamic>) {
+          // Only use the HTTP methods we support
+          for (final methodStr in ['get', 'post', 'put', 'delete', 'patch', 'head']) {
+            if (pathData.containsKey(methodStr)) {
+              final operation = pathData[methodStr] as Map<String, dynamic>;
+              
+              // Convert string method to HTTPVerb enum
+              final HTTPVerb method = _stringToHttpVerb(methodStr);
+              
+              // Create a name for the request
+              final name = operation.containsKey('summary') && operation['summary'] != null
+                  ? operation['summary'] as String
+                  : operation.containsKey('operationId') && operation['operationId'] != null
+                      ? operation['operationId'] as String
+                      : '${methodStr.toUpperCase()} $path';
+              
+              // Build the request model
+              final requestModel = _createRequestModel(
+                method,
+                path,
+                baseUrl,
+                operation,
+              );
+              
+              result.add((name, requestModel));
+            }
+          }
+        }
+      });
+
+      return result;
+    } catch (e) {
+      print('Error parsing OpenAPI/Swagger: $e');
+      return null;
+    }
+  }
+  
+  /// Converts a string HTTP method to the HTTPVerb enum
+  HTTPVerb _stringToHttpVerb(String method) {
+    switch (method.toLowerCase()) {
+      case 'get': return HTTPVerb.get;
+      case 'post': return HTTPVerb.post;
+      case 'put': return HTTPVerb.put;
+      case 'delete': return HTTPVerb.delete;
+      case 'patch': return HTTPVerb.patch;
+      case 'head': return HTTPVerb.head;
+      // Remove OPTIONS since it's not available in your HTTPVerb enum
+      default: return HTTPVerb.get;
+    }
+  }
+
+  /// Creates a basic HttpRequestModel from operation data
+  HttpRequestModel _createRequestModel(
+    HTTPVerb method,
+    String path,
+    String baseUrl,
+    Map<String, dynamic> operation,
+  ) {
+    // Basic URL construction
+    String url = baseUrl;
+    if (!url.endsWith('/') && !path.startsWith('/')) {
+      url += '/';
+    } else if (url.endsWith('/') && path.startsWith('/')) {
+      url = url.substring(0, url.length - 1);
+    }
+    url += path;
+    
+    // Replace path parameters with example values
+    final RegExp pathParamRegex = RegExp(r'\{([^}]+)\}');
+    final matches = pathParamRegex.allMatches(url);
+    for (final match in matches) {
+      final paramName = match.group(1)!;
+      url = url.replaceAll('{$paramName}', 'example');
+    }
+    
+    // Extract headers
+    final List<NameValueModel> headers = [
+      NameValueModel(name: 'Accept', value: 'application/json')
+    ];
+    
+    // Extract query parameters
+    final List<NameValueModel> params = [];
+    if (operation.containsKey('parameters')) {
+      final parameters = operation['parameters'] as List<dynamic>?;
+      if (parameters != null) {
+        for (final param in parameters) {
+          if (param is Map<String, dynamic> && 
+              param.containsKey('in') && 
+              param['in'] == 'query' &&
+              param.containsKey('name')) {
+            params.add(NameValueModel(
+              name: param['name'] as String,
+              value: 'example'
+            ));
+          }
+        }
+      }
+    }
+    
+    // Basic request body for POST/PUT/PATCH
+    String body = '';
+    ContentType bodyContentType = ContentType.json;
+    
+    if (['post', 'put', 'patch'].contains(method.name.toLowerCase()) && 
+        operation.containsKey('requestBody')) {
+      
+      if (operation['requestBody'] is Map<String, dynamic> &&
+          operation['requestBody'].containsKey('content')) {
+        
+        final content = operation['requestBody']['content'] as Map<String, dynamic>?;
+        if (content != null) {
+          if (content.containsKey('application/json')) {
+            bodyContentType = ContentType.json;
+            body = '{}';  // Default empty JSON
+            
+            // Try to extract a sample from the schema
+            final jsonContent = content['application/json'] as Map<String, dynamic>?;
+            if (jsonContent != null && jsonContent.containsKey('example')) {
+              body = json.encode(jsonContent['example']);
+            }
+          } else if (content.containsKey('multipart/form-data')) {
+            bodyContentType = ContentType.formdata;
+            // Form data is handled via formData property
+          } else if (content.containsKey('text/plain')) {
+            bodyContentType = ContentType.text;
+            body = '';
+          }
+        }
+      }
+    }
+    
+ 
+    return HttpRequestModel(
+      method: method,
+      url: url,
+      headers: headers,
+      params: params,
+      body: body,
+      bodyContentType: bodyContentType,
+    );
+  }
+}

--- a/packages/openapi_spec/pubspec.yaml
+++ b/packages/openapi_spec/pubspec.yaml
@@ -1,0 +1,19 @@
+name: openapi_spec
+description: OpenAPI specification parser for APIdash
+version: 0.0.1
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  yaml: ^3.1.2
+  json_annotation: ^4.8.0
+  freezed_annotation: ^2.2.0
+  seed: ^0.0.3 
+  apidash_core:
+    path: ../apidash_core
+
+dev_dependencies:
+  build_runner: ^2.3.3
+  freezed: ^2.3.2
+  json_serializable: ^6.6.0

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1065,6 +1065,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  openapi_spec:
+    dependency: "direct main"
+    description:
+      path: "packages/openapi_spec"
+      relative: true
+    source: path
+    version: "0.0.1"
   package_config:
     dependency: transitive
     description:
@@ -1935,7 +1942,7 @@ packages:
     source: hosted
     version: "6.5.0"
   yaml:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: yaml
       sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,9 @@ dependencies:
   apidash_design_system:
     path: packages/apidash_design_system
   code_builder: ^4.10.0
+  openapi_spec:
+    path: packages/openapi_spec
+  yaml: ^3.1.2
   csv: ^6.0.0
   data_table_2: 2.5.16
   dart_style: ^3.0.1


### PR DESCRIPTION
### **PR Title:**  
**feat: Add support for importing requests from OpenAPI 3 & Swagger 2 JSON/YAML**  

### **PR Description**  
This is a **draft PR**. Soon, I will add test cases once you review the implementation.  

This PR introduces support for importing requests from **OpenAPI 3 and Swagger 2** JSON/YAML files. The developed code:  
- Parses OpenAPI 3 and Swagger 2 specifications from JSON/YAML files  
- Extracts data & examples provided in the specs  
- Allows users to select requests to add to the API Dash collection  
- Generates corresponding request items based on user selection  

Additionally, I have added a video demonstrating the feature.

https://github.com/user-attachments/assets/91c09bec-e6ab-40d9-a3e1-a6a9f0a50f35


### **Related Issues**  
- Closes #121  

### **Checklist**  
- [x] I have gone through the [[[contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)  
- [x] I have updated my branch and synced it with the project `main` branch before making this PR  
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)  
- [ ] I have run the tests (`flutter test`), and **will add more test cases after review**  

### **Added/Updated Tests?**  
- [x] Not yet, will add soon after review  
- [ ] Yes (To be added)  

### **OS on which you have developed and tested the feature?**  
- [ ] Windows  
- [x] macOS  
- [ ] Linux  

Let me know if any changes are needed! 🚀  