### PR TITLE
Env variable from OS

### DIFF
--- a/lib/screens/envvar/editor_pane/variables_pane.dart
+++ b/lib/screens/envvar/editor_pane/variables_pane.dart
@@ -70,6 +70,11 @@ class EditEnvironmentVariablesState
         label: Text("Variable value"),
       ),
       DataColumn2(
+        label: Text('OS'),
+        fixedWidth: 50,
+        tooltip: 'Use OS environment variable',
+      ),
+      DataColumn2(
         label: Text(''),
         fixedWidth: 32,
       ),
@@ -146,6 +151,27 @@ class EditEnvironmentVariablesState
                   _onFieldChange(selectedId!);
                 },
                 colorScheme: Theme.of(context).colorScheme,
+              ),
+            ),
+            DataCell(
+              Tooltip(
+                message: 'Fetch value from OS environment',
+                child: ADCheckBox(
+                  keyId: "$selectedId-$index-variables-os-$seed",
+                  value: variableRows[index].fromOS,
+                  onChanged: isLast
+                      ? null
+                      : (value) {
+                          if (value != null) {
+                            setState(() {
+                              variableRows[index] =
+                                  variableRows[index].copyWith(fromOS: value);
+                            });
+                          }
+                          _onFieldChange(selectedId!);
+                        },
+                  colorScheme: Theme.of(context).colorScheme,
+                ),
               ),
             ),
             DataCell(

--- a/lib/services/os_env_service.dart
+++ b/lib/services/os_env_service.dart
@@ -1,0 +1,38 @@
+import 'dart:io';
+
+/// Service to handle OS environment variable operations
+class OSEnvironmentService {
+  /// Get the value of an environment variable from the OS
+  /// Returns null if variable is not found
+  String? getOSEnvironmentVariable(String key) {
+    try {
+      
+      final envVars = Platform.environment;
+      
+      final matchingKey = envVars.keys
+          .firstWhere((k) => k.toUpperCase() == key.toUpperCase(), orElse: () => '');
+      
+      if (matchingKey.isNotEmpty) {
+        final value = envVars[matchingKey];
+        return value;
+      }
+      
+      return null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /// Check if an environment variable exists in the OS
+  bool hasOSEnvironmentVariable(String key) {
+    try {
+      final exists = Platform.environment.keys
+          .any((k) => k.toUpperCase() == key.toUpperCase());
+      return exists;
+    } catch (e) {
+      return false;
+    }
+  }
+}
+
+final osEnvironmentService = OSEnvironmentService();

--- a/lib/services/services.dart
+++ b/lib/services/services.dart
@@ -2,3 +2,4 @@ export 'hive_services.dart';
 export 'history_service.dart';
 export 'window_services.dart';
 export 'shared_preferences_services.dart';
+export 'os_env_service.dart';

--- a/packages/apidash_core/lib/models/environment_model.dart
+++ b/packages/apidash_core/lib/models/environment_model.dart
@@ -32,16 +32,18 @@ class EnvironmentVariableModel with _$EnvironmentVariableModel {
     required String value,
     @Default(EnvironmentVariableType.variable) EnvironmentVariableType type,
     @Default(false) bool enabled,
+    @Default(false) bool fromOS,
   }) = _EnvironmentVariableModel;
 
   factory EnvironmentVariableModel.fromJson(Map<String, Object?> json) =>
       _$EnvironmentVariableModelFromJson(json);
 }
 
+// Make sure to include fromOS in the constant models to match the model definition
 const kEnvironmentVariableEmptyModel =
-    EnvironmentVariableModel(key: "", value: "");
+    EnvironmentVariableModel(key: "", value: "", fromOS: false);
 const kEnvironmentSecretEmptyModel = EnvironmentVariableModel(
-    key: "", value: "", type: EnvironmentVariableType.secret);
+    key: "", value: "", type: EnvironmentVariableType.secret, fromOS: false);
 
 class EnvironmentVariableSuggestion {
   final String environmentId;

--- a/packages/apidash_core/lib/models/environment_model.freezed.dart
+++ b/packages/apidash_core/lib/models/environment_model.freezed.dart
@@ -224,6 +224,7 @@ mixin _$EnvironmentVariableModel {
   String get value => throw _privateConstructorUsedError;
   EnvironmentVariableType get type => throw _privateConstructorUsedError;
   bool get enabled => throw _privateConstructorUsedError;
+  bool get fromOS => throw _privateConstructorUsedError;
 
   /// Serializes this EnvironmentVariableModel to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -242,7 +243,11 @@ abstract class $EnvironmentVariableModelCopyWith<$Res> {
       _$EnvironmentVariableModelCopyWithImpl<$Res, EnvironmentVariableModel>;
   @useResult
   $Res call(
-      {String key, String value, EnvironmentVariableType type, bool enabled});
+      {String key,
+      String value,
+      EnvironmentVariableType type,
+      bool enabled,
+      bool fromOS});
 }
 
 /// @nodoc
@@ -265,6 +270,7 @@ class _$EnvironmentVariableModelCopyWithImpl<$Res,
     Object? value = null,
     Object? type = null,
     Object? enabled = null,
+    Object? fromOS = null,
   }) {
     return _then(_value.copyWith(
       key: null == key
@@ -283,6 +289,10 @@ class _$EnvironmentVariableModelCopyWithImpl<$Res,
           ? _value.enabled
           : enabled // ignore: cast_nullable_to_non_nullable
               as bool,
+      fromOS: null == fromOS
+          ? _value.fromOS
+          : fromOS // ignore: cast_nullable_to_non_nullable
+              as bool,
     ) as $Val);
   }
 }
