### PR TITLE
Fix Issue[Mobile] #842 Headers, Params & Form data text fields get clipped towards bottom for longer texts

### DIFF
--- a/lib/screens/common_widgets/envfield_cell.dart
+++ b/lib/screens/common_widgets/envfield_cell.dart
@@ -37,7 +37,12 @@ class EnvCellField extends StatelessWidget {
       decoration: getTextFieldInputDecoration(
         clrScheme,
         hintText: hintText,
+        isDense: true,
+        // contentPadding: EdgeInsets.symmetric(vertical: 10.0, horizontal: 8.0),
+        contentPadding: const EdgeInsets.symmetric(vertical: 9.0, horizontal: 10.0),
+
       ),
+      
       autocompleteNoTrigger: autocompleteNoTrigger,
       onChanged: onChanged,
     );

--- a/lib/screens/common_widgets/envfield_cell.dart
+++ b/lib/screens/common_widgets/envfield_cell.dart
@@ -38,7 +38,6 @@ class EnvCellField extends StatelessWidget {
         clrScheme,
         hintText: hintText,
         isDense: true,
-        // contentPadding: EdgeInsets.symmetric(vertical: 10.0, horizontal: 8.0),
         contentPadding: const EdgeInsets.symmetric(vertical: 9.0, horizontal: 10.0),
 
       ),

--- a/lib/screens/common_widgets/envfield_cell.dart
+++ b/lib/screens/common_widgets/envfield_cell.dart
@@ -1,3 +1,4 @@
+import 'package:apidash/consts.dart';
 import 'package:apidash_design_system/apidash_design_system.dart';
 import 'package:flutter/material.dart';
 import 'package:multi_trigger_autocomplete_plus/multi_trigger_autocomplete_plus.dart';
@@ -38,10 +39,8 @@ class EnvCellField extends StatelessWidget {
         clrScheme,
         hintText: hintText,
         isDense: true,
-        contentPadding: const EdgeInsets.symmetric(vertical: 9.0, horizontal: 10.0),
-
+        contentPadding: kIsMobile ? kPh6b12 : null,
       ),
-      
       autocompleteNoTrigger: autocompleteNoTrigger,
       onChanged: onChanged,
     );

--- a/packages/apidash_design_system/lib/tokens/measurements.dart
+++ b/packages/apidash_design_system/lib/tokens/measurements.dart
@@ -64,6 +64,11 @@ const kPs0o6 = EdgeInsets.only(
   right: 6,
   bottom: 6,
 );
+const kPh6b12 = EdgeInsets.only(
+  left: 6.0,
+  right: 6.0,
+  bottom: 12.0,
+);
 const kPh60 = EdgeInsets.symmetric(horizontal: 60);
 const kPh60v60 = EdgeInsets.symmetric(vertical: 60, horizontal: 60);
 const kPt24l4 = EdgeInsets.only(


### PR DESCRIPTION
## PR Description

Fixed a UI issue in `EnvCellField` where text was getting clipped from the bottom when it exceeded the width of the textbox.
Updated the `contentPadding` in `getTextFieldInputDecoration` to resolve vertical clipping.

## Related Issues

* Closes #842

### Checklist

* [x] I have gone through the [[contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
* [x] I have updated my branch and synced it with project `main` branch before making this PR
* [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
* [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

*We encourage you to add relevant test cases.*

* [ ] Yes
* [x] No, and this is why: Minor UI padding fix that does not affect logic or behavior requiring testing

## OS on which you have developed and tested the feature?

* [x] Windows
* [ ] macOS
* [ ] Linux