### PR TITLE
Fix issue #630: Unable to override Content-Type header charset (Using Dio)

### DIFF
--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -267,20 +267,16 @@ class CollectionStateNotifier
     ref.read(codePaneVisibleStateProvider.notifier).state = false;
     final defaultUriScheme = ref.read(settingsProvider).defaultUriScheme;
 
-    if (requestId == null || state == null) {
-      return;
-    }
-    RequestModel? requestModel = state![requestId];
+    if (requestId == null || state == null) return;
 
-    if (requestModel?.httpRequestModel == null) {
-      return;
-    }
+    RequestModel? requestModel = state![requestId];
+    if (requestModel?.httpRequestModel == null) return;
 
     APIType apiType = requestModel!.apiType;
     HttpRequestModel substitutedHttpRequestModel =
         getSubstitutedHttpRequestModel(requestModel.httpRequestModel!);
 
-    // set current model's isWorking to true and update state
+    // Set current model's isWorking to true and update state
     var map = {...state!};
     map[requestId] = requestModel.copyWith(
       isWorking: true,
@@ -298,6 +294,7 @@ class CollectionStateNotifier
     );
 
     late final RequestModel newRequestModel;
+
     if (responseRec.$1 == null) {
       newRequestModel = requestModel.copyWith(
         responseStatus: -1,
@@ -305,17 +302,20 @@ class CollectionStateNotifier
         isWorking: false,
       );
     } else {
-      final httpResponseModel = baseHttpResponseModel.fromResponse(
+      final httpResponseModel = baseHttpResponseModel.fromDioResponse(
         response: responseRec.$1!,
         time: responseRec.$2!,
       );
-      int statusCode = responseRec.$1!.statusCode;
+
+      final int statusCode = responseRec.$1?.statusCode ?? -1;
+
       newRequestModel = requestModel.copyWith(
         responseStatus: statusCode,
         message: kResponseCodeReasons[statusCode],
         httpResponseModel: httpResponseModel,
         isWorking: false,
       );
+
       String newHistoryId = getNewUuid();
       HistoryRequestModel model = HistoryRequestModel(
         historyId: newHistoryId,
@@ -335,7 +335,7 @@ class CollectionStateNotifier
       ref.read(historyMetaStateNotifier.notifier).addHistoryRequest(model);
     }
 
-    // update state with response data
+    // Update state with response data
     map = {...state!};
     map[requestId] = newRequestModel;
     state = map;

--- a/packages/apidash_core/lib/models/http_response_model.dart
+++ b/packages/apidash_core/lib/models/http_response_model.dart
@@ -6,6 +6,7 @@ import 'package:collection/collection.dart' show mergeMaps;
 import 'package:http/http.dart';
 import 'package:http_parser/http_parser.dart';
 import '../extensions/extensions.dart';
+import 'package:dio/dio.dart' as dio;
 import '../utils/utils.dart';
 import '../consts.dart';
 
@@ -82,6 +83,33 @@ class HttpResponseModel with _$HttpResponseModel {
       body: body,
       formattedBody: formatBody(body, mediaType),
       bodyBytes: response.bodyBytes,
+      time: time,
+    );
+  }
+
+  HttpResponseModel fromDioResponse({
+    required dio.Response response,
+    Duration? time,
+  }) {
+    final headers = <String, String>{};
+    response.headers.forEach((k, v) {
+      headers[k] = v.join(',');
+    });
+
+    MediaType? mediaType = getMediaTypeFromHeaders(headers);
+    final body = (mediaType?.subtype == kSubTypeJson)
+        ? jsonEncode(response.data)
+        : response.data.toString();
+
+    return HttpResponseModel(
+      statusCode: response.statusCode,
+      headers: headers,
+      requestHeaders: response.requestOptions.headers.map((k, v) => MapEntry(k, v.toString())),
+      body: body,
+      formattedBody: formatBody(body, mediaType),
+      bodyBytes: response.data is List<int>
+          ? Uint8List.fromList(response.data)
+          : utf8.encode(body),
       time: time,
     );
   }

--- a/packages/apidash_core/lib/services/http_client_manager.dart
+++ b/packages/apidash_core/lib/services/http_client_manager.dart
@@ -1,65 +1,65 @@
 import 'dart:io';
+import 'package:dio/dio.dart';
+import 'package:dio/io.dart';
 import 'package:flutter/foundation.dart';
-import 'package:http/http.dart' as http;
-import 'package:http/io_client.dart';
-
-http.Client createHttpClientWithNoSSL() {
-  var ioClient = HttpClient()
-    ..badCertificateCallback =
-        (X509Certificate cert, String host, int port) => true;
-  return IOClient(ioClient);
-}
 
 class HttpClientManager {
   static final HttpClientManager _instance = HttpClientManager._internal();
   static const int _maxCancelledRequests = 100;
-  final Map<String, http.Client> _clients = {};
+
+  final Map<String, Dio> _clients = {};
+  final Map<String, CancelToken> _cancelTokens = {};
   final Set<String> _cancelledRequests = {};
 
-  factory HttpClientManager() {
-    return _instance;
-  }
+  factory HttpClientManager() => _instance;
 
   HttpClientManager._internal();
 
-  http.Client createClient(
-    String requestId, {
-    bool noSSL = false,
-  }) {
-    final client =
-        (noSSL && !kIsWeb) ? createHttpClientWithNoSSL() : http.Client();
-    _clients[requestId] = client;
-    return client;
+  Dio createClient(String requestId, {bool noSSL = false}) {
+    final dio = Dio();
+
+    if (noSSL && !kIsWeb) {
+      (dio.httpClientAdapter as IOHttpClientAdapter).createHttpClient = () {
+        final client = HttpClient();
+        client.badCertificateCallback = (cert, host, port) => true;
+        return client;
+      };
+    }
+
+    final cancelToken = CancelToken();
+    _clients[requestId] = dio;
+    _cancelTokens[requestId] = cancelToken;
+
+    return dio;
   }
 
-  void cancelRequest(String? requestId) {
-    if (requestId != null && _clients.containsKey(requestId)) {
-      _clients[requestId]?.close();
-      _clients.remove(requestId);
+  CancelToken? getCancelToken(String requestId) => _cancelTokens[requestId];
 
+  void cancelRequest(String? requestId) {
+    if (requestId != null) {
+      _cancelTokens[requestId]?.cancel("Request cancelled");
+      _clients.remove(requestId);
+      _cancelTokens.remove(requestId);
       _cancelledRequests.add(requestId);
+
       if (_cancelledRequests.length > _maxCancelledRequests) {
         _cancelledRequests.remove(_cancelledRequests.first);
       }
     }
   }
 
-  bool wasRequestCancelled(String requestId) {
-    return _cancelledRequests.contains(requestId);
-  }
+  bool wasRequestCancelled(String requestId) =>
+      _cancelledRequests.contains(requestId);
 
   void removeCancelledRequest(String requestId) {
     _cancelledRequests.remove(requestId);
   }
 
   void closeClient(String requestId) {
-    if (_clients.containsKey(requestId)) {
-      _clients[requestId]?.close();
-      _clients.remove(requestId);
-    }
+    _clients.remove(requestId);
+    _cancelTokens.remove(requestId);
   }
 
-  bool hasActiveClient(String requestId) {
-    return _clients.containsKey(requestId);
-  }
+  bool hasActiveClient(String requestId) =>
+      _clients.containsKey(requestId);
 }

--- a/packages/apidash_core/pubspec.yaml
+++ b/packages/apidash_core/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
     path: ../postman
   seed: ^0.0.3
   xml: ^6.3.0
+  dio: ^5.8.0+1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -358,6 +358,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.0"
+  dio:
+    dependency: transitive
+    description:
+      name: dio
+      sha256: "253a18bbd4851fecba42f7343a1df3a9a4c1d31a2c1b37e221086b4fa8c8dbc9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.8.0+1"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "7586e476d70caecaf1686d21eee7247ea43ef5c345eab9e0cc3583ff13378d78"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   equatable:
     dependency: transitive
     description:


### PR DESCRIPTION
## PR Description

To improve request handling, I tried to replace the http package with dio, which provides greater control, better error handling, and enhanced support for advanced features like request cancellation and multipart form data. And it was working well as intented to prevent the Content-type to be overriden.

### Why Dio?
Dio provides:
- More control over request options and headers
- Built-in support for interceptors, timeouts, and cancellation tokens
- Simplified handling of form data and file uploads
- Improved error reporting

![Screenshot 2025-04-07 211455](https://github.com/user-attachments/assets/5125c8b3-44f0-496b-9011-c887ccfdbdf4)
![Screenshot 2025-04-07 211519](https://github.com/user-attachments/assets/2e22082f-ad5a-48fc-aafb-a20cff831fd2)



## Related Issues

- Closes #630 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: already have tests

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux
