### PR TITLE
Adding Tabs at the top of the request pane

### DIFF
--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -32,6 +32,7 @@ final StateNotifierProvider<CollectionStateNotifier, Map<String, RequestModel>?>
           hiveHandler,
         ));
 
+// Manages the set of visible tab IDs
 final visibleTabsProvider = StateNotifierProvider<VisibleTabsNotifier, Set<String>>((ref) {
   return VisibleTabsNotifier(ref);
 });
@@ -41,6 +42,7 @@ class VisibleTabsNotifier extends StateNotifier<Set<String>> {
 
   final Ref ref;
 
+  // Toggles a tab’s visibility in the tab bar
   void toggleVisibility(String id) {
     state = Set.from(state);
     if (state.contains(id)) {
@@ -154,6 +156,7 @@ class CollectionStateNotifier
     } else {
       newId = null;
     }
+    
     ref.read(selectedIdStateProvider.notifier).state = newId;
 
     var map = {...state!};

--- a/lib/screens/home_page/collection_pane.dart
+++ b/lib/screens/home_page/collection_pane.dart
@@ -194,6 +194,9 @@ class RequestItem extends ConsumerWidget {
       editRequestId: editRequestId,
       onTap: () {
         ref.read(selectedIdStateProvider.notifier).state = id;
+        if (!ref.read(visibleTabsProvider).contains(id)) {
+          ref.read(visibleTabsProvider.notifier).toggleVisibility(id);
+        }
         kHomeScaffoldKey.currentState?.closeDrawer();
       },
       onSecondaryTap: () {

--- a/lib/screens/home_page/editor_pane/editor_default.dart
+++ b/lib/screens/home_page/editor_pane/editor_default.dart
@@ -9,33 +9,62 @@ class RequestEditorDefault extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
+    return Stack(
       children: [
-        Text.rich(
-          TextSpan(
-            children: [
-              TextSpan(
-                text: "Click  ",
-                style: Theme.of(context).textTheme.titleMedium,
+        Align(
+          alignment: Alignment.topCenter,
+          child: Padding(
+            padding: const EdgeInsets.only(top: 80.0),
+            child: Opacity(
+              opacity: 0.1,
+              child: const FlutterLogo(
+                size: 400,
               ),
-              WidgetSpan(
-                alignment: PlaceholderAlignment.middle,
-                child: ElevatedButton(
-                  onPressed: () {
-                    ref.read(collectionStateNotifierProvider.notifier).add();
-                  },
-                  child: const Text(
-                    kLabelPlusNew,
-                    style: kTextStyleButton,
+            // TODO: Replace FlutterLogo with apidash_logo
+            // child: Image.asset(
+            //   'assets/apidash_logo.png',
+            //   width: X,
+            //   height: X,
+            // ),
+            // OR use SVG :
+            // child: SvgPicture.asset(
+            //   'assets/apidash_logo.svg',
+            //   width: X,
+            //   height: X,
+            // ),
+            ),
+          ),
+        ),
+        Center(
+          child: Padding(
+            padding: const EdgeInsets.only(top: 200.0),
+            child: Text.rich(
+              TextSpan(
+                children: [
+                  TextSpan(
+                    text: "Click  ",
+                    style: Theme.of(context).textTheme.titleMedium,
                   ),
-                ),
+                  WidgetSpan(
+                    alignment: PlaceholderAlignment.middle,
+                    child: ElevatedButton(
+                      onPressed: () {
+                        ref.read(collectionStateNotifierProvider.notifier).add();
+                      },
+                      child: const Text(
+                        kLabelPlusNew,
+                        style: kTextStyleButton,
+                      ),
+                    ),
+                  ),
+                  TextSpan(
+                    text: "  to start drafting a new API request.",
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ],
               ),
-              TextSpan(
-                text: "  to start drafting a new API request.",
-                style: Theme.of(context).textTheme.titleMedium,
-              ),
-            ],
+              textAlign: TextAlign.center,
+            ),
           ),
         ),
       ],

--- a/lib/screens/home_page/editor_pane/editor_pane.dart
+++ b/lib/screens/home_page/editor_pane/editor_pane.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:apidash/providers/providers.dart';
 import 'editor_default.dart';
 import 'editor_request.dart';
+import 'package:apidash/widgets/logo_apidash.dart';
 
 class RequestEditorPane extends ConsumerWidget {
   const RequestEditorPane({
@@ -12,10 +13,15 @@ class RequestEditorPane extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final selectedId = ref.watch(selectedIdStateProvider);
-    if (selectedId == null) {
+    final collection = ref.watch(collectionStateNotifierProvider);
+
+    if (collection == null || collection.isEmpty) {    //NO collection (empty or null) -> Show logo + text
       return const RequestEditorDefault();
-    } else {
-      return const RequestEditor();
     }
+    if (selectedId == null) {      //  No selectedId -> Show only the logo
+      return const LogoApidash();
+    }
+
+    return const RequestEditor();
   }
 }

--- a/lib/screens/home_page/editor_pane/editor_request.dart
+++ b/lib/screens/home_page/editor_pane/editor_request.dart
@@ -17,7 +17,6 @@ class RequestEditor extends StatelessWidget {
             padding: kPb10,
             child: Column(
               children: [
-                const TabPane(), 
                 kVSpacer20,
                 Expanded(
                   child: const EditRequestPane(),

--- a/lib/screens/home_page/editor_pane/editor_request.dart
+++ b/lib/screens/home_page/editor_pane/editor_request.dart
@@ -5,6 +5,7 @@ import 'details_card/details_card.dart';
 import 'details_card/request_pane/request_pane.dart';
 import 'request_editor_top_bar.dart';
 import 'url_card.dart';
+import 'tab_pane.dart'; 
 
 class RequestEditor extends StatelessWidget {
   const RequestEditor({super.key});
@@ -12,25 +13,28 @@ class RequestEditor extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return context.isMediumWindow
-        ? const Padding(
+        ? Padding(
             padding: kPb10,
             child: Column(
               children: [
+                const TabPane(), 
                 kVSpacer20,
                 Expanded(
-                  child: EditRequestPane(),
+                  child: const EditRequestPane(),
                 ),
               ],
             ),
           )
         : Padding(
             padding: kIsMacOS || kIsWindows ? kPt28o8 : kP8,
-            child: const Column(
+            child: Column(
               children: [
-                RequestEditorTopBar(),
-                EditorPaneRequestURLCard(),
+                const TabPane(), 
                 kVSpacer10,
-                Expanded(
+                const RequestEditorTopBar(),
+                const EditorPaneRequestURLCard(),
+                kVSpacer10,
+                const Expanded(
                   child: EditorPaneRequestDetailsCard(),
                 ),
               ],

--- a/lib/screens/home_page/editor_pane/tab_pane.dart
+++ b/lib/screens/home_page/editor_pane/tab_pane.dart
@@ -5,7 +5,6 @@ import 'package:apidash/consts.dart';
 import 'package:apidash/providers/collection_providers.dart';
 import 'package:apidash/models/models.dart';
 import 'package:apidash/widgets/tab_request_card.dart';
-import 'package:apidash/screens/home_page/collection_pane.dart';
 import 'package:apidash/utils/utils.dart';
 
 class TabPane extends ConsumerWidget {
@@ -16,6 +15,7 @@ class TabPane extends ConsumerWidget {
     final collection = ref.watch(collectionStateNotifierProvider);
     final requestSequence = ref.watch(requestSequenceProvider);
     final selectedId = ref.watch(selectedIdStateProvider);
+    final visibleTabs = ref.watch(visibleTabsProvider);
 
     if (collection == null || requestSequence.isEmpty) {
       return const SizedBox.shrink();
@@ -27,29 +27,36 @@ class TabPane extends ConsumerWidget {
       child: SingleChildScrollView(
         scrollDirection: Axis.horizontal,
         child: ConstrainedBox(
-          constraints: BoxConstraints(
-            minWidth: MediaQuery.of(context).size.width, 
-          ),
+          constraints: BoxConstraints(minWidth: MediaQuery.of(context).size.width),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.start,
-            children: requestSequence.map((id) {
-              final request = collection[id]!;
-              final name = request.name.isNotEmpty
-                  ? request.name
-                  : getRequestTitleFromUrl(request.httpRequestModel?.url) ?? 'Untitled';
-              return TabRequestCard(
-                apiType: request.apiType,
-                method: request.httpRequestModel!.method,
-                name: name,
-                isSelected: selectedId == id,
-                onTap: () {
-                  ref.read(selectedIdStateProvider.notifier).state = id;
-                },
-                onClose: () {
-                  ref.read(collectionStateNotifierProvider.notifier).remove(id: id);
-                },
-              );
-            }).toList(),
+            children: requestSequence
+                .where((id) => visibleTabs.contains(id))
+                .map((id) {
+                  final request = collection[id]!;
+                  final name = request.name.isNotEmpty
+                      ? request.name
+                      : getRequestTitleFromUrl(request.httpRequestModel?.url) ?? 'Untitled';
+                  return TabRequestCard(
+                    apiType: request.apiType,
+                    method: request.httpRequestModel!.method,
+                    name: name,
+                    isSelected: selectedId == id,
+                    onTap: () => ref.read(selectedIdStateProvider.notifier).state = id,
+                    onClose: () {
+                      ref.read(visibleTabsProvider.notifier).toggleVisibility(id);
+                      if (selectedId == id) {
+                        final remainingTabs = requestSequence.where((tabId) => visibleTabs.contains(tabId) && tabId != id).toList();
+                        if (remainingTabs.isNotEmpty) {
+                          ref.read(selectedIdStateProvider.notifier).state = remainingTabs.first;
+                        } else {
+                          ref.read(selectedIdStateProvider.notifier).state = null;
+                        }
+                      }
+                    },
+                  );
+                })
+                .toList(),
           ),
         ),
       ),

--- a/lib/screens/home_page/editor_pane/tab_pane.dart
+++ b/lib/screens/home_page/editor_pane/tab_pane.dart
@@ -17,6 +17,7 @@ class TabPane extends ConsumerWidget {
     final selectedId = ref.watch(selectedIdStateProvider);
     final visibleTabs = ref.watch(visibleTabsProvider);
 
+    // Prevents rendering if data isn’t ready
     if (collection == null || requestSequence.isEmpty) {
       return const SizedBox.shrink();
     }
@@ -24,12 +25,13 @@ class TabPane extends ConsumerWidget {
     return Container(
       color: Theme.of(context).colorScheme.surfaceContainerLowest,
       padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
-      child: SingleChildScrollView(
+      child: SingleChildScrollView(  // horizontal scrolling for the tab bar
         scrollDirection: Axis.horizontal,
         child: ConstrainedBox(
           constraints: BoxConstraints(minWidth: MediaQuery.of(context).size.width),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.start,
+            // Filters and maps only visible tabs for rendering
             children: requestSequence
                 .where((id) => visibleTabs.contains(id))
                 .map((id) {
@@ -37,12 +39,14 @@ class TabPane extends ConsumerWidget {
                   final name = request.name.isNotEmpty
                       ? request.name
                       : getRequestTitleFromUrl(request.httpRequestModel?.url) ?? 'Untitled';
+                      
                   return TabRequestCard(
                     apiType: request.apiType,
                     method: request.httpRequestModel!.method,
                     name: name,
                     isSelected: selectedId == id,
                     onTap: () => ref.read(selectedIdStateProvider.notifier).state = id,
+                    // Manages tab closure and selection adjustment
                     onClose: () {
                       ref.read(visibleTabsProvider.notifier).toggleVisibility(id);
                       if (selectedId == id) {

--- a/lib/screens/home_page/editor_pane/tab_pane.dart
+++ b/lib/screens/home_page/editor_pane/tab_pane.dart
@@ -1,0 +1,58 @@
+import 'package:apidash_design_system/apidash_design_system.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:apidash/consts.dart';
+import 'package:apidash/providers/collection_providers.dart';
+import 'package:apidash/models/models.dart';
+import 'package:apidash/widgets/tab_request_card.dart';
+import 'package:apidash/screens/home_page/collection_pane.dart';
+import 'package:apidash/utils/utils.dart';
+
+class TabPane extends ConsumerWidget {
+  const TabPane({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final collection = ref.watch(collectionStateNotifierProvider);
+    final requestSequence = ref.watch(requestSequenceProvider);
+    final selectedId = ref.watch(selectedIdStateProvider);
+
+    if (collection == null || requestSequence.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Container(
+      color: Theme.of(context).colorScheme.surfaceContainerLowest,
+      padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            minWidth: MediaQuery.of(context).size.width, 
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.start,
+            children: requestSequence.map((id) {
+              final request = collection[id]!;
+              final name = request.name.isNotEmpty
+                  ? request.name
+                  : getRequestTitleFromUrl(request.httpRequestModel?.url) ?? 'Untitled';
+              return TabRequestCard(
+                apiType: request.apiType,
+                method: request.httpRequestModel!.method,
+                name: name,
+                isSelected: selectedId == id,
+                onTap: () {
+                  ref.read(selectedIdStateProvider.notifier).state = id;
+                },
+                onClose: () {
+                  ref.read(collectionStateNotifierProvider.notifier).remove(id: id);
+                },
+              );
+            }).toList(),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/logo_apidash.dart
+++ b/lib/widgets/logo_apidash.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class LogoApidash extends StatelessWidget {
+  const LogoApidash({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Opacity(
+        opacity: 0.1, 
+        child: const FlutterLogo(
+          size: 400, 
+        ),
+        // TODO: Replace FlutterLogo with apidash_logo 
+        // child: Image.asset(
+        //   'assets/apidash_logo.png', 
+        //   width: X,
+        //   height: X,
+        // ),
+        // OR use SVG:
+        // child: SvgPicture.asset(
+        //   'assets/apidash_logo.svg', 
+        //   width: X,
+        //   height: X,
+        // ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/tab_request_card.dart
+++ b/lib/widgets/tab_request_card.dart
@@ -1,0 +1,85 @@
+
+import 'package:apidash_core/apidash_core.dart';
+import 'package:apidash_design_system/apidash_design_system.dart';
+import 'package:flutter/material.dart';
+import 'package:apidash/consts.dart';
+import 'package:apidash/utils/utils.dart';
+import 'package:apidash/widgets/texts.dart';
+
+class TabRequestCard extends StatelessWidget {
+  const TabRequestCard({
+    super.key,
+    required this.apiType,
+    required this.method,
+    required this.name,
+    required this.isSelected,
+    this.onTap,
+    this.onClose,
+  });
+
+  final APIType apiType;
+  final HTTPVerb method;
+  final String name;
+  final bool isSelected;
+  final VoidCallback? onTap;
+  final VoidCallback? onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: isSelected ? 1 : 0,
+      shape: const RoundedRectangleBorder(
+        borderRadius: kBorderRadius8, 
+      ),
+      margin: const EdgeInsets.only(right: 4),
+      child: Stack(
+        children: [
+          InkWell(
+            onTap: onTap,
+            borderRadius: kBorderRadius8,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  SidebarRequestCardTextBox(
+                    apiType: apiType,
+                    method: method,
+                  ),
+                  kHSpacer8,
+                  Text(
+                    name,
+                    overflow: TextOverflow.ellipsis,
+                    maxLines: 1,
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.onSurface,
+                    ),
+                  ),
+                  kHSpacer8,
+                  GestureDetector(
+                    onTap: onClose,
+                    child: Icon(
+                      Icons.close,
+                      size: 16,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          if (isSelected)
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: 0,
+              child: Container(
+                height: 2, 
+                color: Theme.of(context).colorScheme.primary, 
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/tab_request_card.dart
+++ b/lib/widgets/tab_request_card.dart
@@ -5,7 +5,7 @@ import 'package:apidash/consts.dart';
 import 'package:apidash/utils/utils.dart';
 import 'package:apidash/widgets/texts.dart';
 
-class TabRequestCard extends StatelessWidget {
+class TabRequestCard extends StatefulWidget {
   const TabRequestCard({
     super.key,
     required this.apiType,
@@ -24,43 +24,60 @@ class TabRequestCard extends StatelessWidget {
   final VoidCallback? onClose;
 
   @override
+  State<TabRequestCard> createState() => _TabRequestCardState();
+}
+
+class _TabRequestCardState extends State<TabRequestCard> {
+  bool _isHovering = false;
+
+  @override
   Widget build(BuildContext context) {
     return Card(
-      elevation: isSelected ? 1 : 0,
+      elevation: widget.isSelected ? 1 : 0,
       shape: const RoundedRectangleBorder(borderRadius: kBorderRadius8),
       margin: const EdgeInsets.only(right: 4),
       child: Stack(
         children: [
-          InkWell(
-            onTap: onTap,
-            borderRadius: kBorderRadius8,
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  SidebarRequestCardTextBox(apiType: apiType, method: method),
-                  kHSpacer8,
-                  Text(
-                    name,
-                    overflow: TextOverflow.ellipsis,
-                    maxLines: 1,
-                    style: TextStyle(color: Theme.of(context).colorScheme.onSurface),
-                  ),
-                  kHSpacer8,
-                  GestureDetector(
-                    onTap: onClose,
-                    child: Icon(
-                      Icons.close,
-                      size: 16,
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+          // MouseRegion to detect hover state
+          MouseRegion(
+            onEnter: (_) => setState(() => _isHovering = true),
+            onExit: (_) => setState(() => _isHovering = false),
+            child: InkWell(
+              onTap: widget.onTap,
+              borderRadius: kBorderRadius8,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    SidebarRequestCardTextBox(apiType: widget.apiType, method: widget.method),
+                    kHSpacer8,
+                    Text(
+                      widget.name,
+                      overflow: TextOverflow.ellipsis,
+                      maxLines: 1,
+                      style: TextStyle(color: Theme.of(context).colorScheme.onSurface),
                     ),
-                  ),
-                ],
+                    kHSpacer8,
+                    // Show close button only when hovering
+                    if (_isHovering)
+                      GestureDetector(
+                        onTap: widget.onClose,
+                        child: Icon(
+                          Icons.close,
+                          size: 16,
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    // Add space even when close button is not visible
+                    if (!_isHovering)
+                      const SizedBox(width: 16),
+                  ],
+                ),
               ),
             ),
           ),
-          if (isSelected)
+          if (widget.isSelected) // Adds a visual indicator for the selected tab as mentioned in wireframe
             Positioned(
               left: 0,
               right: 0,

--- a/lib/widgets/tab_request_card.dart
+++ b/lib/widgets/tab_request_card.dart
@@ -1,4 +1,3 @@
-
 import 'package:apidash_core/apidash_core.dart';
 import 'package:apidash_design_system/apidash_design_system.dart';
 import 'package:flutter/material.dart';
@@ -28,9 +27,7 @@ class TabRequestCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Card(
       elevation: isSelected ? 1 : 0,
-      shape: const RoundedRectangleBorder(
-        borderRadius: kBorderRadius8, 
-      ),
+      shape: const RoundedRectangleBorder(borderRadius: kBorderRadius8),
       margin: const EdgeInsets.only(right: 4),
       child: Stack(
         children: [
@@ -42,18 +39,13 @@ class TabRequestCard extends StatelessWidget {
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  SidebarRequestCardTextBox(
-                    apiType: apiType,
-                    method: method,
-                  ),
+                  SidebarRequestCardTextBox(apiType: apiType, method: method),
                   kHSpacer8,
                   Text(
                     name,
                     overflow: TextOverflow.ellipsis,
                     maxLines: 1,
-                    style: TextStyle(
-                      color: Theme.of(context).colorScheme.onSurface,
-                    ),
+                    style: TextStyle(color: Theme.of(context).colorScheme.onSurface),
                   ),
                   kHSpacer8,
                   GestureDetector(
@@ -74,8 +66,8 @@ class TabRequestCard extends StatelessWidget {
               right: 0,
               bottom: 0,
               child: Container(
-                height: 2, 
-                color: Theme.of(context).colorScheme.primary, 
+                height: 2,
+                color: Theme.of(context).colorScheme.primary,
               ),
             ),
         ],

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -61,3 +61,4 @@ export 'texts.dart';
 export 'uint8_audio_player.dart';
 export 'window_caption.dart';
 export 'workspace_selector.dart';
+export 'logo_apidash.dart';


### PR DESCRIPTION
## PR Description

The tab bar in this application is implemented primarily in `tab_pane.dart `and` tab_request.dart`, with state management handled in `collections_provider.dart`. The tab bar displays a list of API requests (represented as tabs) that the user can interact with—selecting a tab, closing it, or reordering it. The collections_pane.dart file complements this by managing the collection of requests that populate the tab bar.

### 1. Workflow

**`TabRequestCard` (tab_request.dart):**

1. A stateless widget representing an individual tab.
2. Displays the API type, HTTP method, request name, and a close button.
3. Handles two main user interactions:
4. **onTap**: Triggers when the tab is clicked, typically to select it.
5. `onClose`: Triggers when the close icon is tapped to hide the tab.

> Visual feedback: Selected tabs have a bottom border (via `Positioned` widget) and slight elevation.


**`TabPane` (tab_pane.dart):**

1. A `consumer` widget that builds the entire tab bar using Riverpod for state management.
2. Uses a horizontal `SingleChildScrollView` to display all visible tabs.
3. The close button is visible only when hovering over the tab in the tab bar.

**_Workflow steps:_**

1. Fetches the `requestSequence` (order of requests) and `visibleTabs` (subset of tabs to display).
2. Maps each visible `requestID` to a TabRequestCard.
4. Handles tab selection by updating `selectedIdStateProvider` via `onTap`.
5. Manages tab closure via `onClose`:
6. Toggles visibility in `visibleTabsProvider`.
7. Adjusts the selected tab if the closed tab was active (selects the first remaining tab or null if none remain).

### 2.User Interaction Flow

**Opening a Tab** :  When a request is selected from the collection pane (`collections_pane.dart`), its ID is added to `visibleTabs` and potentially selectedId (via `onTap` in `RequestItem`).

**Selecting a Tab** : Clicking a `TabRequestCard` updates selectedId, highlighting the tab and loading its associated request data.

**Closing a Tab** : Clicking the close button removes the tab from `visibleTabs` and adjusts the selected tab if necessary.

**Dynamic Updates** :  Adding, removing, or reordering requests in `collections_provider.dart` reflects in the tab bar via `requestSequence`.

**3.`logo_apidash.dart`**
   A stateless widget displaying a centered, faded FlutterLogo (opacity 0.1, size 400) as a placeholder for an apidash_logo.

- Intended for use when no request is selected but a collection exists.
- if no collection presents ,displays logo with create new request button 

**Logic changes from the original code:**

- Current: If no collection exists, a new one is created and automatically selected.
- Updated: If no collection exists, a new one is created but not selected. Instead, the default screen (logo) is displayed.
 
 **TODO**:

1. Implement the tab bar for mobile platforms.
2. Replace the Flutter logo with the Apidash logo in `editor_default.dart` and `logo_apidash.dart.`
3. Allow reordering of requests through the tab bar.

**WORKING VIDEO :**


https://github.com/user-attachments/assets/8ca5e7df-12ec-47f5-aa46-305ae697b8e3


## Related Issues 

- Closes #
#306 
### Checklist
- [X] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [X] I have updated my branch and synced it with project `main` branch before making this PR
- [X] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [X] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: Tests will be added after implementation approach is finalized and reviewed.

## OS on which you have developed and tested the feature?

- [X] Windows
- [ ] macOS
- [X] Linux
