### PR TITLE
Added Basic Authentication feature

### DIFF
--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -435,10 +435,12 @@ const kLabelImport = "Import";
 const kUntitled = "untitled";
 // Request Pane
 const kLabelRequest = "Request";
+const kLabelAuthorizationType = "Authorization Type";
 const kLabelHideCode = "Hide Code";
 const kLabelViewCode = "View Code";
 const kLabelURLParams = "URL Params";
 const kLabelHeaders = "Headers";
+const kLabelAuthorization = "Authorization";
 const kLabelBody = "Body";
 const kLabelQuery = "Query";
 const kNameCheckbox = "Checkbox";

--- a/lib/providers/auth_providers.dart
+++ b/lib/providers/auth_providers.dart
@@ -1,0 +1,82 @@
+import 'dart:convert';
+import 'package:apidash_core/apidash_core.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+enum AuthType {
+  none,
+  basicAuth,
+  apiKey,
+  bearerToken,
+  jwtBearer,
+  digestAuth,
+  oauth1,
+  oauth2,
+}
+
+String authTypeToString(AuthType authType) {
+  switch (authType) {
+    case AuthType.basicAuth:
+      return "Basic Auth";
+    case AuthType.apiKey:
+      return "API Key";
+    case AuthType.bearerToken:
+      return "Bearer Token";
+    case AuthType.jwtBearer:
+      return "JWT Bearer";
+    case AuthType.digestAuth:
+      return "Digest Auth";
+    case AuthType.oauth1:
+      return "OAuth 1.0";
+    case AuthType.oauth2:
+      return "OAuth 2.0";
+    case AuthType.none:
+    default:
+      return "None";
+  }
+}
+
+final authTypeProvider = StateProvider<AuthType>((ref) => AuthType.none);
+final authCredentialsProvider = StateProvider<Map<String, String>>((ref) => {
+      'username': '',
+      'password': '',
+      'apiKey': '',
+      'token': '',
+    });
+
+void updateAuthType(WidgetRef ref, AuthType newAuthType) {
+  ref.read(authTypeProvider.notifier).state = newAuthType;
+}
+
+void updateCredentials(WidgetRef ref, Map<String, String> newCredentials) {
+  ref.read(authCredentialsProvider.notifier).update((state) => {
+        ...state,
+        ...newCredentials,
+      });
+}
+
+List<NameValueModel> generateAuthHeaders(WidgetRef ref) {
+  final authType = ref.read(authTypeProvider);
+  final credentials = ref.read(authCredentialsProvider);
+
+  switch (authType) {
+    case AuthType.basicAuth:
+      if (credentials['username']?.isNotEmpty == true &&
+          credentials['password']?.isNotEmpty == true) {
+        String basicAuth =
+            'Basic ${base64Encode(utf8.encode('${credentials['username']}:${credentials['password']}'))}';
+        return [NameValueModel(name: "Authorization", value: basicAuth)];
+      }
+      break;
+    case AuthType.bearerToken:
+    case AuthType.jwtBearer:
+      break;
+    case AuthType.apiKey:
+      break;
+    case AuthType.oauth1:
+    case AuthType.oauth2:
+    case AuthType.digestAuth:
+    case AuthType.none:
+      break;
+  }
+  return [];
+}

--- a/lib/providers/providers.dart
+++ b/lib/providers/providers.dart
@@ -3,3 +3,4 @@ export 'environment_providers.dart';
 export 'history_providers.dart';
 export 'settings_providers.dart';
 export 'ui_providers.dart';
+export 'auth_providers.dart';

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_authorization.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_authorization.dart
@@ -1,0 +1,148 @@
+import 'dart:convert';
+
+import 'package:apidash/consts.dart';
+import 'package:apidash/providers/collection_providers.dart';
+import 'package:apidash_core/apidash_core.dart';
+import 'package:apidash_design_system/tokens/tokens.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../../providers/auth_providers.dart';
+
+class EditRequestAuthorization extends ConsumerStatefulWidget {
+  const EditRequestAuthorization({super.key});
+
+  @override
+  ConsumerState<EditRequestAuthorization> createState() =>
+      _EditRequestAuthorizationState();
+}
+
+class _EditRequestAuthorizationState
+    extends ConsumerState<EditRequestAuthorization> {
+  late TextEditingController _usernameController;
+  late TextEditingController _passwordController;
+
+  @override
+  void initState() {
+    super.initState();
+    _usernameController = TextEditingController();
+    _passwordController = TextEditingController();
+
+    _usernameController.addListener(() {
+      ref.read(authCredentialsProvider.notifier).update((state) => {
+            ...state,
+            'username': _usernameController.text,
+          });
+    });
+
+    _passwordController.addListener(() {
+      ref.read(authCredentialsProvider.notifier).update((state) => {
+            ...state,
+            'password': _passwordController.text,
+          });
+    });
+  }
+
+  @override
+  void dispose() {
+    _usernameController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  void _updateHeaders(AuthType? authType, String? username, String? password) {
+    final headers = _generateAuthHeaders(authType, username, password);
+    ref.read(collectionStateNotifierProvider.notifier).update(headers: headers);
+  }
+
+  List<NameValueModel> _generateAuthHeaders(
+      AuthType? authType, String? username, String? password) {
+    if (authType == AuthType.basicAuth &&
+        username != null &&
+        password != null &&
+        username.isNotEmpty &&
+        password.isNotEmpty) {
+      String basicAuth =
+          'Basic ${base64Encode(utf8.encode('$username:$password'))}';
+      return [NameValueModel(name: "Authorization", value: basicAuth)];
+    }
+    return [];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final authType = ref.watch(authTypeProvider);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          kVSpacer16,
+          DropdownButtonFormField<AuthType>(
+            value: authType,
+            decoration: InputDecoration(
+              labelText: kLabelAuthorizationType,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+              contentPadding:
+                  const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            ),
+            items: AuthType.values.map((AuthType type) {
+              return DropdownMenuItem(
+                  value: type, child: Text(type.toString().split('.').last));
+            }).toList(),
+            onChanged: (value) {
+              if (value != null) {
+                ref.read(authTypeProvider.notifier).update((state) => value);
+                _updateHeaders(
+                    value, _usernameController.text, _passwordController.text);
+              }
+            },
+          ),
+          const SizedBox(height: 16),
+          if (authType == AuthType.basicAuth) ...[
+            TextFormField(
+              controller: _usernameController,
+              decoration: InputDecoration(
+                labelText: "Username",
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                contentPadding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              ),
+              onChanged: (value) {
+                ref.read(authCredentialsProvider.notifier).update((state) => {
+                      ...state,
+                      'username': value,
+                    });
+                _updateHeaders(authType, value, _passwordController.text);
+              },
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: _passwordController,
+              decoration: InputDecoration(
+                labelText: "Password",
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                contentPadding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              ),
+              obscureText: true,
+              onChanged: (value) {
+                ref.read(authCredentialsProvider.notifier).update((state) => {
+                      ...state,
+                      'password': value,
+                    });
+                _updateHeaders(authType, _usernameController.text, value);
+              },
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_pane_graphql.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_pane_graphql.dart
@@ -1,4 +1,5 @@
 import 'package:apidash/consts.dart';
+import 'package:apidash/screens/home_page/editor_pane/details_card/request_pane/request_authorization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:apidash/providers/providers.dart';
@@ -21,6 +22,9 @@ class EditGraphQLRequestPane extends ConsumerWidget {
     final hasQuery = ref.watch(selectedRequestModelProvider
             .select((value) => value?.httpRequestModel?.hasQuery)) ??
         false;
+
+    final authEnabled = ref.watch(authTypeProvider) != AuthType.none;
+    
     if (tabIndex >= 2) {
       tabIndex = 0;
     }
@@ -38,14 +42,17 @@ class EditGraphQLRequestPane extends ConsumerWidget {
             .update(requestTabIndex: index);
       },
       showIndicators: [
-        headerLength > 0,
+        authEnabled,
+        headerLength > 0 && !authEnabled,
         hasQuery,
       ],
       tabLabels: const [
+        kLabelAuthorization,
         kLabelHeaders,
         kLabelQuery,
       ],
       children: const [
+        EditRequestAuthorization(),
         EditRequestHeaders(),
         EditRequestBody(),
       ],

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_pane_rest.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_pane_rest.dart
@@ -1,9 +1,10 @@
 import 'package:apidash/consts.dart';
+import 'package:apidash/screens/home_page/editor_pane/details_card/request_pane/request_authorization.dart';
+import 'package:apidash/screens/home_page/editor_pane/details_card/request_pane/request_headers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:apidash/providers/providers.dart';
 import 'package:apidash/widgets/widgets.dart';
-import 'request_headers.dart';
 import 'request_params.dart';
 import 'request_body.dart';
 
@@ -26,7 +27,7 @@ class EditRestRequestPane extends ConsumerWidget {
     final hasBody = ref.watch(selectedRequestModelProvider
             .select((value) => value?.httpRequestModel?.hasBody)) ??
         false;
-
+    final authEnabled = ref.watch(authTypeProvider) != AuthType.none;
     return RequestPane(
       selectedId: selectedId,
       codePaneVisible: codePaneVisible,
@@ -42,16 +43,19 @@ class EditRestRequestPane extends ConsumerWidget {
       },
       showIndicators: [
         paramLength > 0,
-        headerLength > 0,
+        authEnabled,
+        headerLength > 0 && !authEnabled,
         hasBody,
       ],
       tabLabels: const [
         kLabelURLParams,
+        kLabelAuthorization,
         kLabelHeaders,
         kLabelBody,
       ],
       children: const [
         EditRequestURLParams(),
+        EditRequestAuthorization(),
         EditRequestHeaders(),
         EditRequestBody(),
       ],

--- a/lib/widgets/request_pane.dart
+++ b/lib/widgets/request_pane.dart
@@ -37,7 +37,7 @@ class _RequestPaneState extends State<RequestPane>
   @override
   Widget build(BuildContext context) {
     final TabController controller = useTabController(
-      initialLength: widget.children.length,
+      initialLength: widget.tabLabels.length,
       vsync: this,
     );
     if (widget.tabIndex != null) {


### PR DESCRIPTION
## PR Description  

This PR adds support for Basic Authentication by introducing username and password fields for both GraphQL and REST APIs in the API Dash repo. I’ve also added a new authorization tab to make it easier to configure auth credentials.  

### Summary of Changes  
- Added a **new TabBar widget** for managing API authorization.  
- Created a **provider for auth credentials** to handle state efficiently.  
- Implemented methods to:  
  - **Update authentication type** (None, Basic Auth, etc.).  
  - **Update username and password credentials** dynamically.  
  - **Generate authentication headers** and apply them to API requests.  
- Made sure everything works smoothly for both **GraphQL and REST APIs**. 

## Related Issues

- Closes #610 


## Screenshots

![image](https://github.com/user-attachments/assets/56d72b21-678d-41dc-a6dd-bda7e01941c6)
![image](https://github.com/user-attachments/assets/e05e5dac-2ec9-4343-99e6-3471e62da671)
![image](https://github.com/user-attachments/assets/7848aafd-abfb-425e-89ab-d92482e169e0)
![image](https://github.com/user-attachments/assets/2371db13-7351-4e60-94ce-00a31fef80f0)

### Checklist


- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [x] No, and this is why: _please replace this line with details on why tests have not been included_

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux
