### PR TITLE
Solved RenderFlex Overflow in DropdownButton Problem

### DIFF
--- a/packages/apidash_design_system/lib/widgets/dropdown.dart
+++ b/packages/apidash_design_system/lib/widgets/dropdown.dart
@@ -7,7 +7,7 @@ class ADDropdownButton<T> extends StatelessWidget {
     this.value,
     required this.values,
     this.onChanged,
-    this.isExpanded = false,
+    this.isExpanded = true,
     this.isDense = false,
     this.iconSize,
     this.dropdownMenuItemPadding = kPs8,
@@ -26,39 +26,44 @@ class ADDropdownButton<T> extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final surfaceColor = Theme.of(context).colorScheme.surface;
-    return DropdownButton<T>(
-      isExpanded: isExpanded,
-      isDense: isDense,
-      focusColor: surfaceColor,
-      value: value,
-      icon: Icon(
-        Icons.unfold_more_rounded,
-        size: iconSize,
-      ),
-      elevation: 4,
-      style: kCodeStyle.copyWith(
-        color: Theme.of(context).colorScheme.primary,
-      ),
-      underline: Container(
-        height: 0,
-      ),
-      onChanged: onChanged,
-      borderRadius: kBorderRadius12,
-      items: values.map<DropdownMenuItem<T>>(((T, String?) value) {
-        return DropdownMenuItem<T>(
-          value: value.$1,
-          child: Padding(
-            padding: dropdownMenuItemPadding,
-            child: Text(
-              value.$2 ?? value.$1.toString(),
-              style:
-                  dropdownMenuItemtextStyle?.call(value.$1) ?? kTextStyleButton,
-              overflow: isExpanded ? TextOverflow.ellipsis : null,
-              maxLines: isExpanded ? 1 : null,
-            ),
+
+    return Align( 
+      alignment: Alignment.centerLeft, 
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 105), 
+        child: DropdownButton<T>(
+          isExpanded: isExpanded,
+          isDense: isDense,
+          focusColor: surfaceColor,
+          value: value,
+          icon: Icon(
+            Icons.unfold_more_rounded,
+            size: iconSize ?? 18, 
           ),
-        );
-      }).toList(),
+          elevation: 4,
+          style: kCodeStyle.copyWith(
+            color: Theme.of(context).colorScheme.primary,
+          ),
+          underline: Container(height: 0),
+          onChanged: onChanged,
+          borderRadius: kBorderRadius12,
+          items: values.map<DropdownMenuItem<T>>(((T, String?) value) {
+            return DropdownMenuItem<T>(
+              value: value.$1,
+              child: Padding(
+                padding: dropdownMenuItemPadding,
+                child: Text(
+                  value.$2 ?? value.$1.toString(),
+                  style:
+                      dropdownMenuItemtextStyle?.call(value.$1) ?? kTextStyleButton,
+                  overflow: isExpanded ? TextOverflow.ellipsis : null,
+                  maxLines: isExpanded ? 1 : null,
+                ),
+              ),
+            );
+          }).toList(),
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## PR Description
So it fixes the RenderFlex Overflow in DropdownButton. When using DropdownButton<FormDataType>, a RenderFlex overflowed by 5.3 pixels on the right error occurs. This happens because the dropdown button’s width is constrained inside a Row without allowing flexibility for the button’s content.

```
══╡ EXCEPTION CAUGHT BY RENDERING LIBRARY ╞═════════════════════════════════════════════════════════
The following assertion was thrown during layout:
A RenderFlex overflowed by 5.3 pixels on the right.

The relevant error-causing widget was:
  DropdownButton<FormDataType>
  DropdownButton:file:///E:/apidash-main/packages/apidash_design_system/lib/widgets/dropdown.dart:29:12

To inspect this widget in Flutter DevTools, visit:
http://127.0.0.1:9101/#/inspector?uri=http%3A%2F%2F127.0.0.1%3A38735%2FhYpbDgRNnb0%3D%2F&inspectorRef=inspector-0

The overflowing RenderFlex has an orientation of Axis.horizontal.
The edge of the RenderFlex that is overflowing has been marked in the rendering with a yellow and
black striped pattern. This is usually caused by the contents being too big for the RenderFlex.
Consider applying a flex factor (e.g. using an Expanded widget) to force the children of the
RenderFlex to fit within the available space instead of being sized to their natural size.
This is considered an error condition because it indicates that there is content that cannot be
seen. If the content is legitimately bigger than the available space, consider clipping it with a
ClipRect widget before putting it in the flex, or using a scrollable container rather than a Flex,
like a ListView.
The specific RenderFlex in question is: RenderFlex#1e7ed relayoutBoundary=up8 OVERFLOWING:
  creator: Row ← Padding ← SizedBox ← DefaultTextStyle ← Listener ← RawGestureDetector ←
    GestureDetector ← Semantics ← DefaultSelectionStyle ← Builder ← MouseRegion ← Semantics ← ⋯
  parentData: offset=Offset(0.0, 0.0) (can use size)
  constraints: BoxConstraints(0.0<=w<=58.0, 0.0<=h<=36.0)
  size: Size(58.0, 36.0)
  direction: horizontal
  mainAxisAlignment: spaceBetween
  mainAxisSize: min
  crossAxisAlignment: center
  textDirection: ltr
  verticalDirection: down
  spacing: 0.0
◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤
════════════════════════════════════════════════════════════════════════════════════════════════════

Another exception was thrown: A RenderFlex overflowed by 5.3 pixels on the right.
```

![Screenshot 2025-03-21 000945](https://github.com/user-attachments/assets/418f7f18-1dc5-43dd-a777-655a879108b2)

## Related Issues

- Closes #683 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
- [ ] Yes
- [x] No, and this is why: Not Needed

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux
