### PR TITLE
feat : Added Basic Authorization in API request

### DIFF
--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -438,6 +438,7 @@ const kLabelRequest = "Request";
 const kLabelHideCode = "Hide Code";
 const kLabelViewCode = "View Code";
 const kLabelURLParams = "URL Params";
+const kLabelAuth = "Authorization";
 const kLabelHeaders = "Headers";
 const kLabelBody = "Body";
 const kLabelQuery = "Query";

--- a/lib/providers/auth_providers.dart
+++ b/lib/providers/auth_providers.dart
@@ -1,0 +1,30 @@
+import 'dart:convert';
+import 'package:apidash_core/consts.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+// Provider for selected auth type
+final authTypeProvider = StateProvider<AuthType>((ref) => AuthType.none);
+
+// Provider for auth data (e.g., username/password for Basic Auth)
+final authDataProvider = StateProvider<Map<String, String>?>((ref) => null);
+
+// Provider to compute the Authorization header
+final authHeaderProvider = Provider<String?>((ref) {
+  final authType = ref.watch(authTypeProvider);
+  final authData = ref.watch(authDataProvider);
+
+  if (authType == AuthType.none || authData == null || authData.isEmpty) {
+    return null;
+  }
+
+  switch (authType) {
+    case AuthType.basic:
+      final username = authData['username'] ?? '';
+      final password = authData['password'] ?? '';
+      if (username.isEmpty && password.isEmpty) return null;
+      final authString = base64Encode(utf8.encode('$username:$password'));
+      return 'Basic $authString';
+    case AuthType.none:
+      return null;
+  }
+});

