### PR TITLE
Implement Highlight and Hover Support for Environment Variables in JSON Request Body

### DIFF
--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_body.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_body.dart
@@ -6,6 +6,7 @@ import 'package:apidash/providers/providers.dart';
 import 'package:apidash/widgets/widgets.dart';
 import 'package:apidash/consts.dart';
 import 'request_form_data.dart';
+import 'package:apidash/screens/common_widgets/env_regexp_span_builder.dart';
 
 class EditRequestBody extends ConsumerWidget {
   const EditRequestBody({super.key});
@@ -55,6 +56,7 @@ class EditRequestBody extends ConsumerWidget {
                             .update(body: value);
                       },
                       hintText: kHintJson,
+                      specialTextSpanBuilder: EnvRegExpSpanBuilder(), // Add this
                     ),
                   ),
                 _ => Padding(

--- a/lib/widgets/editor.dart
+++ b/lib/widgets/editor.dart
@@ -3,6 +3,7 @@ import 'package:apidash/consts.dart';
 import 'package:apidash_design_system/apidash_design_system.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:extended_text_field/extended_text_field.dart'; 
 
 class TextFieldEditor extends StatefulWidget {
   const TextFieldEditor({
@@ -12,6 +13,7 @@ class TextFieldEditor extends StatefulWidget {
     this.initialValue,
     this.readOnly = false,
     this.hintText,
+    this.specialTextSpanBuilder, // Optional builder for custom text styling
   });
 
   final String fieldKey;
@@ -19,6 +21,7 @@ class TextFieldEditor extends StatefulWidget {
   final String? initialValue;
   final bool readOnly;
   final String? hintText;
+  final SpecialTextSpanBuilder? specialTextSpanBuilder; // Defines the special text handler 
   @override
   State<TextFieldEditor> createState() => _TextFieldEditorState();
 }
@@ -67,7 +70,7 @@ class _TextFieldEditorState extends State<TextFieldEditor> {
           insertTab();
         },
       },
-      child: TextFormField(
+      child: ExtendedTextField( // Replace TextFormField with ExtendedTextField
         key: Key(widget.fieldKey),
         controller: controller,
         focusNode: editorFocusNode,
@@ -83,6 +86,7 @@ class _TextFieldEditorState extends State<TextFieldEditor> {
         onTapOutside: (PointerDownEvent event) {
           editorFocusNode.unfocus();
         },
+        specialTextSpanBuilder: widget.specialTextSpanBuilder, // Passes the builder to apply formatting
         decoration: InputDecoration(
           hintText: widget.hintText ?? kHintContent,
           hintStyle: TextStyle(


### PR DESCRIPTION
## PR Description

1. This PR adds env variable highlighting and hover values to the JSON request body editor .It reuses `EnvRegExpSpanBuilder`, `EnvVarSpan`, and `EnvVarPopover`, updates `TextFieldEditor to ExtendedTextField` with `specialTextSpanBuilde`r, sets it in `EditRequestBody`, 

2. And fixes the import path. Improves API editing without changing style or behavior.
 
3. Support both light and dark mode

![image](https://github.com/user-attachments/assets/bc41ba8f-f729-4f59-b7ff-a87267ff746e)

## Related Issues

- Closes #592

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [ ] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [x] No, and this is why: Existing tests already cover the reused components (`EnvRegExpSpanBuilder`, `EnvVarSpan`), and this change focuses on integrating them into the JSON editor.So additional testing is not required.
## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [x] Linux
