### PR TITLE
feat(status): Implement global status bar and request body in get val…

### DIFF
--- a/lib/providers/providers.dart
+++ b/lib/providers/providers.dart
@@ -3,3 +3,4 @@ export 'environment_providers.dart';
 export 'history_providers.dart';
 export 'settings_providers.dart';
 export 'ui_providers.dart';
+export 'status_message_provider.dart';

--- a/lib/providers/status_message_provider.dart
+++ b/lib/providers/status_message_provider.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:apidash_core/apidash_core.dart';
+import 'package:apidash/providers/collection_providers.dart';
+import 'package:apidash/utils/status_validator.dart';
+
+enum StatusMessageType { defaultType, info, warning, error }
+
+class StatusMessage {
+  final String message;
+  final StatusMessageType type;
+
+  StatusMessage(this.message, this.type);
+}
+
+final statusMessageProvider =
+    StateNotifierProvider<GlobalStatusBarManager, StatusMessage>((ref) {
+  return GlobalStatusBarManager(ref);
+});
+
+class GlobalStatusBarManager extends StateNotifier<StatusMessage> {
+  final Ref ref;
+
+  GlobalStatusBarManager(this.ref)
+      : super(StatusMessage("Global Status Bar", StatusMessageType.defaultType)) {
+    // Listen for request changes and validate
+    ref.listen(selectedRequestModelProvider, (previous, next) {
+      final method = next?.httpRequestModel?.method ?? HTTPVerb.get;
+      final body = next?.httpRequestModel?.body;
+      _updateStatusMessage(StatusValidator().validateRequest(method, body));
+    });
+  }
+
+  // Updates the status message
+  void _updateStatusMessage(StatusMessage newMessage) {
+    state = newMessage;
+  }
+}

--- a/lib/screens/home_page/editor_pane/editor_pane.dart
+++ b/lib/screens/home_page/editor_pane/editor_pane.dart
@@ -3,19 +3,24 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:apidash/providers/providers.dart';
 import 'editor_default.dart';
 import 'editor_request.dart';
+import 'global_status_bar.dart';
 
 class RequestEditorPane extends ConsumerWidget {
-  const RequestEditorPane({
-    super.key,
-  });
+  const RequestEditorPane({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final selectedId = ref.watch(selectedIdStateProvider);
-    if (selectedId == null) {
-      return const RequestEditorDefault();
-    } else {
-      return const RequestEditor();
-    }
+
+    return Column(
+      children: [
+        Expanded(
+          child: selectedId == null
+              ? const RequestEditorDefault()
+              : const RequestEditor(),
+        ),
+        const GlobalStatusBar(),
+      ],
+    );
   }
 }

--- a/lib/screens/home_page/editor_pane/global_status_bar.dart
+++ b/lib/screens/home_page/editor_pane/global_status_bar.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:apidash_design_system/apidash_design_system.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:apidash/providers/providers.dart';
+
+class GlobalStatusBar extends ConsumerWidget {
+  const GlobalStatusBar({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final statusMessage = ref.watch(statusMessageProvider);
+
+    // Get color based on message type
+    final color = statusMessage.type == StatusMessageType.info
+        ? kColorSchemeSeed
+        : statusMessage.type == StatusMessageType.warning
+            ? kColorHttpMethodPut
+            : statusMessage.type == StatusMessageType.error
+                ? kColorDarkDanger
+                : kColorBlack;
+
+    // Get icon based on message type
+    final icon = statusMessage.type == StatusMessageType.error
+        ? Icons.error_outline
+        : statusMessage.type == StatusMessageType.warning
+            ? Icons.warning_amber_outlined
+            : statusMessage.type == StatusMessageType.info
+                ? Icons.info_outline
+                : null;
+
+    return Container(
+      padding: kPh12,
+      width: double.infinity,
+      height: 40,
+      // Use background color only for status messages (info/warning/error)
+      color: icon != null ? color.withOpacity(kForegroundOpacity) : kColorWhite,
+      child: Row(
+        children: [
+          // Only display icons for info, warning, and error states
+          if (icon != null) ...[
+            Icon(icon, size: kButtonIconSizeSmall, color: color),
+            kHSpacer8,
+          ],
+          Expanded(
+            child: Text(
+              statusMessage.message,
+              style: TextStyle(
+                color: color,
+                fontSize: 14,
+                fontWeight: FontWeight.w500,
+              ),
+              // Prevent text overflow issues
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/utils/status_validator.dart
+++ b/lib/utils/status_validator.dart
@@ -1,0 +1,20 @@
+import 'package:apidash_core/apidash_core.dart';
+import 'package:apidash/providers/status_message_provider.dart'; 
+import 'package:apidash_design_system/apidash_design_system.dart';
+
+class StatusValidator {
+  StatusMessage validateRequest(HTTPVerb method, String? body) {
+    if (_isInvalidGetRequest(method, body)) {
+      return StatusMessage(
+        "GET requests cannot have a body. Remove the body or change the method to POST.",
+        StatusMessageType.info,
+      );
+    }
+    return StatusMessage("Global Status Bar", StatusMessageType.defaultType);
+  }
+
+  bool _isInvalidGetRequest(HTTPVerb method, String? body) {
+    return method == HTTPVerb.get && body != null && body.isNotEmpty;
+  }
+
+}


### PR DESCRIPTION
## PR Description

This PR introduces a Global Status Bar to provide real-time feedback on API request configurations. . The system validates  and displays informative messages through a persistent status bar.

**Key Features**

1. **Global Status Bar**: A persistent UI component that displays validation messages with appropriate visual indicators (colors and icons)
2. **State Management**: Riverpod-based state management for seamless status updates throughout the application
3. **Request Validation**: Initial implementation focuses on validating GET
4. **Dynamic UI**: Status messages adapt their appearance based on message type (info, warning, error)

**Implementation Details**
The implementation follows a clean architecture pattern with clear separation of concerns:

1. `StatusMessage`: Data class holding message content and type
2. `GlobalStatusBarManager`: StateNotifier for managing status message state
3. `StatusValidator`: Contains validation logic for API requests
4. `GlobalStatusBar`: UI component for displaying status messages

## Related Issues

- Closes #178 
- Partially Closes #587
 
**Demonstration**

https://github.com/user-attachments/assets/a20a0cc7-e42b-470b-8688-6bb073539f87



### Checklist
- [ X] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [X] I have updated my branch and synced it with project `main` branch before making this PR
- [X] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [ ] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [x] No, and this is why: _Tests will be added after implementation approach is finalized and reviewed._

## OS on which you have developed and tested the feature?

- [X] Windows
- [ ] macOS
- [X] Linux