--- a/lib/providers/auth_providers.dart
+++ b/lib/providers/auth_providers.dart
@@ -18,7 +18,7 @@ final authHeaderProvider = Provider<String?>((ref) {
   }
 
   switch (authType) {
-    case AuthType.basic:
+   case AuthType.basic:
       final username = authData['username'] ?? '';
       final password = authData['password'] ?? '';
       if (username.isEmpty && password.isEmpty) return null;

--- a/lib/providers/auth_providers.dart
+++ b/lib/providers/auth_providers.dart
@@ -18,7 +18,19 @@ final authHeaderProvider = Provider<String?>((ref) {
   }
 
   switch (authType) {
-   case AuthType.basic:
+    case AuthType.oAuth2:
+      return null;
+    case AuthType.oAuth1:
+      return null;
+    case AuthType.digest:
+      return null;
+    case AuthType.jwtBearer:
+      return null;
+    case AuthType.bearer:
+      return null;
+    case AuthType.apiKey:
+      return null;
+    case AuthType.basic:
       final username = authData['username'] ?? '';
       final password = authData['password'] ?? '';
       if (username.isEmpty && password.isEmpty) return null;

--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -1,3 +1,4 @@
+import 'package:apidash/providers/auth_providers.dart';
 import 'package:apidash_core/apidash_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -279,6 +280,7 @@ class CollectionStateNotifier
     APIType apiType = requestModel!.apiType;
     HttpRequestModel substitutedHttpRequestModel =
         getSubstitutedHttpRequestModel(requestModel.httpRequestModel!);
+    final authHeader = ref.read(authHeaderProvider);
 
     // set current model's isWorking to true and update state
     var map = {...state!};
@@ -293,6 +295,7 @@ class CollectionStateNotifier
       requestId,
       apiType,
       substitutedHttpRequestModel,
+      authHeader: authHeader,
       defaultUriScheme: defaultUriScheme,
       noSSL: noSSL,
     );

--- a/lib/screens/dashboard.dart
+++ b/lib/screens/dashboard.dart
@@ -4,7 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:apidash/providers/providers.dart';
 import 'package:apidash/widgets/widgets.dart';
 import 'package:apidash/consts.dart';
-import 'package:apidash/dashbot/dashbot.dart';
+//import 'package:apidash/dashbot/dashbot.dart';
 import 'common_widgets/common_widgets.dart';
 import 'envvar/environment_page.dart';
 import 'home_page/home_page.dart';

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_auth.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_auth.dart
@@ -5,18 +5,35 @@ import 'package:apidash_design_system/tokens/measurements.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class EditRequestAuth extends ConsumerWidget {
+class EditRequestAuth extends ConsumerStatefulWidget {
   const EditRequestAuth({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<EditRequestAuth> createState() => _EditRequestAuthState();
+}
+
+class _EditRequestAuthState extends ConsumerState<EditRequestAuth> {
+  late final TextEditingController usernameController;
+  late final TextEditingController passwordController;
+
+  @override
+  void initState() {
+    super.initState();
+    usernameController = TextEditingController();
+    passwordController = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    usernameController.dispose();
+    passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final authData = ref.watch(authDataProvider) ?? {};
     final authType = ref.watch(authTypeProvider);
-
-    final usernameController =
-        TextEditingController(text: authData['username'] ?? '');
-    final passwordController =
-        TextEditingController(text: authData['password'] ?? '');
 
     return Padding(
       padding: const EdgeInsets.all(8.0),
@@ -39,63 +56,61 @@ class EditRequestAuth extends ConsumerWidget {
                       }
                     }
                   },
-                ), // Reusable dropdown
+                ),
               ],
             ),
           ),
           if (authType == AuthType.basic) ...[
             Padding(
-              padding: kPt5o10, // Consistent padding
+              padding: kPt5o10,
               child: TextField(
-                controller: usernameController,
-                decoration: const InputDecoration(
-                  labelText: 'Username',
-                  border: OutlineInputBorder(
-                    borderSide: BorderSide(color: Colors.blue),
-                    borderRadius: BorderRadius.all(
-                      Radius.circular(16),
+                  controller: usernameController,
+                  decoration: const InputDecoration(
+                    labelText: 'Username',
+                    border: OutlineInputBorder(
+                      borderSide: BorderSide(color: Colors.blue),
+                      borderRadius: BorderRadius.all(
+                        Radius.circular(16),
+                      ),
                     ),
-                  ),
-                  focusedBorder: const OutlineInputBorder(
-                    borderSide: BorderSide(color: Colors.blue),
-                    borderRadius: BorderRadius.all(
-                      Radius.circular(16),
+                    focusedBorder: OutlineInputBorder(
+                      borderSide: BorderSide(color: Colors.blue),
+                      borderRadius: BorderRadius.all(
+                        Radius.circular(16),
+                      ),
                     ),
+                    fillColor: Colors.white,
+                    filled: true,
                   ),
-                  fillColor: Colors.white,
-                  filled: true,
-                ),
-                textDirection: TextDirection.ltr,
-                onChanged: (value) =>
-                    _updateAuth(ref, usernameController, passwordController),
-              ),
+                  onChanged: (value) {
+                    _updateAuth(ref, usernameController, passwordController);
+                  }),
             ),
             Padding(
               padding: kPt5o10,
               child: TextField(
-                controller: passwordController,
-                decoration: const InputDecoration(
-                  labelText: 'Password',
-                  border: OutlineInputBorder(
-                    borderSide: BorderSide(color: Colors.blue),
-                    borderRadius: BorderRadius.all(
-                      Radius.circular(16),
+                  controller: passwordController,
+                  decoration: const InputDecoration(
+                    labelText: 'Password',
+                    border: OutlineInputBorder(
+                      borderSide: BorderSide(color: Colors.blue),
+                      borderRadius: BorderRadius.all(
+                        Radius.circular(16),
+                      ),
                     ),
-                  ),
-                  focusedBorder: const OutlineInputBorder(
-                    borderSide: BorderSide(color: Colors.blue),
-                    borderRadius: BorderRadius.all(
-                      Radius.circular(16),
+                    focusedBorder: OutlineInputBorder(
+                      borderSide: BorderSide(color: Colors.blue),
+                      borderRadius: BorderRadius.all(
+                        Radius.circular(16),
+                      ),
                     ),
+                    fillColor: Colors.white,
+                    filled: true,
                   ),
-                  fillColor: Colors.white,
-                  filled: true,
-                ),
-                textDirection: TextDirection.ltr,
-                obscureText: true,
-                onChanged: (value) =>
-                    _updateAuth(ref, usernameController, passwordController),
-              ),
+                  obscureText: true,
+                  onChanged: (value) {
+                    _updateAuth(ref, usernameController, passwordController);
+                  }),
             ),
           ],
         ],
@@ -128,13 +143,11 @@ class DropdownButtonAuthType extends StatelessWidget {
     return DropdownButton<AuthType>(
       value: authType,
       onChanged: onChanged,
-      dropdownColor: Colors.white, // Background color of dropdown menu
-      icon:
-          const Icon(Icons.arrow_drop_down, color: Colors.blue), // Custom icon
+      dropdownColor: Colors.white,
+      icon: const Icon(Icons.arrow_drop_down, color: Colors.blue),
       underline: Container(height: 0),
-      padding:
-          const EdgeInsets.symmetric(horizontal: 12.0), // Padding inside button
-      borderRadius: BorderRadius.circular(8.0), // Rounded corners for menu
+      padding: const EdgeInsets.symmetric(horizontal: 12.0),
+      borderRadius: BorderRadius.circular(8.0),
       elevation: 4,
       items: const [
         DropdownMenuItem(

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_auth.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_auth.dart
@@ -1,0 +1,78 @@
+import 'package:apidash/providers/auth_providers.dart';
+import 'package:apidash_core/apidash_core.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:apidash/providers/providers.dart';
+import 'package:apidash/widgets/widgets.dart';
+
+class EditRequestAuth extends ConsumerWidget {
+  const EditRequestAuth({super.key});
+
+ @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final authData = ref.watch(authDataProvider) ?? {};
+
+    final usernameController = TextEditingController(text: authData['username'] ?? '');
+    final passwordController = TextEditingController(text: authData['password'] ?? '');
+
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Basic Authorization',
+            style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            controller: usernameController,
+            decoration: const InputDecoration(
+              labelText: 'Username',
+              border: OutlineInputBorder(),
+            ),
+            onChanged: (value) => _updateAuth(ref, usernameController, passwordController),
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            controller: passwordController,
+            decoration: const InputDecoration(
+              labelText: 'Password',
+              border: OutlineInputBorder(),
+            ),
+            obscureText: true,
+            onChanged: (value) => _updateAuth(ref, usernameController, passwordController),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _updateAuth(WidgetRef ref, TextEditingController usernameController, TextEditingController passwordController) {
+    ref.read(authTypeProvider.notifier).state = AuthType.basic;
+    ref.read(authDataProvider.notifier).state = {
+      'username': usernameController.text,
+      'password': passwordController.text,
+    };
+  }
+}
+class DropdownButtonAuthType extends ConsumerWidget {
+  const DropdownButtonAuthType({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.watch(selectedIdStateProvider);
+    final requestAuthType = ref.watch(selectedRequestModelProvider
+        .select((value) => value?.httpRequestModel?.bodyContentType));
+    return DropdownButtonContentType(
+      contentType: requestAuthType,
+      onChanged: (ContentType? value) {
+        ref
+            .read(collectionStateNotifierProvider.notifier)
+            .update(bodyContentType: value);
+      },
+    );
+  }
+}

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_auth.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_auth.dart
@@ -1,5 +1,7 @@
 import 'package:apidash/consts.dart';
 import 'package:apidash/providers/auth_providers.dart';
+import 'package:apidash/widgets/dropdown_auth_type.dart';
+import 'package:apidash/widgets/text_auth.dart';
 import 'package:apidash_core/apidash_core.dart';
 import 'package:apidash_design_system/tokens/measurements.dart';
 import 'package:flutter/material.dart';
@@ -63,54 +65,25 @@ class _EditRequestAuthState extends ConsumerState<EditRequestAuth> {
           if (authType == AuthType.basic) ...[
             Padding(
               padding: kPt5o10,
-              child: TextField(
-                  controller: usernameController,
-                  decoration: const InputDecoration(
-                    labelText: 'Username',
-                    border: OutlineInputBorder(
-                      borderSide: BorderSide(color: Colors.blue),
-                      borderRadius: BorderRadius.all(
-                        Radius.circular(16),
-                      ),
-                    ),
-                    focusedBorder: OutlineInputBorder(
-                      borderSide: BorderSide(color: Colors.blue),
-                      borderRadius: BorderRadius.all(
-                        Radius.circular(16),
-                      ),
-                    ),
-                    fillColor: Colors.white,
-                    filled: true,
-                  ),
-                  onChanged: (value) {
-                    _updateAuth(ref, usernameController, passwordController);
-                  }),
+              child: AuthTextField(
+                controller: usernameController,
+                labelText: 'Username',
+                obscureText: false,
+                onChanged: (value) {
+                  _updateAuth(ref, usernameController, passwordController);
+                },
+              ),
             ),
             Padding(
               padding: kPt5o10,
-              child: TextField(
-                  controller: passwordController,
-                  decoration: const InputDecoration(
-                    labelText: 'Password',
-                    border: OutlineInputBorder(
-                      borderSide: BorderSide(color: Colors.blue),
-                      borderRadius: BorderRadius.all(
-                        Radius.circular(16),
-                      ),
-                    ),
-                    focusedBorder: OutlineInputBorder(
-                      borderSide: BorderSide(color: Colors.blue),
-                      borderRadius: BorderRadius.all(
-                        Radius.circular(16),
-                      ),
-                    ),
-                    fillColor: Colors.white,
-                    filled: true,
-                  ),
-                  obscureText: true,
-                  onChanged: (value) {
-                    _updateAuth(ref, usernameController, passwordController);
-                  }),
+              child: AuthTextField(
+                controller: passwordController,
+                labelText: 'Password',
+                obscureText: true,
+                onChanged: (value) {
+                  _updateAuth(ref, usernameController, passwordController);
+                },
+              ),
             ),
           ],
         ],
@@ -125,40 +98,5 @@ class _EditRequestAuthState extends ConsumerState<EditRequestAuth> {
       'username': usernameController.text,
       'password': passwordController.text,
     };
-  }
-}
-
-class DropdownButtonAuthType extends StatelessWidget {
-  final AuthType authType;
-  final ValueChanged<AuthType?> onChanged;
-
-  const DropdownButtonAuthType({
-    super.key,
-    required this.authType,
-    required this.onChanged,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return DropdownButton<AuthType>(
-      value: authType,
-      onChanged: onChanged,
-      dropdownColor: Colors.white,
-      icon: const Icon(Icons.arrow_drop_down, color: Colors.blue),
-      underline: Container(height: 0),
-      padding: const EdgeInsets.symmetric(horizontal: 12.0),
-      borderRadius: BorderRadius.circular(8.0),
-      elevation: 4,
-      items: const [
-        DropdownMenuItem(
-          value: AuthType.none,
-          child: Text('None'),
-        ),
-        DropdownMenuItem(
-          value: AuthType.basic,
-          child: Text('Basic'),
-        ),
-      ],
-    );
   }
 }

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_auth.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_auth.dart
@@ -1,54 +1,110 @@
+import 'package:apidash/consts.dart';
 import 'package:apidash/providers/auth_providers.dart';
 import 'package:apidash_core/apidash_core.dart';
+import 'package:apidash_design_system/tokens/measurements.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:apidash/providers/providers.dart';
-import 'package:apidash/widgets/widgets.dart';
 
 class EditRequestAuth extends ConsumerWidget {
   const EditRequestAuth({super.key});
 
- @override
+  @override
   Widget build(BuildContext context, WidgetRef ref) {
     final authData = ref.watch(authDataProvider) ?? {};
+    final authType = ref.watch(authTypeProvider);
 
-    final usernameController = TextEditingController(text: authData['username'] ?? '');
-    final passwordController = TextEditingController(text: authData['password'] ?? '');
+    final usernameController =
+        TextEditingController(text: authData['username'] ?? '');
+    final passwordController =
+        TextEditingController(text: authData['password'] ?? '');
 
     return Padding(
       padding: const EdgeInsets.all(8.0),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text(
-            'Basic Authorization',
-            style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-          ),
-          const SizedBox(height: 8),
-          TextField(
-            controller: usernameController,
-            decoration: const InputDecoration(
-              labelText: 'Username',
-              border: OutlineInputBorder(),
+          SizedBox(
+            height: kHeaderHeight,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                const Text('Select Authorization Type:'),
+                DropdownButtonAuthType(
+                  authType: authType,
+                  onChanged: (AuthType? value) {
+                    if (value != null) {
+                      ref.read(authTypeProvider.notifier).state = value;
+                      if (value == AuthType.none) {
+                        ref.read(authDataProvider.notifier).state = null;
+                      }
+                    }
+                  },
+                ), // Reusable dropdown
+              ],
             ),
-            onChanged: (value) => _updateAuth(ref, usernameController, passwordController),
           ),
-          const SizedBox(height: 8),
-          TextField(
-            controller: passwordController,
-            decoration: const InputDecoration(
-              labelText: 'Password',
-              border: OutlineInputBorder(),
+          if (authType == AuthType.basic) ...[
+            Padding(
+              padding: kPt5o10, // Consistent padding
+              child: TextField(
+                controller: usernameController,
+                decoration: const InputDecoration(
+                  labelText: 'Username',
+                  border: OutlineInputBorder(
+                    borderSide: BorderSide(color: Colors.blue),
+                    borderRadius: BorderRadius.all(
+                      Radius.circular(16),
+                    ),
+                  ),
+                  focusedBorder: const OutlineInputBorder(
+                    borderSide: BorderSide(color: Colors.blue),
+                    borderRadius: BorderRadius.all(
+                      Radius.circular(16),
+                    ),
+                  ),
+                  fillColor: Colors.white,
+                  filled: true,
+                ),
+                textDirection: TextDirection.ltr,
+                onChanged: (value) =>
+                    _updateAuth(ref, usernameController, passwordController),
+              ),
             ),
-            obscureText: true,
-            onChanged: (value) => _updateAuth(ref, usernameController, passwordController),
-          ),
+            Padding(
+              padding: kPt5o10,
+              child: TextField(
+                controller: passwordController,
+                decoration: const InputDecoration(
+                  labelText: 'Password',
+                  border: OutlineInputBorder(
+                    borderSide: BorderSide(color: Colors.blue),
+                    borderRadius: BorderRadius.all(
+                      Radius.circular(16),
+                    ),
+                  ),
+                  focusedBorder: const OutlineInputBorder(
+                    borderSide: BorderSide(color: Colors.blue),
+                    borderRadius: BorderRadius.all(
+                      Radius.circular(16),
+                    ),
+                  ),
+                  fillColor: Colors.white,
+                  filled: true,
+                ),
+                textDirection: TextDirection.ltr,
+                obscureText: true,
+                onChanged: (value) =>
+                    _updateAuth(ref, usernameController, passwordController),
+              ),
+            ),
+          ],
         ],
       ),
     );
   }
 
-  void _updateAuth(WidgetRef ref, TextEditingController usernameController, TextEditingController passwordController) {
+  void _updateAuth(WidgetRef ref, TextEditingController usernameController,
+      TextEditingController passwordController) {
     ref.read(authTypeProvider.notifier).state = AuthType.basic;
     ref.read(authDataProvider.notifier).state = {
       'username': usernameController.text,
@@ -56,23 +112,40 @@ class EditRequestAuth extends ConsumerWidget {
     };
   }
 }
-class DropdownButtonAuthType extends ConsumerWidget {
+
+class DropdownButtonAuthType extends StatelessWidget {
+  final AuthType authType;
+  final ValueChanged<AuthType?> onChanged;
+
   const DropdownButtonAuthType({
     super.key,
+    required this.authType,
+    required this.onChanged,
   });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    ref.watch(selectedIdStateProvider);
-    final requestAuthType = ref.watch(selectedRequestModelProvider
-        .select((value) => value?.httpRequestModel?.bodyContentType));
-    return DropdownButtonContentType(
-      contentType: requestAuthType,
-      onChanged: (ContentType? value) {
-        ref
-            .read(collectionStateNotifierProvider.notifier)
-            .update(bodyContentType: value);
-      },
+  Widget build(BuildContext context) {
+    return DropdownButton<AuthType>(
+      value: authType,
+      onChanged: onChanged,
+      dropdownColor: Colors.white, // Background color of dropdown menu
+      icon:
+          const Icon(Icons.arrow_drop_down, color: Colors.blue), // Custom icon
+      underline: Container(height: 0),
+      padding:
+          const EdgeInsets.symmetric(horizontal: 12.0), // Padding inside button
+      borderRadius: BorderRadius.circular(8.0), // Rounded corners for menu
+      elevation: 4,
+      items: const [
+        DropdownMenuItem(
+          value: AuthType.none,
+          child: Text('None'),
+        ),
+        DropdownMenuItem(
+          value: AuthType.basic,
+          child: Text('Basic'),
+        ),
+      ],
     );
   }
 }

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_pane_graphql.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_pane_graphql.dart
@@ -1,4 +1,7 @@
 import 'package:apidash/consts.dart';
+import 'package:apidash/providers/auth_providers.dart';
+import 'package:apidash/screens/home_page/editor_pane/details_card/request_pane/request_auth.dart';
+import 'package:apidash_core/consts.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:apidash/providers/providers.dart';
@@ -18,6 +21,8 @@ class EditGraphQLRequestPane extends ConsumerWidget {
     final headerLength = ref.watch(selectedRequestModelProvider
             .select((value) => value?.httpRequestModel?.headersMap.length)) ??
         0;
+    final hasAuth = ref.watch(authTypeProvider) != AuthType.none &&
+        (ref.watch(authDataProvider)?.isNotEmpty ?? false);
     final hasQuery = ref.watch(selectedRequestModelProvider
             .select((value) => value?.httpRequestModel?.hasQuery)) ??
         false;
@@ -39,14 +44,17 @@ class EditGraphQLRequestPane extends ConsumerWidget {
       },
       showIndicators: [
         headerLength > 0,
+        hasAuth,
         hasQuery,
       ],
       tabLabels: const [
         kLabelHeaders,
+        kLabelAuth,
         kLabelQuery,
       ],
       children: const [
         EditRequestHeaders(),
+        EditRequestAuth(),
         EditRequestBody(),
       ],
     );

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_pane_rest.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_pane_rest.dart
@@ -1,4 +1,7 @@
 import 'package:apidash/consts.dart';
+import 'package:apidash/providers/auth_providers.dart';
+import 'package:apidash/screens/home_page/editor_pane/details_card/request_pane/request_auth.dart';
+import 'package:apidash_core/consts.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:apidash/providers/providers.dart';
@@ -20,6 +23,9 @@ class EditRestRequestPane extends ConsumerWidget {
     final headerLength = ref.watch(selectedRequestModelProvider
             .select((value) => value?.httpRequestModel?.headersMap.length)) ??
         0;
+    final hasAuth = ref.watch(authTypeProvider) !=
+            AuthType.none &&
+        (ref.watch(authDataProvider)?.isNotEmpty ?? false);
     final paramLength = ref.watch(selectedRequestModelProvider
             .select((value) => value?.httpRequestModel?.paramsMap.length)) ??
         0;
@@ -42,16 +48,19 @@ class EditRestRequestPane extends ConsumerWidget {
       },
       showIndicators: [
         paramLength > 0,
+        hasAuth,
         headerLength > 0,
         hasBody,
       ],
       tabLabels: const [
         kLabelURLParams,
+        kLabelAuth,
         kLabelHeaders,
         kLabelBody,
       ],
       children: const [
         EditRequestURLParams(),
+        EditRequestAuth(),
         EditRequestHeaders(),
         EditRequestBody(),
       ],

--- a/lib/widgets/dropdown_auth_type.dart
+++ b/lib/widgets/dropdown_auth_type.dart
@@ -1,0 +1,61 @@
+import 'package:apidash_core/apidash_core.dart';
+import 'package:flutter/material.dart';
+
+class DropdownButtonAuthType extends StatelessWidget {
+  final AuthType authType;
+  final ValueChanged<AuthType?> onChanged;
+
+  const DropdownButtonAuthType({
+    super.key,
+    required this.authType,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return DropdownButton<AuthType>(
+      value: authType,
+      onChanged: onChanged,
+      dropdownColor: Colors.white,
+      icon: const Icon(Icons.arrow_drop_down, color: Colors.blue),
+      underline: Container(height: 0),
+      padding: const EdgeInsets.symmetric(horizontal: 12.0),
+      borderRadius: BorderRadius.circular(8.0),
+      elevation: 4,
+      items: const [
+        DropdownMenuItem(
+          value: AuthType.none,
+          child: Text('None'),
+        ),
+        DropdownMenuItem(
+          value: AuthType.basic,
+          child: Text('Basic'),
+        ),
+        DropdownMenuItem(
+          value: AuthType.apiKey,
+          child: Text('API Key'),
+        ),
+        DropdownMenuItem(
+          value: AuthType.bearer,
+          child: Text('Bearer Token'),
+        ),
+        DropdownMenuItem(
+          value: AuthType.jwtBearer,
+          child: Text('JWT Bearer'),
+        ),
+        DropdownMenuItem(
+          value: AuthType.digest,
+          child: Text('Digest Auth'),
+        ),
+        DropdownMenuItem(
+          value: AuthType.oAuth1,
+          child: Text('OAuth1.0'),
+        ),
+        DropdownMenuItem(
+          value: AuthType.oAuth2,
+          child: Text('OAuth2.0'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/text_auth.dart
+++ b/lib/widgets/text_auth.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+class AuthTextField extends StatelessWidget {
+  // ignore: prefer_typing_uninitialized_variables
+  final controller;
+  final String labelText;
+  final bool obscureText;
+  final void Function(String)? onChanged;
+
+  const AuthTextField({
+    super.key,
+    required this.controller,
+    required this.labelText,
+    required this.obscureText,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(4),
+      child: TextField(
+        onChanged: onChanged,
+        controller: controller,
+        obscureText: obscureText,
+        decoration: InputDecoration(
+          enabledBorder: const OutlineInputBorder(
+            borderSide: BorderSide(color: Colors.grey),
+            borderRadius: BorderRadius.all(
+              Radius.circular(16),
+            ),
+          ),
+          focusedBorder: const OutlineInputBorder(
+            borderSide: BorderSide(color: Colors.blue),
+            borderRadius: BorderRadius.all(
+              Radius.circular(16),
+            ),
+          ),
+          fillColor: Colors.white,
+          filled: true,
+          labelText: labelText,
+        ),
+      ),
+    );
+  }
+}

--- a/packages/apidash_core/lib/consts.dart
+++ b/packages/apidash_core/lib/consts.dart
@@ -86,8 +86,16 @@ enum ContentType {
 }
 
 enum AuthType {
-  none,
-  basic,
+  none("None"),
+  basic("Basic Auth"),
+  apiKey("API Key"),
+  bearer("Bearer Token"),
+  jwtBearer("JWT Bearer"),
+  digest("Digest Auth"),
+  oAuth1("OAuth 1.0"),
+  oAuth2("OAuth 2.0");
+  const AuthType(this.header);
+  final String header;
 }
 
 const JsonEncoder kJsonEncoder = JsonEncoder.withIndent('  ');

--- a/packages/apidash_core/lib/consts.dart
+++ b/packages/apidash_core/lib/consts.dart
@@ -84,7 +84,8 @@ enum ContentType {
   const ContentType(this.header);
   final String header;
 }
-enum AuthType{
+
+enum AuthType {
   none,
   basic,
 }

--- a/packages/apidash_core/lib/consts.dart
+++ b/packages/apidash_core/lib/consts.dart
@@ -84,6 +84,10 @@ enum ContentType {
   const ContentType(this.header);
   final String header;
 }
+enum AuthType{
+  none,
+  basic,
+}
 
 const JsonEncoder kJsonEncoder = JsonEncoder.withIndent('  ');
 const JsonDecoder kJsonDecoder = JsonDecoder();

--- a/packages/apidash_core/lib/services/http_service.dart
+++ b/packages/apidash_core/lib/services/http_service.dart
@@ -1,6 +1,5 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'dart:async';
-import 'dart:convert';
+import 'dart:convert'; 
 import 'dart:io';
 import 'package:http/http.dart' as http;
 import 'package:seed/seed.dart';
@@ -17,7 +16,7 @@ Future<(HttpResponse?, Duration?, String?)> sendHttpRequest(
   String requestId,
   APIType apiType,
   HttpRequestModel requestModel, {
-    required Ref ref,
+  String? authHeader,
   SupportedUriSchemes defaultUriScheme = kDefaultUriScheme,
   bool noSSL = false,
 }) async {
@@ -31,7 +30,10 @@ Future<(HttpResponse?, Duration?, String?)> sendHttpRequest(
 
   if (uriRec.$1 != null) {
     Uri requestUrl = uriRec.$1!;
-    Map<String, String> headers = requestModel.enabledHeadersMap;
+    Map<String, String> headers = {
+      ...requestModel.enabledHeadersMap,
+      if (authHeader != null) 'Authorization': authHeader,
+    };
     HttpResponse? response;
     String? body;
     try {

--- a/packages/apidash_core/lib/services/http_service.dart
+++ b/packages/apidash_core/lib/services/http_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
@@ -16,6 +17,7 @@ Future<(HttpResponse?, Duration?, String?)> sendHttpRequest(
   String requestId,
   APIType apiType,
   HttpRequestModel requestModel, {
+    required Ref ref,
   SupportedUriSchemes defaultUriScheme = kDefaultUriScheme,
   bool noSSL = false,
 }) async {

--- a/packages/apidash_core/pubspec.yaml
+++ b/packages/apidash_core/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
     path: ../postman
   seed: ^0.0.3
   xml: ^6.3.0
+  flutter_riverpod: ^2.5.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/apidash_core/pubspec.yaml
+++ b/packages/apidash_core/pubspec.yaml
@@ -23,7 +23,6 @@ dependencies:
     path: ../postman
   seed: ^0.0.3
   xml: ^6.3.0
-  flutter_riverpod: ^2.5.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/apidash_core/pubspec_overrides.yaml
+++ b/packages/apidash_core/pubspec_overrides.yaml
@@ -1,10 +1,10 @@
 # melos_managed_dependency_overrides: curl_parser,insomnia_collection,postman,seed
 dependency_overrides:
   curl_parser:
-    path: ../curl_parser
+    path: ..\\curl_parser
   insomnia_collection:
-    path: ../insomnia_collection
+    path: ..\\insomnia_collection
   postman:
-    path: ../postman
+    path: ..\\postman
   seed:
-    path: ../seed
+    path: ..\\seed


### PR DESCRIPTION
## PR Description

Added Basic Authorization method for both rest and graphql apis by directly injecting the authorization header into the sendhttprequest method without making any changes in existing httprequest model because of thier freezed nature and this method provides more scope for scalability for future auth methods.

## Related Issues

- Closes #610 
## Screenshots
![Screenshot 2025-03-20 071754](https://github.com/user-attachments/assets/b8fc2c6e-f488-4155-b8fa-c971a56bd27c)
![Screenshot 2025-03-20 071824](https://github.com/user-attachments/assets/1a1356fb-adf6-4b10-b5f3-084dfaf5fffb)
![Screenshot 2025-03-20 071932](https://github.com/user-attachments/assets/e90b093e-a980-43ab-b9f9-8ce5ece802fd)
![Screenshot 2025-03-20 071958](https://github.com/user-attachments/assets/627e53ac-a5a9-44b8-a74f-066de814618c)

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all melos tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [x] No, and this is why: I wanted to but i didn't know how to that is why I couldn't add them.

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux
