### PR TITLE
fix: Imporved the encoding charset using the Encoding class

### DIFF
--- a/packages/apidash_core/lib/services/http_service.dart
+++ b/packages/apidash_core/lib/services/http_service.dart
@@ -55,8 +55,8 @@ Future<(HttpResponse?, Duration?, String?)> sendHttpRequest(
                 }
               }
             }
-            final encoding = Encoding.getByName(encodingName) ?? utf8;
-            var contentLength = encoding.encode(requestBody).length;
+            final encoding = Encoding.getByName(encodingName);
+            var contentLength = encoding!.encode(requestBody).length;
             if (contentLength > 0) {
               body = requestBody;
               headers[HttpHeaders.contentLengthHeader] =

--- a/packages/apidash_core/lib/services/http_service.dart
+++ b/packages/apidash_core/lib/services/http_service.dart
@@ -41,7 +41,22 @@ Future<(HttpResponse?, Duration?, String?)> sendHttpRequest(
         if (kMethodsWithBody.contains(requestModel.method)) {
           var requestBody = requestModel.body;
           if (requestBody != null && !isMultiPartRequest) {
-            var contentLength = utf8.encode(requestBody).length;
+            var encodingName = "utf-8";
+            if (requestModel.headers != null) {
+              for (var header in requestModel.headers!) {
+                if (header.name.toLowerCase() == "content-type") {
+                  final charset =
+                      RegExp(r'charset=([^\s;]+)', caseSensitive: false)
+                          .firstMatch(header.value);
+                  if (charset != null) {
+                    encodingName = charset.group(1)!;
+                  }
+                  break;
+                }
+              }
+            }
+            final encoding = Encoding.getByName(encodingName) ?? utf8;
+            var contentLength = encoding.encode(requestBody).length;
             if (contentLength > 0) {
               body = requestBody;
               headers[HttpHeaders.contentLengthHeader] =


### PR DESCRIPTION
## PR Description

I have imporved the encoding where the user can specify the encoding and that same encoding type will be used to encode the data instead of previously default utf-8 

I have used just in built Encoding class in the flutter which provide encoiding as follows as mentioned in the encoding.dart class 

```static final Map<String, Encoding> _nameToEncoding = <String, Encoding>{
    // ISO_8859-1:1987.
    "iso_8859-1:1987": latin1,
    "iso-ir-100": latin1,
    "iso_8859-1": latin1,
    "iso-8859-1": latin1,
    "latin1": latin1,
    "l1": latin1,
    "ibm819": latin1,
    "cp819": latin1,
    "csisolatin1": latin1,

    // US-ASCII.
    "iso-ir-6": ascii,
    "ansi_x3.4-1968": ascii,
    "ansi_x3.4-1986": ascii,
    "iso_646.irv:1991": ascii,
    "iso646-us": ascii,
    "us-ascii": ascii,
    "us": ascii,
    "ibm367": ascii,
    "cp367": ascii,
    "csascii": ascii,
    "ascii": ascii, // This is not in the IANA official names.
    // UTF-8.
    "csutf8": utf8,
    "utf-8": utf8,
  };
```



we can add supoort for other enocding types using the charset encoding . Please let me how on your opinion .

Ps; None of this is made by ai 
## Related Issues

- Closes #630 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [x] No, and this is why: I would like to see the approch and once imporved i will write the testcase 

## OS on which you have developed and tested the feature?

- [x] Windows
- [x] macOS
- [x] Linux
