### PR TITLE
updated rust codegen 

### DIFF
--- a/lib/codegen/rust/ureq.dart
+++ b/lib/codegen/rust/ureq.dart
@@ -30,7 +30,7 @@ fn main() -> Result<(), ureq::Error> {
 """;
 
   String kTemplateHeaders =
-      """\n        {% for key, val in headers -%}.set("{{key}}", "{{val}}"){% if not loop.last %}{{ '\n        ' }}{% endif %}{%- endfor -%}""";
+      """\n        {% for key, val in headers -%}.header("{{key}}", "{{val}}"){% if not loop.last %}{{ '\n        ' }}{% endif %}{%- endfor -%}""";
 
   String kTemplateFormHeaderContentType = '''
 multipart/form-data; boundary={{boundary}}''';

--- a/lib/codegen/rust/ureq.dart
+++ b/lib/codegen/rust/ureq.dart
@@ -24,8 +24,8 @@ fn main() -> Result<(), ureq::Error> {
 """;
 
   String kTemplateJson = """
-
-    let payload = ureq::json!({{body}});
+    use serde_json::json;
+    let payload = json!({{body}});
 
 """;
 

--- a/lib/codegen/rust/ureq.dart
+++ b/lib/codegen/rust/ureq.dart
@@ -100,7 +100,7 @@ multipart/form-data; boundary={{boundary}}''';
 
   final String kStringRequestEnd = """\n
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }

--- a/test/codegen/rust_ureq_codegen_test.dart
+++ b/test/codegen/rust_ureq_codegen_test.dart
@@ -15,7 +15,7 @@ void main() {
         .call()?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -37,7 +37,7 @@ void main() {
         .call()?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -59,7 +59,7 @@ void main() {
         .call()?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -85,7 +85,7 @@ void main() {
         .call()?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -107,7 +107,7 @@ void main() {
         .call()?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -130,7 +130,7 @@ void main() {
         .call()?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -151,7 +151,7 @@ void main() {
         .call()?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -174,7 +174,7 @@ void main() {
         .call()?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -197,7 +197,7 @@ void main() {
         .call()?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -219,7 +219,7 @@ void main() {
         .call()?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -243,7 +243,7 @@ void main() {
         .call()?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -264,7 +264,7 @@ void main() {
         .call()?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -287,7 +287,7 @@ void main() {
         .call()?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -308,7 +308,7 @@ void main() {
         .call()?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -336,7 +336,7 @@ void main() {
         .send_string(payload)?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -366,7 +366,7 @@ void main() {
         .send_json(payload)?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -392,7 +392,7 @@ void main() {
         .send_json(payload)?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -469,7 +469,7 @@ fn main() -> Result<(), ureq::Error> {
         .send_bytes(&payload)?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -547,7 +547,7 @@ fn main() -> Result<(), ureq::Error> {
         .send_bytes(&payload)?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -616,7 +616,7 @@ fn main() -> Result<(), ureq::Error> {
         .send_bytes(&payload)?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -685,7 +685,7 @@ fn main() -> Result<(), ureq::Error> {
         .send_bytes(&payload)?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -761,7 +761,7 @@ fn main() -> Result<(), ureq::Error> {
         .send_bytes(&payload)?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -834,7 +834,7 @@ fn main() -> Result<(), ureq::Error> {
         .send_bytes(&payload)?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -860,7 +860,7 @@ fn main() -> Result<(), ureq::Error> {
         .send_json(payload)?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -888,7 +888,7 @@ fn main() -> Result<(), ureq::Error> {
         .send_json(payload)?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -911,7 +911,7 @@ fn main() -> Result<(), ureq::Error> {
         .call()?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }
@@ -937,7 +937,7 @@ fn main() -> Result<(), ureq::Error> {
         .send_json(payload)?;
 
     println!("Response Status: {}", response.status());
-    println!("Response: {}", response.into_string()?);
+    println!("Response: {}", response.into_body().read_to_string()?);
 
     Ok(())
 }

--- a/test/codegen/rust_ureq_codegen_test.dart
+++ b/test/codegen/rust_ureq_codegen_test.dart
@@ -9,7 +9,8 @@ void main() {
 
   group('GET Request', () {
     test('GET 1', () {
-      const expectedCode = r"""fn main() -> Result<(), ureq::Error> {
+      const expectedCode = r"""
+fn main() -> Result<(), ureq::Error> {
     let url = "https://api.apidash.dev";
     let response = ureq::get(url)
         .call()?;
@@ -103,7 +104,7 @@ void main() {
       const expectedCode = r"""fn main() -> Result<(), ureq::Error> {
     let url = "https://api.github.com/repos/foss42/apidash";
     let response = ureq::get(url)
-        .set("User-Agent", "Test Agent")
+        .header("User-Agent", "Test Agent")
         .call()?;
 
     println!("Response Status: {}", response.status());
@@ -126,7 +127,7 @@ void main() {
     let url = "https://api.github.com/repos/foss42/apidash";
     let response = ureq::get(url)
         .query("raw", "true")
-        .set("User-Agent", "Test Agent")
+        .header("User-Agent", "Test Agent")
         .call()?;
 
     println!("Response Status: {}", response.status());
@@ -170,7 +171,7 @@ void main() {
     let url = "https://api.github.com/repos/foss42/apidash";
     let response = ureq::get(url)
         .query("raw", "true")
-        .set("User-Agent", "Test Agent")
+        .header("User-Agent", "Test Agent")
         .call()?;
 
     println!("Response Status: {}", response.status());
@@ -215,7 +216,7 @@ void main() {
       const expectedCode = r"""fn main() -> Result<(), ureq::Error> {
     let url = "https://api.apidash.dev/humanize/social";
     let response = ureq::get(url)
-        .set("User-Agent", "Test Agent")
+        .header("User-Agent", "Test Agent")
         .call()?;
 
     println!("Response Status: {}", response.status());
@@ -239,7 +240,7 @@ void main() {
     let response = ureq::get(url)
         .query("num", "8700000")
         .query("digits", "3")
-        .set("User-Agent", "Test Agent")
+        .header("User-Agent", "Test Agent")
         .call()?;
 
     println!("Response Status: {}", response.status());
@@ -332,8 +333,8 @@ void main() {
 }"#;
 
     let response = ureq::post(url)
-        .set("content-type", "text/plain")
-        .send_string(payload)?;
+        .header("content-type", "text/plain")
+        .send(payload)?;
 
     println!("Response Status: {}", response.status());
     println!("Response: {}", response.into_body().read_to_string()?);
@@ -351,9 +352,12 @@ void main() {
     });
 
     test('POST 2', () {
-      const expectedCode = r'''fn main() -> Result<(), ureq::Error> {
+      const expectedCode = r'''
+use serde_json::json;
+fn main() -> Result<(), ureq::Error> {
     let url = "https://api.apidash.dev/case/lower";
-    let payload = ureq::json!({
+
+    let payload = json!({
 "text": "I LOVE Flutter",
 "flag": null,
 "male": true,
@@ -381,14 +385,17 @@ void main() {
     });
 
     test('POST 3', () {
-      const expectedCode = r'''fn main() -> Result<(), ureq::Error> {
+      const expectedCode = r'''
+use serde_json::json;
+fn main() -> Result<(), ureq::Error> {
     let url = "https://api.apidash.dev/case/lower";
-    let payload = ureq::json!({
+
+    let payload = json!({
 "text": "I LOVE Flutter"
 });
 
     let response = ureq::post(url)
-        .set("User-Agent", "Test Agent")
+        .header("User-Agent", "Test Agent")
         .send_json(payload)?;
 
     println!("Response Status: {}", response.status());
@@ -465,7 +472,7 @@ fn main() -> Result<(), ureq::Error> {
   
     let payload = build_data_list(form_data_items);
     let response = ureq::post(url)
-        .set("content-type", "multipart/form-data; boundary=test")
+        .header("content-type", "multipart/form-data; boundary=test")
         .send_bytes(&payload)?;
 
     println!("Response Status: {}", response.status());
@@ -542,8 +549,8 @@ fn main() -> Result<(), ureq::Error> {
   
     let payload = build_data_list(form_data_items);
     let response = ureq::post(url)
-        .set("User-Agent", "Test Agent")
-        .set("content-type", "multipart/form-data; boundary=test")
+        .header("User-Agent", "Test Agent")
+        .header("content-type", "multipart/form-data; boundary=test")
         .send_bytes(&payload)?;
 
     println!("Response Status: {}", response.status());
@@ -612,7 +619,7 @@ fn main() -> Result<(), ureq::Error> {
   
     let payload = build_data_list(form_data_items);
     let response = ureq::post(url)
-        .set("content-type", "multipart/form-data; boundary=test")
+        .header("content-type", "multipart/form-data; boundary=test")
         .send_bytes(&payload)?;
 
     println!("Response Status: {}", response.status());
@@ -681,7 +688,7 @@ fn main() -> Result<(), ureq::Error> {
   
     let payload = build_data_list(form_data_items);
     let response = ureq::post(url)
-        .set("content-type", "multipart/form-data; boundary=test")
+        .header("content-type", "multipart/form-data; boundary=test")
         .send_bytes(&payload)?;
 
     println!("Response Status: {}", response.status());
@@ -757,7 +764,7 @@ fn main() -> Result<(), ureq::Error> {
     let response = ureq::post(url)
         .query("size", "2")
         .query("len", "3")
-        .set("content-type", "multipart/form-data; boundary=test")
+        .header("content-type", "multipart/form-data; boundary=test")
         .send_bytes(&payload)?;
 
     println!("Response Status: {}", response.status());
@@ -828,9 +835,9 @@ fn main() -> Result<(), ureq::Error> {
     let response = ureq::post(url)
         .query("size", "2")
         .query("len", "3")
-        .set("User-Agent", "Test Agent")
-        .set("Keep-Alive", "true")
-        .set("content-type", "multipart/form-data; boundary=test")
+        .header("User-Agent", "Test Agent")
+        .header("Keep-Alive", "true")
+        .header("content-type", "multipart/form-data; boundary=test")
         .send_bytes(&payload)?;
 
     println!("Response Status: {}", response.status());
@@ -849,9 +856,11 @@ fn main() -> Result<(), ureq::Error> {
 
   group('PUT Request', () {
     test('PUT 1', () {
-      const expectedCode = r'''fn main() -> Result<(), ureq::Error> {
+      const expectedCode = r'''use serde_json::json;
+fn main() -> Result<(), ureq::Error> {
     let url = "https://reqres.in/api/users/2";
-    let payload = ureq::json!({
+
+    let payload = json!({
 "name": "morpheus",
 "job": "zion resident"
 });
@@ -877,9 +886,12 @@ fn main() -> Result<(), ureq::Error> {
 
   group('PATCH Request', () {
     test('PATCH 1', () {
-      const expectedCode = r'''fn main() -> Result<(), ureq::Error> {
+      const expectedCode = r'''
+use serde_json::json;
+fn main() -> Result<(), ureq::Error> {
     let url = "https://reqres.in/api/users/2";
-    let payload = ureq::json!({
+
+    let payload = json!({
 "name": "marfeus",
 "job": "accountant"
 });
@@ -905,7 +917,8 @@ fn main() -> Result<(), ureq::Error> {
 
   group('DELETE Request', () {
     test('DELETE 1', () {
-      const expectedCode = r"""fn main() -> Result<(), ureq::Error> {
+      const expectedCode = r"""
+fn main() -> Result<(), ureq::Error> {
     let url = "https://reqres.in/api/users/2";
     let response = ureq::delete(url)
         .call()?;
@@ -926,9 +939,12 @@ fn main() -> Result<(), ureq::Error> {
     });
 
     test('DELETE 2', () {
-      const expectedCode = r'''fn main() -> Result<(), ureq::Error> {
+      const expectedCode = r'''
+use serde_json::json;
+fn main() -> Result<(), ureq::Error> {
     let url = "https://reqres.in/api/users/2";
-    let payload = ureq::json!({
+
+    let payload = json!({
 "name": "marfeus",
 "job": "accountant"
 });


### PR DESCRIPTION
## PR Description
This PR fixes a compatibility issue with ureq 3.x caused by the removal of the into_string() method.] The code generated  currently uses response.into_string(), which leads to compilation errors when using ureq 3.x and above.
Updated it to into_body().read_to_string()

## Related Issues

- Closes #697 
### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_

## OS on which you have developed and tested the feature?

- [x] Windows