@@ -297,7 +307,11 @@ abstract class _$$EnvironmentVariableModelImplCopyWith<$Res>
   @override
   @useResult
   $Res call(
-      {String key, String value, EnvironmentVariableType type, bool enabled});
+      {String key,
+      String value,
+      EnvironmentVariableType type,
+      bool enabled,
+      bool fromOS});
 }
 
 /// @nodoc
@@ -319,6 +333,7 @@ class __$$EnvironmentVariableModelImplCopyWithImpl<$Res>
     Object? value = null,
     Object? type = null,
     Object? enabled = null,
+    Object? fromOS = null,
   }) {
     return _then(_$EnvironmentVariableModelImpl(
       key: null == key
@@ -337,6 +352,10 @@ class __$$EnvironmentVariableModelImplCopyWithImpl<$Res>
           ? _value.enabled
           : enabled // ignore: cast_nullable_to_non_nullable
               as bool,
+      fromOS: null == fromOS
+          ? _value.fromOS
+          : fromOS // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -349,7 +368,8 @@ class _$EnvironmentVariableModelImpl implements _EnvironmentVariableModel {
       {required this.key,
       required this.value,
       this.type = EnvironmentVariableType.variable,
-      this.enabled = false});
+      this.enabled = false,
+      this.fromOS = false});
 
   factory _$EnvironmentVariableModelImpl.fromJson(Map<String, dynamic> json) =>
       _$$EnvironmentVariableModelImplFromJson(json);
@@ -364,10 +384,13 @@ class _$EnvironmentVariableModelImpl implements _EnvironmentVariableModel {
   @override
   @JsonKey()
   final bool enabled;
+  @override
+  @JsonKey()
+  final bool fromOS;
 
   @override
   String toString() {
-    return 'EnvironmentVariableModel(key: $key, value: $value, type: $type, enabled: $enabled)';
+    return 'EnvironmentVariableModel(key: $key, value: $value, type: $type, enabled: $enabled, fromOS: $fromOS)';
   }
 
   @override
@@ -378,12 +401,14 @@ class _$EnvironmentVariableModelImpl implements _EnvironmentVariableModel {
             (identical(other.key, key) || other.key == key) &&
             (identical(other.value, value) || other.value == value) &&
             (identical(other.type, type) || other.type == type) &&
-            (identical(other.enabled, enabled) || other.enabled == enabled));
+            (identical(other.enabled, enabled) || other.enabled == enabled) &&
+            (identical(other.fromOS, fromOS) || other.fromOS == fromOS));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(runtimeType, key, value, type, enabled);
+  int get hashCode =>
+      Object.hash(runtimeType, key, value, type, enabled, fromOS);
 
   /// Create a copy of EnvironmentVariableModel
   /// with the given fields replaced by the non-null parameter values.
@@ -407,7 +432,8 @@ abstract class _EnvironmentVariableModel implements EnvironmentVariableModel {
       {required final String key,
       required final String value,
       final EnvironmentVariableType type,
-      final bool enabled}) = _$EnvironmentVariableModelImpl;
+      final bool enabled,
+      final bool fromOS}) = _$EnvironmentVariableModelImpl;
 
   factory _EnvironmentVariableModel.fromJson(Map<String, dynamic> json) =
       _$EnvironmentVariableModelImpl.fromJson;
@@ -420,6 +446,8 @@ abstract class _EnvironmentVariableModel implements EnvironmentVariableModel {
   EnvironmentVariableType get type;
   @override
   bool get enabled;
+  @override
+  bool get fromOS;
 
   /// Create a copy of EnvironmentVariableModel
   /// with the given fields replaced by the non-null parameter values.

--- a/packages/apidash_core/lib/models/environment_model.g.dart
+++ b/packages/apidash_core/lib/models/environment_model.g.dart
@@ -30,10 +30,10 @@ _$EnvironmentVariableModelImpl _$$EnvironmentVariableModelImplFromJson(
     _$EnvironmentVariableModelImpl(
       key: json['key'] as String,
       value: json['value'] as String,
-      type:
-          $enumDecodeNullable(_$EnvironmentVariableTypeEnumMap, json['type']) ??
-              EnvironmentVariableType.variable,
+      type: $enumDecodeNullable(_$EnvironmentVariableTypeEnumMap, json['type']) ??
+          EnvironmentVariableType.variable,
       enabled: json['enabled'] as bool? ?? false,
+      fromOS: json['fromOS'] as bool? ?? false,
     );
 
 Map<String, dynamic> _$$EnvironmentVariableModelImplToJson(
@@ -43,6 +43,7 @@ Map<String, dynamic> _$$EnvironmentVariableModelImplToJson(
       'value': instance.value,
       'type': _$EnvironmentVariableTypeEnumMap[instance.type]!,
       'enabled': instance.enabled,
+      'fromOS': instance.fromOS,
     };
 
 const _$EnvironmentVariableTypeEnumMap = {


### PR DESCRIPTION
## PR Description

This PR adds support for fetching environment variables directly from the OS in API Dash. Users can now specify in the environment manager that a variable should be pulled from the system's environment variables instead of being stored in API Dash. The feature enhances security by allowing users to reference sensitive credentials (e.g., API keys, tokens, passwords) without exposing them in the app.

## Related Issues

- Closes #600 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why:  Will include the tests as soon as my approach will be accepted

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux
