### PR TITLE
Fix Issue #824 [Mobile] Making copying values (like tokens) from JSON previewer easy for end users 

### DIFF
--- a/packages/json_explorer/lib/src/json_explorer.dart
+++ b/packages/json_explorer/lib/src/json_explorer.dart
@@ -288,17 +288,19 @@ class JsonAttribute extends StatelessWidget {
         node.highlight(isHighlighted: false);
         node.focus(isFocused: false);
       },
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: hasInteraction
-            ? () {
-                if (valueStyle.onTap != null) {
-                  valueStyle.onTap!.call();
-                } else {
-                  _onTap(context);
-                }
-              }
-            : null,
+      child: Listener(
+        behavior: HitTestBehavior.translucent,
+        onPointerDown: (_) {
+          node.highlight();
+          node.focus();
+          if (hasInteraction) {
+            if (valueStyle.onTap != null) {
+              valueStyle.onTap!.call();
+            } else {
+            _onTap(context);
+            }
+          }
+        },
         child: AnimatedBuilder(
           animation: node,
 


### PR DESCRIPTION
## PR Description
This PR adds the feature to copy for mobile users in one click on the key-value pair just like in desktop it shows copy option on hovering. 
So I have replaced the GestureDetector with Listener as this caused issues where taps wouldn’t trigger correctly due to SelectableText or TextFields

https://github.com/user-attachments/assets/5244ce07-99e3-4424-9d23-6b4e51ad0f51


## Related Issues

- Closes #824 

### Checklist
- [X] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [X] I have updated my branch and synced it with project `main` branch before making this PR
- [X] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [X] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
- [ ] Yes
- [X] No, and this is why: Already There

## OS on which you have developed and tested the feature?

- [X] Windows
- [ ] macOS
- [ ] Linux
