### PR TITLE
Fix Issue #630 Unable to override Content-Type header charset

### DIFF
--- a/packages/apidash_core/lib/extensions/map_extensions.dart
+++ b/packages/apidash_core/lib/extensions/map_extensions.dart
@@ -23,4 +23,10 @@ extension MapExtension on Map {
   String? getValueContentType() {
     return this[getKeyContentType()];
   }
+
+  Map removeKeyContentType() {
+    removeWhere(
+        (key, value) => key.toLowerCase() == HttpHeaders.contentTypeHeader);
+    return this;
+  }
 }

--- a/test/models/http_request_models.dart
+++ b/test/models/http_request_models.dart
@@ -441,3 +441,28 @@ const httpRequestModelPost11 = HttpRequestModel(
 "text": "I LOVE Flutter"
 }""",
 );
+
+/// POST request model with default (utf-8) content type charset
+const httpRequestModelPost12 = HttpRequestModel(
+  method: HTTPVerb.post,
+  url: 'https://api.apidash.dev/case/lower',
+  bodyContentType: ContentType.json,
+  body: r"""{
+"text": "I LOVE Flutter"
+}""",
+);
+
+/// POST request model with charset override (latin1)
+const httpRequestModelPost13 = HttpRequestModel(
+  method: HTTPVerb.post,
+  url: 'https://api.apidash.dev/case/lower',
+  headers: [
+    NameValueModel(
+        name: 'Content-Type', value: 'application/json; charset=latin1'),
+  ],
+  isHeaderEnabledList: [true],
+  bodyContentType: ContentType.json,
+  body: r"""{
+"text": "I LOVE Flutter"
+}""",
+);

--- a/test/models/request_models.dart
+++ b/test/models/request_models.dart
@@ -233,8 +233,23 @@ const requestModelGetBadSSL = RequestModel(
   httpRequestModel: httpRequestModelGetBadSSL,
 );
 
+/// POST request model with content type override having no charset
 const requestModelPost11 = RequestModel(
   id: 'post11',
   apiType: APIType.rest,
   httpRequestModel: httpRequestModelPost11,
+);
+
+/// POST request model with default (utf-8) content type charset
+const requestModelPost12 = RequestModel(
+  id: 'post12',
+  apiType: APIType.rest,
+  httpRequestModel: httpRequestModelPost12,
+);
+
+/// POST request model with charset override (latin1)
+const requestModelPost13 = RequestModel(
+  id: 'post13',
+  apiType: APIType.rest,
+  httpRequestModel: httpRequestModelPost13,
 );

--- a/test/models/response_model_test.dart
+++ b/test/models/response_model_test.dart
@@ -62,6 +62,32 @@ void main() {
     expect(responseData.requestHeaders?['content-type'], 'application/json');
   });
 
+  test('Testing default contentType charset added by dart', () async {
+    var responseRec = await sendHttpRequest(
+      requestModelPost12.id,
+      requestModelPost12.apiType,
+      requestModelPost12.httpRequestModel!,
+    );
+
+    final responseData = responseModel.fromResponse(response: responseRec.$1!);
+    expect(responseData.statusCode, 200);
+    expect(responseData.requestHeaders?['content-type'],
+        'application/json; charset=utf-8');
+  });
+
+  test('Testing latin1 charset added by user', () async {
+    var responseRec = await sendHttpRequest(
+      requestModelPost13.id,
+      requestModelPost13.apiType,
+      requestModelPost13.httpRequestModel!,
+    );
+
+    final responseData = responseModel.fromResponse(response: responseRec.$1!);
+    expect(responseData.statusCode, 200);
+    expect(responseData.requestHeaders?['content-type'],
+        'application/json; charset=latin1');
+  });
+
   test('Testing fromResponse for Bad SSL with certificate check', () async {
     var responseRec = await sendHttpRequest(
       requestModelGetBadSSL.id,

--- a/test/models/response_model_test.dart
+++ b/test/models/response_model_test.dart
@@ -58,7 +58,7 @@ void main() {
     final responseData = responseModel.fromResponse(response: responseRec.$1!);
     expect(responseData.statusCode, 200);
     expect(responseData.body, '{"data":"i love flutter"}');
-    expect(responseData.contentType, 'application/json; charset=utf-8');
+    expect(responseData.contentType, 'application/json');
     expect(responseData.requestHeaders?['content-type'], 'application/json');
   });
 


### PR DESCRIPTION
## PR Description
Fixes the issue of content-type overriding for certain types. I found a workaround soln in github disscussions and it worked just we have to  _Set the body first (this sets default headers), then set the headers._
just like this-
```
Request request = new Request('POST', Uri.parse(url));
request.body = body;
request.headers['content-type'] = 'text/xml';
request.headers['accept'] = 'text/xml';
```
So i have reordered the body and headers assignments for POST, PUT, PATCH, and DELETE methods to follow the workaround where body is set before headers, ensuring proper behavior across platforms.

![Screenshot 2025-04-17 140014](https://github.com/user-attachments/assets/9927fe95-a234-4f24-b191-9b1039200534)
![Screenshot 2025-04-17 140041](https://github.com/user-attachments/assets/b11e7a2d-9fff-4a41-95e9-f4803fefff2e)

## Related Issues

- Closes #630 

### Checklist
- [X] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [X] I have updated my branch and synced it with project `main` branch before making this PR
- [X] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [X] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: already there

## OS on which you have developed and tested the feature?

- [X] Windows
- [ ] macOS
- [ ] Linux
