### PR TITLE
Fixes Rare '<optimized out>' Exception when changing Body Content-Type back to json

### DIFF
--- a/lib/widgets/editor_json.dart
+++ b/lib/widgets/editor_json.dart
@@ -51,7 +51,10 @@ class _JsonTextFieldEditorState extends State<JsonTextFieldEditor> {
     if (widget.initialValue != null) {
       controller.text = widget.initialValue!;
     }
-    controller.formatJson(sortJson: false);
+    Future.delayed(Duration(milliseconds: 50), () {
+      controller.formatJson(sortJson: false);
+      setState(() {});
+    });
     editorFocusNode = FocusNode(debugLabel: "Editor Focus Node");
   }
 


### PR DESCRIPTION
## PR Description

While using the application I came across an issue that is a fairly common user-flow. This does not happen for all types of JSON but it has happened to me a couple of times. At the end of this, I will be adding examples of JSON that cause this error

Steps to Reproduce:
1. Go to the Body Section when defining a request and add JSON content to the Textbox (in json content type)
2. change content type to text and come back to json
3. We get an error exception mentioning `<optimized out>`

Issue Video:

https://github.com/user-attachments/assets/e1790b78-3aca-485a-a591-759ba34055fc


I identified the source of this issue to this line:
```dart
//editor_json.dart
controller.formatJson(sortJson: false);
```
Adding a 50ms delay fixed this problem and running the same set of steps does not reproduce the error now

After Fix:

https://github.com/user-attachments/assets/751a2815-3554-4f70-bc52-c1f8cf845839

### Some Examples of JSON that trigger this issue
This occurs to a subset of JSON bodies that are syntactically correct but have some formatting problem.
it might have something to do with the formatting because when i paste these examples in jsonbeautifier and paste them back into apidash, things work normally.

```json
{
  "user": {
        "id": 12345,
        "name": "John Doe",
        "email": "johndoe@example.com",
        "roles": ["admin", "editor"],
        "preferences": {
            "language": "en",
            "timezone": "UTC"
        }
    },
    "action": "create",
    "metadata": {
        "device": "iPhone",
        "app_version": "1.2.3"
    }
}
```

```json
{ "name"   : "Alice Brown",
  "sku"    : "54321",
  "price"  : 199.95,
  "shipTo" : { "name" : "Bob Brown",
               "address" : "456 Oak Lane",
               "city" : "Pretendville",
               "state" : "HI",
               "zip"   : "98999" },
  "billTo" : { "name" : "Alice Brown",
               "address" : "456 Oak Lane",
               "city" : "Pretendville",
               "state" : "HI",
               "zip"   : "98999" }
}
```
```json
{
    "name": "John Doe",
    "email": "johndoe@example.com",
    "message": "This is a test message."
}
```
The examples above are directly copied from the internet/LLMs (which many of our users are going to do).
We cannot expect users to go and manually format their copied json bodies.

Hence this issue could affect end users of the application and needs fixing. My approach tested against all these examples has not reproduced that error again.

Hence, please review & merge this!
Thanks

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## OS on which you have developed and tested the feature?

- [ ] Windows
- [x] macOS
- [ ] Linux

