### PR TITLE
Add pre-request and post-response scripting

### DIFF
--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -487,7 +487,6 @@ const kMsgClearHistorySuccess = 'History cleared successfully';
 const kMsgClearHistoryError = 'Error clearing history';
 const kMsgShareError = "Unable to share";
 
-
 const String setupScript = r"""
 // === APIDash Setup Script ===
 
@@ -547,7 +546,7 @@ try {
 // This object provides functions to interact with the request, response,
 // environment, and the Dart host application.
 
-const ad = {
+var ad = {
   /**
    * Functions to modify the request object *before* it is sent.
    * Only available in pre-request scripts.

--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -485,3 +485,510 @@ const kMsgClearHistory =
 const kMsgClearHistorySuccess = 'History cleared successfully';
 const kMsgClearHistoryError = 'Error clearing history';
 const kMsgShareError = "Unable to share";
+
+
+const String setupScript = r"""
+// === APIDash Setup Script ===
+
+// --- 1. Parse Injected Data ---
+// These variables are expected to be populated by Dart before this script runs.
+// Example: const injectedRequestJson = '{"method":"get", "url":"...", ...}';
+
+let request = {}; // Will hold the RequestModel data
+let response = {}; // Will hold the ResponseModel data (only for post-request)
+let environment = {}; // Will hold the active environment variables
+
+// Note: Using 'let' because environment might be completely cleared/reassigned.
+
+try {
+  // 'injectedRequestJson' should always be provided (even if empty for some edge case)
+  if (typeof injectedRequestJson !== 'undefined' && injectedRequestJson) {
+    request = JSON.parse(injectedRequestJson);
+    // Ensure essential arrays exist if they are null/undefined after parsing
+    request.headers = request.headers || [];
+    request.params = request.params || [];
+    request.formData = request.formData || [];
+  } else {
+     // Should not happen based on the plan, but good to log
+     sendMessage('consoleError', JSON.stringify(['Setup Error: injectedRequestJson is missing or empty.']));
+  }
+
+  // 'injectedResponseJson' is only for post-response scripts
+  if (typeof injectedResponseJson !== 'undefined' && injectedResponseJson) {
+    response = JSON.parse(injectedResponseJson);
+    // Ensure response headers map exists
+    response.headers = response.headers || {};
+    response.requestHeaders = response.requestHeaders || {};
+  }
+
+  // 'injectedEnvironmentJson' should always be provided
+  if (typeof injectedEnvironmentJson !== 'undefined' && injectedEnvironmentJson) {
+    environment = JSON.parse(injectedEnvironmentJson);
+  } else {
+     // Should not happen based on the plan, but good to log
+     sendMessage('consoleError', JSON.stringify(['Setup Error: injectedEnvironmentJson is missing or empty.']));
+     environment = {}; // Initialize to empty object to avoid errors later
+  }
+
+} catch (e) {
+  // Send error back to Dart if parsing fails catastrophically
+  sendMessage('fatalError', JSON.stringify({
+      message: 'Failed to parse injected JSON data.',
+      error: e.toString(),
+      stack: e.stack
+  }));
+  // Optionally, re-throw to halt script execution immediately
+  // throw new Error('Failed to parse injected JSON data: ' + e.toString());
+}
+
+
+// --- 2. Define APIDash Helper (`ad`) Object ---
+// This object provides functions to interact with the request, response,
+// environment, and the Dart host application.
+
+const ad = {
+  /**
+   * Functions to modify the request object *before* it is sent.
+   * Only available in pre-request scripts.
+   * Changes are made directly to the 'request' JS object.
+   */
+  request: {
+    /**
+     * Access and modify request headers. Remember header names are case-insensitive in HTTP,
+     * but comparisons here might be case-sensitive unless handled carefully.
+     * Headers are represented as an array of objects: [{name: string, value: string}, ...]
+     */
+    headers: {
+      /**
+       * Adds or updates a header. If a header with the same name (case-sensitive)
+       * already exists, it updates its value. Otherwise, adds a new header.
+       * @param {string} key The header name.
+       * @param {string} value The header value.
+       */
+      set: (key, value) => {
+        if (!request || typeof request !== 'object' || !Array.isArray(request.headers)) return; // Safety check
+        if (typeof key !== 'string') return; // Safety check
+        const stringValue = String(value); // Ensure value is a string
+        const existingHeaderIndex = request.headers.findIndex(h => typeof h === 'object' && h.name === key);
+        if (existingHeaderIndex > -1) {
+          request.headers[existingHeaderIndex].value = stringValue;
+        } else {
+          request.headers.push({ name: key, value: stringValue });
+        }
+      },
+       /**
+       * Gets the value of the first header matching the key (case-sensitive).
+       * @param {string} key The header name.
+       * @returns {string|undefined} The header value or undefined if not found.
+       */
+      get: (key) => {
+        if (!request || typeof request !== 'object' || !Array.isArray(request.headers)) return undefined; // Safety check
+        const header = request.headers.find(h => typeof h === 'object' && h.name === key);
+        return header ? header.value : undefined;
+      },
+      /**
+       * Removes all headers with the given name (case-sensitive).
+       * @param {string} key The header name to remove.
+       */
+      remove: (key) => {
+         if (!request || typeof request !== 'object' || !Array.isArray(request.headers)) return; // Safety check
+         request.headers = request.headers.filter(h => !(typeof h === 'object' && h.name === key));
+      },
+       /**
+       * Checks if a header with the given name exists (case-sensitive).
+       * @param {string} key The header name.
+       * @returns {boolean} True if the header exists, false otherwise.
+       */
+      has: (key) => {
+        if (!request || typeof request !== 'object' || !Array.isArray(request.headers)) return false; // Safety check
+        return request.headers.some(h => typeof h === 'object' && h.name === key);
+      },
+      /**
+       * Clears all request headers.
+       */
+      clear: () => {
+        if (!request || typeof request !== 'object') return; // Safety check
+        request.headers = [];
+      }
+    },
+
+    /**
+     * Access and modify URL query parameters.
+     * Params are represented as an array of objects: [{name: string, value: string}, ...]
+     */
+    params: {
+       /**
+       * Adds or updates a query parameter. If a param with the same name (case-sensitive)
+       * already exists, it updates its value. Use multiple times for duplicate keys if needed by server.
+       * Consider URL encoding implications - values should likely be pre-encoded if necessary.
+       * @param {string} key The parameter name.
+       * @param {string} value The parameter value.
+       */
+       set: (key, value) => {
+        if (!request || typeof request !== 'object' || !Array.isArray(request.params)) return; // Safety check
+        if (typeof key !== 'string') return; // Safety check
+        const stringValue = String(value); // Ensure value is a string
+         // Note: Unlike headers, duplicate param keys are sometimes meaningful.
+         // This simple 'set' replaces the *first* occurrence or adds if not found.
+         // A different method like 'add' could be used to allow duplicates.
+        const existingParamIndex = request.params.findIndex(p => typeof p === 'object' && p.name === key);
+        if (existingParamIndex > -1) {
+          request.params[existingParamIndex].value = stringValue;
+        } else {
+          request.params.push({ name: key, value: stringValue });
+        }
+      },
+       /**
+       * Gets the value of the first query parameter matching the key (case-sensitive).
+       * @param {string} key The parameter name.
+       * @returns {string|undefined} The parameter value or undefined if not found.
+       */
+      get: (key) => {
+         if (!request || typeof request !== 'object' || !Array.isArray(request.params)) return undefined; // Safety check
+         const param = request.params.find(p => typeof p === 'object' && p.name === key);
+         return param ? param.value : undefined;
+      },
+       /**
+       * Removes all query parameters with the given name (case-sensitive).
+       * @param {string} key The parameter name to remove.
+       */
+      remove: (key) => {
+         if (!request || typeof request !== 'object' || !Array.isArray(request.params)) return; // Safety check
+         request.params = request.params.filter(p => !(typeof p === 'object' && p.name === key));
+      },
+       /**
+       * Checks if a query parameter with the given name exists (case-sensitive).
+       * @param {string} key The parameter name.
+       * @returns {boolean} True if the parameter exists, false otherwise.
+       */
+      has: (key) => {
+        if (!request || typeof request !== 'object' || !Array.isArray(request.params)) return false; // Safety check
+        return request.params.some(p => typeof p === 'object' && p.name === key);
+      },
+       /**
+       * Clears all query parameters.
+       */
+      clear: () => {
+        if (!request || typeof request !== 'object') return; // Safety check
+        request.params = [];
+      }
+    },
+
+    /**
+     * Access or modify the request URL.
+     */
+    url: {
+        /**
+         * Gets the current request URL string.
+         * @returns {string} The URL.
+         */
+        get: () => {
+            return (request && typeof request === 'object') ? request.url : '';
+        },
+        /**
+         * Sets the request URL string.
+         * @param {string} newUrl The new URL.
+         */
+        set: (newUrl) => {
+            if (request && typeof request === 'object' && typeof newUrl === 'string') {
+                request.url = newUrl;
+            }
+        }
+        // Future: Could add methods to manipulate parts (host, path, query) if needed
+    },
+
+    /**
+     * Access or modify the request body.
+     */
+    body: {
+        /**
+         * Gets the current request body content (string).
+         * Note: For form-data, this returns the raw string body (if any), not the structured data. Use `ad.request.formData` for that.
+         * @returns {string|null|undefined} The request body string.
+         */
+        get: () => {
+            return (request && typeof request === 'object') ? request.body : undefined;
+        },
+        /**
+         * Sets the request body content (string).
+         * Important: Also updates the Content-Type if setting JSON/Text, unless a Content-Type header is already explicitly set.
+         * Setting the body will clear form-data if the content type changes away from form-data.
+         * @param {string|object} newBody The new body content. If an object is provided, it's stringified as JSON.
+         * @param {string} [contentType] Optionally specify the Content-Type (e.g., 'application/json', 'text/plain'). If not set, defaults to 'text/plain' or 'application/json' if newBody is an object.
+         */
+        set: (newBody, contentType) => {
+            if (!request || typeof request === 'object') return; // Safety check
+
+            let finalBody = '';
+            let finalContentType = contentType;
+
+            if (typeof newBody === 'object' && newBody !== null) {
+                try {
+                    finalBody = JSON.stringify(newBody);
+                    finalContentType = contentType || 'application/json'; // Default to JSON if object
+                    request.bodyContentType = 'json'; // Update internal model type
+                } catch (e) {
+                     sendMessage('consoleError', JSON.stringify(['Error stringifying object for request body:', e.toString()]));
+                     return; // Don't proceed if stringify fails
+                }
+            } else {
+                finalBody = String(newBody); // Ensure it's a string
+                finalContentType = contentType || 'text/plain'; // Default to text
+                 request.bodyContentType = 'text'; // Update internal model type
+            }
+
+            request.body = finalBody;
+
+            // Clear form data if we are setting a string/json body
+            request.formData = [];
+
+            // Set Content-Type header if not already set by user explicitly in headers
+            // Use case-insensitive check for existing Content-Type
+            const hasContentTypeHeader = request.headers.some(h => typeof h === 'object' && h.name.toLowerCase() === 'content-type');
+            if (!hasContentTypeHeader && finalContentType) {
+                ad.request.headers.set('Content-Type', finalContentType);
+            }
+        }
+        // TODO: Add helpers for request.formData if needed (similar to headers/params)
+    },
+
+     /**
+     * Access or modify the request method (e.g., 'GET', 'POST').
+     */
+    method: {
+         /**
+         * Gets the current request method.
+         * @returns {string} The HTTP method (e.g., "get", "post").
+         */
+        get: () => {
+             return (request && typeof request === 'object') ? request.method : '';
+        },
+        /**
+         * Sets the request method.
+         * @param {string} newMethod The new HTTP method (e.g., "POST", "put"). Case might matter for the Dart model enum.
+         */
+        set: (newMethod) => {
+            if (request && typeof request === 'object' && typeof newMethod === 'string') {
+                 // Consider converting to lowercase to match HTTPVerb enum likely usage
+                 request.method = newMethod.toLowerCase();
+            }
+        }
+    }
+  },
+
+  /**
+   * Read-only access to the response data.
+   * Only available in post-response scripts.
+   */
+  response: {
+    /**
+     * The HTTP status code of the response.
+     * @type {number|undefined}
+     */
+    get status() { return (response && typeof response === 'object') ? response.statusCode : undefined; },
+
+    /**
+     * The response body as a string. If the response was binary, this might be decoded text
+     * based on Content-Type or potentially garbled. Use `bodyBytes` for raw binary data access (if provided).
+     * @type {string|undefined}
+     */
+    get body() { return (response && typeof response === 'object') ? response.body : undefined; },
+
+     /**
+     * The response body automatically formatted (e.g., pretty-printed JSON). Provided by Dart.
+     * @type {string|undefined}
+     */
+    get formattedBody() { return (response && typeof response === 'object') ? response.formattedBody : undefined; },
+
+    /**
+     * The raw response body as an array of bytes (numbers).
+     * Note: This relies on the Dart side serializing Uint8List correctly (e.g., as List<int>).
+     * Accessing large byte arrays in JS might be memory-intensive.
+     * @type {number[]|undefined}
+     */
+     get bodyBytes() { return (response && typeof response === 'object') ? response.bodyBytes : undefined; },
+
+
+    /**
+     * The approximate time taken for the request-response cycle. Provided by Dart.
+     * Assumes Dart sends it as microseconds and converts it to milliseconds here.
+     * @type {number|undefined} Time in milliseconds.
+     */
+     get time() {
+        // Assuming response.time is in microseconds from Dart's DurationConverter
+        return (response && typeof response === 'object' && typeof response.time === 'number') ? response.time / 1000 : undefined;
+     },
+
+    /**
+     * An object containing the response headers (keys are header names, values are header values).
+     * Header names are likely lowercase from the http package.
+     * @type {object|undefined} e.g., {'content-type': 'application/json', ...}
+     */
+    get headers() { return (response && typeof response === 'object') ? response.headers : undefined; },
+
+    /**
+     * An object containing the request headers that were actually sent (useful for verification).
+     * Header names are likely lowercase.
+     * @type {object|undefined} e.g., {'user-agent': '...', ...}
+     */
+    get requestHeaders() { return (response && typeof response === 'object') ? response.requestHeaders : undefined; },
+
+
+    /**
+     * Attempts to parse the response body as JSON.
+     * @returns {object|undefined} The parsed JSON object, or undefined if parsing fails or body is empty.
+     */
+    json: () => {
+      if (!ad.response.body) {
+        return undefined;
+      }
+      try {
+        return JSON.parse(ad.response.body);
+      } catch (e) {
+        ad.console.error("Failed to parse response body as JSON:", e.toString());
+        return undefined;
+      }
+    },
+
+    /**
+     * Gets a specific response header value (case-insensitive key lookup).
+     * @param {string} key The header name.
+     * @returns {string|undefined} The header value or undefined if not found.
+     */
+    getHeader: (key) => {
+        const headers = ad.response.headers;
+        if (!headers || typeof key !== 'string') return undefined;
+        const lowerKey = key.toLowerCase();
+        const headerKey = Object.keys(headers).find(k => k.toLowerCase() === lowerKey);
+        return headerKey ? headers[headerKey] : undefined;
+    }
+  },
+
+  /**
+   * Access and modify environment variables for the active environment.
+   * Changes are made to the 'environment' JS object and sent back to Dart.
+   */
+  environment: {
+    /**
+     * Gets the value of an environment variable.
+     * @param {string} key The variable name.
+     * @returns {any} The variable value or undefined if not found.
+     */
+    get: (key) => {
+      return (environment && typeof environment === 'object') ? environment[key] : undefined;
+    },
+    /**
+     * Sets the value of an environment variable.
+     * @param {string} key The variable name.
+     * @param {any} value The variable value. Should be JSON-serializable (string, number, boolean, object, array).
+     */
+    set: (key, value) => {
+      if (environment && typeof environment === 'object' && typeof key === 'string') {
+        environment[key] = value;
+      }
+    },
+    /**
+     * Removes an environment variable.
+     * @param {string} key The variable name to remove.
+     */
+    unset: (key) => {
+      if (environment && typeof environment === 'object') {
+        delete environment[key];
+      }
+    },
+    /**
+     * Checks if an environment variable exists.
+     * @param {string} key The variable name.
+     * @returns {boolean} True if the variable exists, false otherwise.
+     */
+    has: (key) => {
+       return (environment && typeof environment === 'object') ? environment.hasOwnProperty(key) : false;
+    },
+    /**
+     * Removes all variables from the current environment scope.
+     */
+    clear: () => {
+      if (environment && typeof environment === 'object') {
+          for (const key in environment) {
+              if (environment.hasOwnProperty(key)) {
+                  delete environment[key];
+              }
+          }
+      }
+    }
+    // Note: A separate 'globals' object could be added here if global variables are implemented distinctly.
+  },
+
+  /**
+   * Provides logging capabilities. Messages are sent back to Dart via the bridge.
+   */
+  console: {
+    /**
+     * Logs informational messages.
+     * @param {...any} args Values to log. They will be JSON-stringified.
+     */
+    log: (...args) => {
+      try {
+        sendMessage('consoleLog', JSON.stringify(args));
+      } catch(e) { /* Ignore stringify errors for console? Or maybe log the error itself? */ }
+    },
+    /**
+     * Logs warning messages.
+     * @param {...any} args Values to log.
+     */
+    warn: (...args) => {
+       try {
+         sendMessage('consoleWarn', JSON.stringify(args));
+       } catch(e) { /* Ignore */ }
+    },
+    /**
+     * Logs error messages.
+     * @param {...any} args Values to log.
+     */
+    error: (...args) => {
+      try {
+        sendMessage('consoleError', JSON.stringify(args));
+      } catch(e) { /* Ignore */ }
+    }
+  },
+
+  /**
+   * Basic testing functions (example structure).
+   * Results might need to be collected and sent back via the bridge or at the end.
+   */
+  // test: (testName, callback) => {
+  //   try {
+  //     callback();
+  //     ad.console.log(`Test Passed: ${testName}`);
+  //     // TODO: Potentially collect results: sendMessage('testResult', JSON.stringify({ name: testName, status: 'passed' }));
+  //   } catch (e) {
+  //     ad.console.error(`Test Failed: ${testName}`, e.toString(), e.stack);
+  //      // TODO: Potentially collect results: sendMessage('testResult', JSON.stringify({ name: testName, status: 'failed', error: e.toString() }));
+  //   }
+  // },
+
+  // expect: (value) => {
+  //   // Very basic assertion example (can be expanded or use a tiny library)
+  //   return {
+  //     toBe: (expected) => {
+  //       if (value !== expected) {
+  //         throw new Error(`Assertion Failed: Expected ${JSON.stringify(value)} to be ${JSON.stringify(expected)}`);
+  //       }
+  //     },
+       // Add more assertions: toBeTruthy, toEqual (deep compare), etc.
+  //   };
+  // }
+
+  // TODO: Add other utilities if needed: crypto, base64 (atob/btoa - might need polyfills)
+  // E.g.,
+  // crypto: { /* methods */ },
+  // btoa: (str) => btoa(str), // Needs btoa to be available in the JS context
+  // atob: (encodedStr) => atob(encodedStr) // Needs atob
+
+};
+
+// --- End of APIDash Setup Script ---
+
+// User's script will be appended below this line by Dart.
+// Dart will also append the final JSON.stringify() call to return results.
+""";

--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -501,63 +501,63 @@ let environment = {}; // Will hold the *active* environment variables as a simpl
 // Note: Using 'let' because environment might be completely cleared/reassigned by ad.environment.clear().
 
 try {
-  // 'injectedRequestJson' should always be provided
-  if (typeof injectedRequestJson !== 'undefined' && injectedRequestJson) {
-    request = JSON.parse(injectedRequestJson);
-    // Ensure essential arrays exist if they are null/undefined after parsing
-    request.headers = request.headers || [];
-    request.params = request.params || [];
-    request.formData = request.formData || [];
-  } else {
-     sendMessage('consoleError', JSON.stringify(['Setup Error: injectedRequestJson is missing or empty.']));
-  }
-
-  // 'injectedResponseJson' is only for post-response scripts
-  if (typeof injectedResponseJson !== 'undefined' && injectedResponseJson) {
-    response = JSON.parse(injectedResponseJson);
-    // Ensure response headers map exists
-    response.headers = response.headers || {};
-    response.requestHeaders = response.requestHeaders || {};
-  }
-
-  // 'injectedEnvironmentJson' should always be provided
-  if (typeof injectedEnvironmentJson !== 'undefined' && injectedEnvironmentJson) {
-    const parsedEnvData = JSON.parse(injectedEnvironmentJson);
-
-    environment = {}; // Initialize the target simple map
-
-    if (parsedEnvData && Array.isArray(parsedEnvData.values)) {
-      parsedEnvData.values.forEach(variable => {
-        // Check if the variable object is valid and enabled
-        if (variable && typeof variable === 'object' && variable.enabled === true && typeof variable.key === 'string') {
-           // Add the key-value pair to our simplified 'environment' map
-           environment[variable.key] = variable.value;
-        }
-      });
-      // sendMessage('consoleLog', JSON.stringify(['Successfully parsed environment variables.']));
+    // 'injectedRequestJson' should always be provided
+    if (typeof injectedRequestJson !== 'undefined' && injectedRequestJson) {
+        request = JSON.parse(injectedRequestJson);
+        // Ensure essential arrays exist if they are null/undefined after parsing
+        request.headers = request.headers || [];
+        request.params = request.params || [];
+        request.formData = request.formData || [];
     } else {
-      // Log a warning if the structure is not as expected, but continue with an empty env
-      sendMessage('consoleWarn', JSON.stringify([
-          'Setup Warning: injectedEnvironmentJson does not have the expected structure ({values: Array}). Using an empty environment.',
-          'Received Data:', parsedEnvData // Log received data for debugging
-      ]));
-      environment = {}; // Ensure it's an empty object
+        sendMessage('consoleError', JSON.stringify(['Setup Error: injectedRequestJson is missing or empty.']));
     }
 
-  } else {
-     sendMessage('consoleError', JSON.stringify(['Setup Error: injectedEnvironmentJson is missing or empty.']));
-     environment = {}; // Initialize to empty object to avoid errors later
-  }
+    // 'injectedResponseJson' is only for post-response scripts
+    if (typeof injectedResponseJson !== 'undefined' && injectedResponseJson) {
+        response = JSON.parse(injectedResponseJson);
+        // Ensure response headers map exists
+        response.headers = response.headers || {};
+        response.requestHeaders = response.requestHeaders || {};
+    }
+
+    // 'injectedEnvironmentJson' should always be provided
+    if (typeof injectedEnvironmentJson !== 'undefined' && injectedEnvironmentJson) {
+        const parsedEnvData = JSON.parse(injectedEnvironmentJson);
+
+        environment = {}; // Initialize the target simple map
+
+        if (parsedEnvData && Array.isArray(parsedEnvData.values)) {
+            parsedEnvData.values.forEach(variable => {
+                // Check if the variable object is valid and enabled
+                if (variable && typeof variable === 'object' && variable.enabled === true && typeof variable.key === 'string') {
+                    // Add the key-value pair to our simplified 'environment' map
+                    environment[variable.key] = variable.value;
+                }
+            });
+            // sendMessage('consoleLog', JSON.stringify(['Successfully parsed environment variables.']));
+        } else {
+            // Log a warning if the structure is not as expected, but continue with an empty env
+            sendMessage('consoleWarn', JSON.stringify([
+                'Setup Warning: injectedEnvironmentJson does not have the expected structure ({values: Array}). Using an empty environment.',
+                'Received Data:', parsedEnvData // Log received data for debugging
+            ]));
+            environment = {}; // Ensure it's an empty object
+        }
+
+    } else {
+        sendMessage('consoleError', JSON.stringify(['Setup Error: injectedEnvironmentJson is missing or empty.']));
+        environment = {}; // Initialize to empty object to avoid errors later
+    }
 
 } catch (e) {
-  // Send error back to Dart if parsing fails catastrophically
-  sendMessage('fatalError', JSON.stringify({
-      message: 'Failed to parse injected JSON data.',
-      error: e.toString(),
-      stack: e.stack
-  }));
-  // Optionally, re-throw to halt script execution immediately
-  // throw new Error('Failed to parse injected JSON data: ' + e.toString());
+    // Send error back to Dart if parsing fails catastrophically
+    sendMessage('fatalError', JSON.stringify({
+        message: 'Failed to parse injected JSON data.',
+        error: e.toString(),
+        stack: e.stack
+    }));
+    // Optionally, re-throw to halt script execution immediately
+    // throw new Error('Failed to parse injected JSON data: ' + e.toString());
 }
 
 
@@ -566,453 +566,535 @@ try {
 // environment, and the Dart host application.
 
 const ad = {
-  /**
-   * Functions to modify the request object *before* it is sent.
-   * Only available in pre-request scripts.
-   * Changes are made directly to the 'request' JS object.
-   */
-  request: {
     /**
-     * Access and modify request headers. Remember header names are case-insensitive in HTTP,
-     * but comparisons here might be case-sensitive unless handled carefully.
-     * Headers are represented as an array of objects: [{name: string, value: string}, ...]
+     * Functions to modify the request object *before* it is sent.
+     * Only available in pre-request scripts.
+     * Changes are made directly to the 'request' JS object.
      */
-    headers: {
-      /**
-       * Adds or updates a header. If a header with the same name (case-sensitive)
-       * already exists, it updates its value. Otherwise, adds a new header.
-       * @param {string} key The header name.
-       * @param {string} value The header value.
-       */
-      set: (key, value) => {
-        if (!request || typeof request !== 'object' || !Array.isArray(request.headers)) return; // Safety check
-        if (typeof key !== 'string') return; // Safety check
-        const stringValue = String(value); // Ensure value is a string
-        const existingHeaderIndex = request.headers.findIndex(h => typeof h === 'object' && h.name === key);
-        if (existingHeaderIndex > -1) {
-          request.headers[existingHeaderIndex].value = stringValue;
-        } else {
-          request.headers.push({ name: key, value: stringValue });
-        }
-      },
-       /**
-       * Gets the value of the first header matching the key (case-sensitive).
-       * @param {string} key The header name.
-       * @returns {string|undefined} The header value or undefined if not found.
-       */
-      get: (key) => {
-        if (!request || typeof request !== 'object' || !Array.isArray(request.headers)) return undefined; // Safety check
-        const header = request.headers.find(h => typeof h === 'object' && h.name === key);
-        return header ? header.value : undefined;
-      },
-      /**
-       * Removes all headers with the given name (case-sensitive).
-       * @param {string} key The header name to remove.
-       */
-      remove: (key) => {
-         if (!request || typeof request !== 'object' || !Array.isArray(request.headers)) return; // Safety check
-         request.headers = request.headers.filter(h => !(typeof h === 'object' && h.name === key));
-      },
-       /**
-       * Checks if a header with the given name exists (case-sensitive).
-       * @param {string} key The header name.
-       * @returns {boolean} True if the header exists, false otherwise.
-       */
-      has: (key) => {
-        if (!request || typeof request !== 'object' || !Array.isArray(request.headers)) return false; // Safety check
-        return request.headers.some(h => typeof h === 'object' && h.name === key);
-      },
-      /**
-       * Clears all request headers.
-       */
-      clear: () => {
-        if (!request || typeof request !== 'object') return; // Safety check
-        request.headers = [];
-      }
-    },
-
-    /**
-     * Access and modify URL query parameters.
-     * Params are represented as an array of objects: [{name: string, value: string}, ...]
-     */
-    params: {
-       /**
-       * Adds or updates a query parameter. If a param with the same name (case-sensitive)
-       * already exists, it updates its value. Use multiple times for duplicate keys if needed by server.
-       * Consider URL encoding implications - values should likely be pre-encoded if necessary.
-       * @param {string} key The parameter name.
-       * @param {string} value The parameter value.
-       */
-       set: (key, value) => {
-        if (!request || typeof request !== 'object' || !Array.isArray(request.params)) return; // Safety check
-        if (typeof key !== 'string') return; // Safety check
-        const stringValue = String(value); // Ensure value is a string
-         // Note: Unlike headers, duplicate param keys are sometimes meaningful.
-         // This simple 'set' replaces the *first* occurrence or adds if not found.
-         // A different method like 'add' could be used to allow duplicates.
-        const existingParamIndex = request.params.findIndex(p => typeof p === 'object' && p.name === key);
-        if (existingParamIndex > -1) {
-          request.params[existingParamIndex].value = stringValue;
-        } else {
-          request.params.push({ name: key, value: stringValue });
-        }
-      },
-       /**
-       * Gets the value of the first query parameter matching the key (case-sensitive).
-       * @param {string} key The parameter name.
-       * @returns {string|undefined} The parameter value or undefined if not found.
-       */
-      get: (key) => {
-         if (!request || typeof request !== 'object' || !Array.isArray(request.params)) return undefined; // Safety check
-         const param = request.params.find(p => typeof p === 'object' && p.name === key);
-         return param ? param.value : undefined;
-      },
-       /**
-       * Removes all query parameters with the given name (case-sensitive).
-       * @param {string} key The parameter name to remove.
-       */
-      remove: (key) => {
-         if (!request || typeof request !== 'object' || !Array.isArray(request.params)) return; // Safety check
-         request.params = request.params.filter(p => !(typeof p === 'object' && p.name === key));
-      },
-       /**
-       * Checks if a query parameter with the given name exists (case-sensitive).
-       * @param {string} key The parameter name.
-       * @returns {boolean} True if the parameter exists, false otherwise.
-       */
-      has: (key) => {
-        if (!request || typeof request !== 'object' || !Array.isArray(request.params)) return false; // Safety check
-        return request.params.some(p => typeof p === 'object' && p.name === key);
-      },
-       /**
-       * Clears all query parameters.
-       */
-      clear: () => {
-        if (!request || typeof request !== 'object') return; // Safety check
-        request.params = [];
-      }
-    },
-
-    /**
-     * Access or modify the request URL.
-     */
-    url: {
+    request: {
         /**
-         * Gets the current request URL string.
-         * @returns {string} The URL.
+         * Access and modify request headers. Remember header names are case-insensitive in HTTP,
+         * but comparisons here might be case-sensitive unless handled carefully.
+         * Headers are represented as an array of objects: [{name: string, value: string}, ...]
          */
-        get: () => {
-            return (request && typeof request === 'object') ? request.url : '';
-        },
-        /**
-         * Sets the request URL string.
-         * @param {string} newUrl The new URL.
-         */
-        set: (newUrl) => {
-            if (request && typeof request === 'object' && typeof newUrl === 'string') {
-                request.url = newUrl;
-            }
-        }
-        // Future: Could add methods to manipulate parts (host, path, query) if needed
-    },
+        headers: {
+            /**
+             * Adds or updates a header. If a header with the same name (case-sensitive)
+             * already exists, it updates its value. Otherwise, adds a new header.
+             * Also updates the isHeaderEnabledList to include {true} by default
+             * @param {string} key The header name.
+             * @param {string} value The header value.
+             * @param {boolean} isHeaderEnabledList value.
+             */
+            set: (key, value) => {
+                if (!request || typeof request !== 'object' || !Array.isArray(request.headers)) return;
+                if (typeof key !== 'string') return;
 
-    /**
-     * Access or modify the request body.
-     */
-    body: {
-        /**
-         * Gets the current request body content (string).
-         * Note: For form-data, this returns the raw string body (if any), not the structured data. Use `ad.request.formData` for that.
-         * @returns {string|null|undefined} The request body string.
-         */
-        get: () => {
-            return (request && typeof request === 'object') ? request.body : undefined;
-        },
-        /**
-         * Sets the request body content (string).
-         * Important: Also updates the Content-Type if setting JSON/Text, unless a Content-Type header is already explicitly set.
-         * Setting the body will clear form-data if the content type changes away from form-data.
-         * @param {string|object} newBody The new body content. If an object is provided, it's stringified as JSON.
-         * @param {string} [contentType] Optionally specify the Content-Type (e.g., 'application/json', 'text/plain'). If not set, defaults to 'text/plain' or 'application/json' if newBody is an object.
-         */
-        set: (newBody, contentType) => {
-            if (!request || typeof request !== 'object') return; // Safety check fix: check !request or typeof !== object
+                const stringValue = String(value);
+                const existingHeaderIndex = request.headers.findIndex(
+                    h => typeof h === 'object' && h.name === key
+                );
 
-            let finalBody = '';
-            let finalContentType = contentType;
-
-            if (typeof newBody === 'object' && newBody !== null) {
-                try {
-                    finalBody = JSON.stringify(newBody);
-                    finalContentType = contentType || 'application/json'; // Default to JSON if object
-                    request.bodyContentType = 'json'; // Update internal model type
-                } catch (e) {
-                     sendMessage('consoleError', JSON.stringify(['Error stringifying object for request body:', e.toString()]));
-                     return; // Don't proceed if stringify fails
+                if (!Array.isArray(request.isHeaderEnabledList)) {
+                    request.isHeaderEnabledList = [];
                 }
-            } else {
-                finalBody = String(newBody); // Ensure it's a string
-                finalContentType = contentType || 'text/plain'; // Default to text
-                 request.bodyContentType = 'text'; // Update internal model type
+
+                if (existingHeaderIndex > -1) {
+                    request.headers[existingHeaderIndex].value = stringValue;
+                    request.isHeaderEnabledList[existingHeaderIndex] = true;
+                } else {
+                    request.headers.push({
+                        name: key,
+                        value: stringValue
+                    });
+                    request.isHeaderEnabledList.push(true);
+                }
+            },
+            /**
+             * Gets the value of the first header matching the key (case-sensitive).
+             * @param {string} key The header name.
+             * @returns {string|undefined} The header value or undefined if not found.
+             */
+
+            get: (key) => {
+                if (!request || typeof request !== 'object' || !Array.isArray(request.headers)) return undefined;
+                const header = request.headers.find(h => typeof h === 'object' && h.name === key);
+                return header ? header.value : undefined;
+            },
+
+            /**
+             * Removes all headers with the given name (case-sensitive).
+             * @param {string} key The header name to remove.
+             */
+
+            remove: (key) => {
+                if (!request || typeof request !== 'object' || !Array.isArray(request.headers)) return;
+
+                if (!Array.isArray(request.isHeaderEnabledList)) {
+                    request.isHeaderEnabledList = [];
+                }
+
+                const indicesToRemove = [];
+                request.headers.forEach((h, index) => {
+                    if (typeof h === 'object' && h.name === key) {
+                        indicesToRemove.push(index);
+                    }
+                });
+
+                // Remove from end to start to prevent index shifting
+                for (let i = indicesToRemove.length - 1; i >= 0; i--) {
+                    const idx = indicesToRemove[i];
+                    request.headers.splice(idx, 1);
+                    request.isHeaderEnabledList.splice(idx, 1);
+                }
+            },
+            /**
+             * Checks if a header with the given name exists (case-sensitive).
+             * @param {string} key The header name.
+             * @returns {boolean} True if the header exists, false otherwise.
+             */
+
+            has: (key) => {
+                if (!request || typeof request !== 'object' || !Array.isArray(request.headers)) return false;
+                return request.headers.some(h => typeof h === 'object' && h.name === key);
+            },
+            /**
+             * Clears all request headers along with isHeaderEnabledList.
+             */
+
+            clear: () => {
+                if (!request || typeof request !== 'object') return;
+                request.headers = [];
+                request.isHeaderEnabledList = [];
             }
+        },
 
-            request.body = finalBody;
+        /**
+         * Access and modify URL query parameters.
+         * Params are represented as an array of objects: [{name: string, value: string}, ...]
+         */
+        params: {
+            /**
+             * Adds or updates a query parameter. If a param with the same name (case-sensitive)
+             * already exists, it updates its value. Use multiple times for duplicate keys if needed by server.
+             * Consider URL encoding implications - values should likely be pre-encoded if necessary.
+             * @param {string} key The parameter name.
+             * @param {string} value The parameter value.
+             */
+            set: (key, value) => {
+                if (!request || typeof request !== 'object' || !Array.isArray(request.params)) return;
+                if (typeof key !== 'string') return;
 
-            // Clear form data if we are setting a string/json body
-            request.formData = [];
+                const stringValue = String(value);
 
-            // Set Content-Type header if not already set by user explicitly in headers
-            // Use case-insensitive check for existing Content-Type
-            const hasContentTypeHeader = request.headers.some(h => typeof h === 'object' && h.name.toLowerCase() === 'content-type');
-            if (!hasContentTypeHeader && finalContentType) {
-                ad.request.headers.set('Content-Type', finalContentType);
+                if (!Array.isArray(request.isParamEnabledList)) {
+                    request.isParamEnabledList = [];
+                }
+
+                const existingParamIndex = request.params.findIndex(p => typeof p === 'object' && p.name === key);
+
+                if (existingParamIndex > -1) {
+                    request.params[existingParamIndex].value = stringValue;
+                    request.isParamEnabledList[existingParamIndex] = true;
+                } else {
+                    request.params.push({
+                        name: key,
+                        value: stringValue
+                    });
+                    request.isParamEnabledList.push(true);
+                }
+            },
+            /**
+             * Gets the value of the first query parameter matching the key (case-sensitive).
+             * @param {string} key The parameter name.
+             * @returns {string|undefined} The parameter value or undefined if not found.
+             */
+            get: (key) => {
+                if (!request || typeof request !== 'object' || !Array.isArray(request.params)) return undefined; // Safety check
+                const param = request.params.find(p => typeof p === 'object' && p.name === key);
+                return param ? param.value : undefined;
+            },
+            /**
+             * Removes all query parameters with the given name (case-sensitive).
+             * @param {string} key The parameter name to remove.
+             */
+            remove: (key) => {
+                if (!request || typeof request !== 'object' || !Array.isArray(request.params)) return;
+
+                if (!Array.isArray(request.isParamEnabledList)) {
+                    request.isParamEnabledList = [];
+                }
+
+                const indicesToRemove = [];
+                request.params.forEach((p, index) => {
+                    if (typeof p === 'object' && p.name === key) {
+                        indicesToRemove.push(index);
+                    }
+                });
+
+                for (let i = indicesToRemove.length - 1; i >= 0; i--) {
+                    const idx = indicesToRemove[i];
+                    request.params.splice(idx, 1);
+                    request.isParamEnabledList.splice(idx, 1);
+                }
+            },
+            /**
+             * Checks if a query parameter with the given name exists (case-sensitive).
+             * @param {string} key The parameter name.
+             * @returns {boolean} True if the parameter exists, false otherwise.
+             */
+            has: (key) => {
+                if (!request || typeof request !== 'object' || !Array.isArray(request.params)) return false; // Safety check
+                return request.params.some(p => typeof p === 'object' && p.name === key);
+            },
+            /**
+             * Clears all query parameters.
+             */
+            clear: () => {
+                if (!request || typeof request !== 'object') return;
+                request.params = [];
+                request.isParamEnabledList = [];
+            }
+        },
+
+        /**
+         * Access or modify the request URL.
+         */
+        url: {
+            /**
+             * Gets the current request URL string.
+             * @returns {string} The URL.
+             */
+            get: () => {
+                return (request && typeof request === 'object') ? request.url : '';
+            },
+            /**
+             * Sets the request URL string.
+             * @param {string} newUrl The new URL.
+             */
+            set: (newUrl) => {
+                if (request && typeof request === 'object' && typeof newUrl === 'string') {
+                    request.url = newUrl;
+                }
+            }
+            // Future: Could add methods to manipulate parts (host, path, query) if needed
+        },
+
+        /**
+         * Access or modify the request body.
+         */
+        body: {
+            /**
+             * Gets the current request body content (string).
+             * Note: For form-data, this returns the raw string body (if any), not the structured data. Use `ad.request.formData` for that.
+             * @returns {string|null|undefined} The request body string.
+             */
+            get: () => {
+                return (request && typeof request === 'object') ? request.body : undefined;
+            },
+            /**
+             * Sets the request body content (string).
+             * Important: Also updates the Content-Type if setting JSON/Text, unless a Content-Type header is already explicitly set.
+             * Setting the body will clear form-data if the content type changes away from form-data.
+             * @param {string|object} newBody The new body content. If an object is provided, it's stringified as JSON.
+             * @param {string} [contentType] Optionally specify the Content-Type (e.g., 'application/json', 'text/plain'). If not set, defaults to 'text/plain' or 'application/json' if newBody is an object.
+             */
+            set: (newBody, contentType) => {
+                if (!request || typeof request !== 'object') return; // Safety check fix: check !request or typeof !== object
+
+                let finalBody = '';
+                let finalContentType = contentType;
+
+                if (typeof newBody === 'object' && newBody !== null) {
+                    try {
+                        finalBody = JSON.stringify(newBody);
+                        finalContentType = contentType || 'application/json'; // Default to JSON if object
+                        request.bodyContentType = 'json'; // Update internal model type
+                    } catch (e) {
+                        sendMessage('consoleError', JSON.stringify(['Error stringifying object for request body:', e.toString()]));
+                        return; // Don't proceed if stringify fails
+                    }
+                } else {
+                    finalBody = String(newBody); // Ensure it's a string
+                    finalContentType = contentType || 'text/plain'; // Default to text
+                    request.bodyContentType = 'text'; // Update internal model type
+                }
+
+                request.body = finalBody;
+
+                // Clear form data if we are setting a string/json body
+                request.formData = [];
+
+                // Set Content-Type header if not already set by user explicitly in headers
+                // Use case-insensitive check for existing Content-Type
+                const hasContentTypeHeader = request.headers.some(h => typeof h === 'object' && h.name.toLowerCase() === 'content-type');
+                if (!hasContentTypeHeader && finalContentType) {
+                    ad.request.headers.set('Content-Type', finalContentType);
+                }
+            }
+            // TODO: Add helpers for request.formData if needed (similar to headers/params)
+        },
+
+        /**
+         * Access or modify the request method (e.g., 'GET', 'POST').
+         */
+        method: {
+            /**
+             * Gets the current request method.
+             * @returns {string} The HTTP method (e.g., "get", "post").
+             */
+            get: () => {
+                return (request && typeof request === 'object') ? request.method : '';
+            },
+            /**
+             * Sets the request method.
+             * @param {string} newMethod The new HTTP method (e.g., "POST", "put"). Case might matter for the Dart model enum.
+             */
+            set: (newMethod) => {
+                if (request && typeof request === 'object' && typeof newMethod === 'string') {
+                    // Consider converting to lowercase to match HTTPVerb enum likely usage
+                    request.method = newMethod.toLowerCase();
+                }
             }
         }
-        // TODO: Add helpers for request.formData if needed (similar to headers/params)
     },
 
-     /**
-     * Access or modify the request method (e.g., 'GET', 'POST').
+    /**
+     * Read-only access to the response data.
+     * Only available in post-response scripts.
      */
-    method: {
-         /**
-         * Gets the current request method.
-         * @returns {string} The HTTP method (e.g., "get", "post").
+    response: {
+        /**
+         * The HTTP status code of the response.
+         * @type {number|undefined}
          */
-        get: () => {
-             return (request && typeof request === 'object') ? request.method : '';
+        get status() {
+            return (response && typeof response === 'object') ? response.statusCode : undefined;
+        },
+
+        /**
+         * The response body as a string. If the response was binary, this might be decoded text
+         * based on Content-Type or potentially garbled. Use `bodyBytes` for raw binary data access (if provided).
+         * @type {string|undefined}
+         */
+        get body() {
+            return (response && typeof response === 'object') ? response.body : undefined;
+        },
+
+        /**
+         * The response body automatically formatted (e.g., pretty-printed JSON). Provided by Dart.
+         * @type {string|undefined}
+         */
+        get formattedBody() {
+            return (response && typeof response === 'object') ? response.formattedBody : undefined;
+        },
+
+        /**
+         * The raw response body as an array of bytes (numbers).
+         * Note: This relies on the Dart side serializing Uint8List correctly (e.g., as List<int>).
+         * Accessing large byte arrays in JS might be memory-intensive.
+         * @type {number[]|undefined}
+         */
+        get bodyBytes() {
+            return (response && typeof response === 'object') ? response.bodyBytes : undefined;
+        },
+
+
+        /**
+         * The approximate time taken for the request-response cycle. Provided by Dart.
+         * Assumes Dart sends it as microseconds and converts it to milliseconds here.
+         * @type {number|undefined} Time in milliseconds.
+         */
+        get time() {
+            // Assuming response.time is in microseconds from Dart's DurationConverter
+            return (response && typeof response === 'object' && typeof response.time === 'number') ? response.time / 1000 : undefined;
+        },
+
+        /**
+         * An object containing the response headers (keys are header names, values are header values).
+         * Header names are likely lowercase from the http package.
+         * @type {object|undefined} e.g., {'content-type': 'application/json', ...}
+         */
+        get headers() {
+            return (response && typeof response === 'object') ? response.headers : undefined;
+        },
+
+        /**
+         * An object containing the request headers that were actually sent (useful for verification).
+         * Header names are likely lowercase.
+         * @type {object|undefined} e.g., {'user-agent': '...', ...}
+         */
+        get requestHeaders() {
+            return (response && typeof response === 'object') ? response.requestHeaders : undefined;
+        },
+
+
+        /**
+         * Attempts to parse the response body as JSON.
+         * @returns {object|undefined} The parsed JSON object, or undefined if parsing fails or body is empty.
+         */
+        json: () => {
+            const bodyContent = ad.response.body; // Assign to variable first
+            if (!bodyContent) { // Check the variable
+                return undefined;
+            }
+            try {
+                return JSON.parse(bodyContent); // Parse the variable
+            } catch (e) {
+                ad.console.error("Failed to parse response body as JSON:", e.toString());
+                return undefined;
+            }
+        },
+
+        /**
+         * Gets a specific response header value (case-insensitive key lookup).
+         * @param {string} key The header name.
+         * @returns {string|undefined} The header value or undefined if not found.
+         */
+        getHeader: (key) => {
+            const headers = ad.response.headers;
+            if (!headers || typeof key !== 'string') return undefined;
+            const lowerKey = key.toLowerCase();
+            // Find the key in the headers object case-insensitively
+            const headerKey = Object.keys(headers).find(k => k.toLowerCase() === lowerKey);
+            return headerKey ? headers[headerKey] : undefined; // Return the value using the found key
+        }
+    },
+
+    /**
+     * Access and modify environment variables for the active environment.
+     * Changes are made to the 'environment' JS object (simple {key: value} map)
+     * and sent back to Dart. Dart side will need to merge these changes back
+     * into the original structured format if needed.
+     */
+    environment: {
+        /**
+         * Gets the value of an environment variable from the simplified map.
+         * @param {string} key The variable name.
+         * @returns {any} The variable value or undefined if not found.
+         */
+        get: (key) => {
+            // Access the simplified 'environment' object directly
+            return (environment && typeof environment === 'object') ? environment[key] : undefined;
         },
         /**
-         * Sets the request method.
-         * @param {string} newMethod The new HTTP method (e.g., "POST", "put"). Case might matter for the Dart model enum.
+         * Sets the value of an environment variable in the simplified map.
+         * @param {string} key The variable name.
+         * @param {any} value The variable value. Should be JSON-serializable (string, number, boolean, object, array).
          */
-        set: (newMethod) => {
-            if (request && typeof request === 'object' && typeof newMethod === 'string') {
-                 // Consider converting to lowercase to match HTTPVerb enum likely usage
-                 request.method = newMethod.toLowerCase();
+        set: (key, value) => {
+            if (environment && typeof environment === 'object' && typeof key === 'string') {
+                // Modify the simplified 'environment' object
+                environment[key] = value;
+            }
+        },
+        /**
+         * Removes an environment variable from the simplified map.
+         * @param {string} key The variable name to remove.
+         */
+        unset: (key) => {
+            if (environment && typeof environment === 'object') {
+                // Modify the simplified 'environment' object
+                delete environment[key];
+            }
+        },
+        /**
+         * Checks if an environment variable exists in the simplified map.
+         * @param {string} key The variable name.
+         * @returns {boolean} True if the variable exists, false otherwise.
+         */
+        has: (key) => {
+            // Check the simplified 'environment' object
+            return (environment && typeof environment === 'object') ? environment.hasOwnProperty(key) : false;
+        },
+        /**
+         * Removes all variables from the simplified environment map scope.
+         */
+        clear: () => {
+            if (environment && typeof environment === 'object') {
+                // Clear the simplified 'environment' object
+                for (const key in environment) {
+                    if (environment.hasOwnProperty(key)) {
+                        delete environment[key];
+                    }
+                }
+                // Alternatively, just reassign: environment = {};
             }
         }
-    }
-  },
-
-  /**
-   * Read-only access to the response data.
-   * Only available in post-response scripts.
-   */
-  response: {
-    /**
-     * The HTTP status code of the response.
-     * @type {number|undefined}
-     */
-    get status() { return (response && typeof response === 'object') ? response.statusCode : undefined; },
-
-    /**
-     * The response body as a string. If the response was binary, this might be decoded text
-     * based on Content-Type or potentially garbled. Use `bodyBytes` for raw binary data access (if provided).
-     * @type {string|undefined}
-     */
-    get body() { return (response && typeof response === 'object') ? response.body : undefined; },
-
-     /**
-     * The response body automatically formatted (e.g., pretty-printed JSON). Provided by Dart.
-     * @type {string|undefined}
-     */
-    get formattedBody() { return (response && typeof response === 'object') ? response.formattedBody : undefined; },
-
-    /**
-     * The raw response body as an array of bytes (numbers).
-     * Note: This relies on the Dart side serializing Uint8List correctly (e.g., as List<int>).
-     * Accessing large byte arrays in JS might be memory-intensive.
-     * @type {number[]|undefined}
-     */
-     get bodyBytes() { return (response && typeof response === 'object') ? response.bodyBytes : undefined; },
-
-
-    /**
-     * The approximate time taken for the request-response cycle. Provided by Dart.
-     * Assumes Dart sends it as microseconds and converts it to milliseconds here.
-     * @type {number|undefined} Time in milliseconds.
-     */
-     get time() {
-        // Assuming response.time is in microseconds from Dart's DurationConverter
-        return (response && typeof response === 'object' && typeof response.time === 'number') ? response.time / 1000 : undefined;
-     },
-
-    /**
-     * An object containing the response headers (keys are header names, values are header values).
-     * Header names are likely lowercase from the http package.
-     * @type {object|undefined} e.g., {'content-type': 'application/json', ...}
-     */
-    get headers() { return (response && typeof response === 'object') ? response.headers : undefined; },
-
-    /**
-     * An object containing the request headers that were actually sent (useful for verification).
-     * Header names are likely lowercase.
-     * @type {object|undefined} e.g., {'user-agent': '...', ...}
-     */
-    get requestHeaders() { return (response && typeof response === 'object') ? response.requestHeaders : undefined; },
-
-
-    /**
-     * Attempts to parse the response body as JSON.
-     * @returns {object|undefined} The parsed JSON object, or undefined if parsing fails or body is empty.
-     */
-    json: () => {
-      const bodyContent = ad.response.body; // Assign to variable first
-      if (!bodyContent) { // Check the variable
-        return undefined;
-      }
-      try {
-        return JSON.parse(bodyContent); // Parse the variable
-      } catch (e) {
-        ad.console.error("Failed to parse response body as JSON:", e.toString());
-        return undefined;
-      }
+        // Note: A separate 'globals' object could be added here if global variables are implemented distinctly.
     },
 
     /**
-     * Gets a specific response header value (case-insensitive key lookup).
-     * @param {string} key The header name.
-     * @returns {string|undefined} The header value or undefined if not found.
+     * Provides logging capabilities. Messages are sent back to Dart via the bridge.
      */
-    getHeader: (key) => {
-        const headers = ad.response.headers;
-        if (!headers || typeof key !== 'string') return undefined;
-        const lowerKey = key.toLowerCase();
-        // Find the key in the headers object case-insensitively
-        const headerKey = Object.keys(headers).find(k => k.toLowerCase() === lowerKey);
-        return headerKey ? headers[headerKey] : undefined; // Return the value using the found key
-    }
-  },
+    console: {
+        /**
+         * Logs informational messages.
+         * @param {...any} args Values to log. They will be JSON-stringified.
+         */
+        log: (...args) => {
+            try {
+                sendMessage('consoleLog', JSON.stringify(args));
+            } catch (e) {
+                /* Ignore stringify errors for console? Or maybe log the error itself? */
+            }
+        },
+        /**
+         * Logs warning messages.
+         * @param {...any} args Values to log.
+         */
+        warn: (...args) => {
+            try {
+                sendMessage('consoleWarn', JSON.stringify(args));
+            } catch (e) {
+                /* Ignore */
+            }
+        },
+        /**
+         * Logs error messages.
+         * @param {...any} args Values to log.
+         */
+        error: (...args) => {
+            try {
+                sendMessage('consoleError', JSON.stringify(args));
+            } catch (e) {
+                /* Ignore */
+            }
+        }
+    },
 
-  /**
-   * Access and modify environment variables for the active environment.
-   * Changes are made to the 'environment' JS object (simple {key: value} map)
-   * and sent back to Dart. Dart side will need to merge these changes back
-   * into the original structured format if needed.
-   */
-  environment: {
     /**
-     * Gets the value of an environment variable from the simplified map.
-     * @param {string} key The variable name.
-     * @returns {any} The variable value or undefined if not found.
+     * Basic testing functions (example structure).
+     * Results might need to be collected and sent back via the bridge or at the end.
      */
-    get: (key) => {
-      // Access the simplified 'environment' object directly
-      return (environment && typeof environment === 'object') ? environment[key] : undefined;
-    },
-    /**
-     * Sets the value of an environment variable in the simplified map.
-     * @param {string} key The variable name.
-     * @param {any} value The variable value. Should be JSON-serializable (string, number, boolean, object, array).
-     */
-    set: (key, value) => {
-      if (environment && typeof environment === 'object' && typeof key === 'string') {
-        // Modify the simplified 'environment' object
-        environment[key] = value;
-      }
-    },
-    /**
-     * Removes an environment variable from the simplified map.
-     * @param {string} key The variable name to remove.
-     */
-    unset: (key) => {
-      if (environment && typeof environment === 'object') {
-        // Modify the simplified 'environment' object
-        delete environment[key];
-      }
-    },
-    /**
-     * Checks if an environment variable exists in the simplified map.
-     * @param {string} key The variable name.
-     * @returns {boolean} True if the variable exists, false otherwise.
-     */
-    has: (key) => {
-       // Check the simplified 'environment' object
-       return (environment && typeof environment === 'object') ? environment.hasOwnProperty(key) : false;
-    },
-    /**
-     * Removes all variables from the simplified environment map scope.
-     */
-    clear: () => {
-      if (environment && typeof environment === 'object') {
-          // Clear the simplified 'environment' object
-          for (const key in environment) {
-              if (environment.hasOwnProperty(key)) {
-                  delete environment[key];
-              }
-          }
-          // Alternatively, just reassign: environment = {};
-      }
-    }
-    // Note: A separate 'globals' object could be added here if global variables are implemented distinctly.
-  },
+    // test: (testName, callback) => {
+    //   try {
+    //     callback();
+    //     ad.console.log(`Test Passed: ${testName}`);
+    //     // TODO: Potentially collect results: sendMessage('testResult', JSON.stringify({ name: testName, status: 'passed' }));
+    //   } catch (e) {
+    //     ad.console.error(`Test Failed: ${testName}`, e.toString(), e.stack);
+    //      // TODO: Potentially collect results: sendMessage('testResult', JSON.stringify({ name: testName, status: 'failed', error: e.toString() }));
+    //   }
+    // },
 
-  /**
-   * Provides logging capabilities. Messages are sent back to Dart via the bridge.
-   */
-  console: {
-    /**
-     * Logs informational messages.
-     * @param {...any} args Values to log. They will be JSON-stringified.
-     */
-    log: (...args) => {
-      try {
-        sendMessage('consoleLog', JSON.stringify(args));
-      } catch(e) { /* Ignore stringify errors for console? Or maybe log the error itself? */ }
-    },
-    /**
-     * Logs warning messages.
-     * @param {...any} args Values to log.
-     */
-    warn: (...args) => {
-       try {
-         sendMessage('consoleWarn', JSON.stringify(args));
-       } catch(e) { /* Ignore */ }
-    },
-    /**
-     * Logs error messages.
-     * @param {...any} args Values to log.
-     */
-    error: (...args) => {
-      try {
-        sendMessage('consoleError', JSON.stringify(args));
-      } catch(e) { /* Ignore */ }
-    }
-  },
+    // expect: (value) => {
+    //   // Very basic assertion example (can be expanded or use a tiny library)
+    //   return {
+    //     toBe: (expected) => {
+    //       if (value !== expected) {
+    //         throw new Error(`Assertion Failed: Expected ${JSON.stringify(value)} to be ${JSON.stringify(expected)}`);
+    //       }
+    //     },
+    // Add more assertions: toBeTruthy, toEqual (deep compare), etc.
+    //   };
+    // }
 
-  /**
-   * Basic testing functions (example structure).
-   * Results might need to be collected and sent back via the bridge or at the end.
-   */
-  // test: (testName, callback) => {
-  //   try {
-  //     callback();
-  //     ad.console.log(`Test Passed: ${testName}`);
-  //     // TODO: Potentially collect results: sendMessage('testResult', JSON.stringify({ name: testName, status: 'passed' }));
-  //   } catch (e) {
-  //     ad.console.error(`Test Failed: ${testName}`, e.toString(), e.stack);
-  //      // TODO: Potentially collect results: sendMessage('testResult', JSON.stringify({ name: testName, status: 'failed', error: e.toString() }));
-  //   }
-  // },
-
-  // expect: (value) => {
-  //   // Very basic assertion example (can be expanded or use a tiny library)
-  //   return {
-  //     toBe: (expected) => {
-  //       if (value !== expected) {
-  //         throw new Error(`Assertion Failed: Expected ${JSON.stringify(value)} to be ${JSON.stringify(expected)}`);
-  //       }
-  //     },
-       // Add more assertions: toBeTruthy, toEqual (deep compare), etc.
-  //   };
-  // }
-
-  // TODO: Add other utilities if needed: crypto, base64 (atob/btoa - might need polyfills)
-  // E.g.,
-  // crypto: { /* methods */ },
-  // btoa: (str) => btoa(str), // Needs btoa to be available in the JS context
-  // atob: (encodedStr) => atob(encodedStr) // Needs atob
+    // TODO: Add other utilities if needed: crypto, base64 (atob/btoa - might need polyfills)
+    // E.g.,
+    // crypto: { /* methods */ },
+    // btoa: (str) => btoa(str), // Needs btoa to be available in the JS context
+    // atob: (encodedStr) => atob(encodedStr) // Needs atob
 
 };
 

--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -443,6 +443,7 @@ const kLabelViewCode = "View Code";
 const kLabelURLParams = "URL Params";
 const kLabelHeaders = "Headers";
 const kLabelBody = "Body";
+const kLabelScripts = "Scripts";
 const kLabelQuery = "Query";
 const kNameCheckbox = "Checkbox";
 const kNameURLParam = "URL Parameter";

--- a/lib/dashbot/widgets/content_renderer.dart
+++ b/lib/dashbot/widgets/content_renderer.dart
@@ -1,8 +1,8 @@
 // lib/dashbot/widgets/content_renderer.dart
 import 'dart:convert';
 import 'package:flutter/material.dart';
-import 'package:flutter_highlighter/flutter_highlighter.dart';
-import 'package:flutter_highlighter/themes/monokai-sublime.dart';
+import 'package:flutter_highlight/flutter_highlight.dart';
+import 'package:flutter_highlight/themes/monokai-sublime.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 
 Widget renderContent(BuildContext context, String text) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:apidash/services/flutter_js_service.dart';
 import 'package:apidash_design_system/apidash_design_system.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -11,6 +12,7 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   var settingsModel = await getSettingsFromSharedPrefs();
   var onboardingStatus = await getOnboardingStatusFromSharedPrefs();
+  initializeJsRuntime();
   final initStatus = await initApp(
     kIsDesktop,
     settingsModel: settingsModel,

--- a/lib/models/request_model.dart
+++ b/lib/models/request_model.dart
@@ -22,6 +22,8 @@ class RequestModel with _$RequestModel {
     HttpResponseModel? httpResponseModel,
     @JsonKey(includeToJson: false) @Default(false) bool isWorking,
     @JsonKey(includeToJson: false) DateTime? sendingTime,
+    @Default("") String preRequestScript,
+    @Default("") String postRequestScript,
   }) = _RequestModel;
 
   factory RequestModel.fromJson(Map<String, Object?> json) =>

--- a/lib/models/request_model.freezed.dart
+++ b/lib/models/request_model.freezed.dart
@@ -35,6 +35,8 @@ mixin _$RequestModel {
   bool get isWorking => throw _privateConstructorUsedError;
   @JsonKey(includeToJson: false)
   DateTime? get sendingTime => throw _privateConstructorUsedError;
+  String get preRequestScript => throw _privateConstructorUsedError;
+  String get postRequestScript => throw _privateConstructorUsedError;
 
   /// Serializes this RequestModel to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -63,7 +65,9 @@ abstract class $RequestModelCopyWith<$Res> {
       String? message,
       HttpResponseModel? httpResponseModel,
       @JsonKey(includeToJson: false) bool isWorking,
-      @JsonKey(includeToJson: false) DateTime? sendingTime});
+      @JsonKey(includeToJson: false) DateTime? sendingTime,
+      String preRequestScript,
+      String postRequestScript});
 
   $HttpRequestModelCopyWith<$Res>? get httpRequestModel;
   $HttpResponseModelCopyWith<$Res>? get httpResponseModel;
@@ -95,6 +99,8 @@ class _$RequestModelCopyWithImpl<$Res, $Val extends RequestModel>
     Object? httpResponseModel = freezed,
     Object? isWorking = null,
     Object? sendingTime = freezed,
+    Object? preRequestScript = null,
+    Object? postRequestScript = null,
   }) {
     return _then(_value.copyWith(
       id: null == id
@@ -141,6 +147,14 @@ class _$RequestModelCopyWithImpl<$Res, $Val extends RequestModel>
           ? _value.sendingTime
           : sendingTime // ignore: cast_nullable_to_non_nullable
               as DateTime?,
+      preRequestScript: null == preRequestScript
+          ? _value.preRequestScript
+          : preRequestScript // ignore: cast_nullable_to_non_nullable
+              as String,
+      postRequestScript: null == postRequestScript
+          ? _value.postRequestScript
+          : postRequestScript // ignore: cast_nullable_to_non_nullable
+              as String,
     ) as $Val);
   }
 
@@ -192,7 +206,9 @@ abstract class _$$RequestModelImplCopyWith<$Res>
       String? message,
       HttpResponseModel? httpResponseModel,
       @JsonKey(includeToJson: false) bool isWorking,
-      @JsonKey(includeToJson: false) DateTime? sendingTime});
+      @JsonKey(includeToJson: false) DateTime? sendingTime,
+      String preRequestScript,
+      String postRequestScript});
 
   @override
   $HttpRequestModelCopyWith<$Res>? get httpRequestModel;
@@ -224,6 +240,8 @@ class __$$RequestModelImplCopyWithImpl<$Res>
     Object? httpResponseModel = freezed,
     Object? isWorking = null,
     Object? sendingTime = freezed,
+    Object? preRequestScript = null,
+    Object? postRequestScript = null,
   }) {
     return _then(_$RequestModelImpl(
       id: null == id
@@ -269,6 +287,14 @@ class __$$RequestModelImplCopyWithImpl<$Res>
           ? _value.sendingTime
           : sendingTime // ignore: cast_nullable_to_non_nullable
               as DateTime?,
+      preRequestScript: null == preRequestScript
+          ? _value.preRequestScript
+          : preRequestScript // ignore: cast_nullable_to_non_nullable
+              as String,
+      postRequestScript: null == postRequestScript
+          ? _value.postRequestScript
+          : postRequestScript // ignore: cast_nullable_to_non_nullable
+              as String,
     ));
   }
 }
@@ -288,7 +314,9 @@ class _$RequestModelImpl implements _RequestModel {
       this.message,
       this.httpResponseModel,
       @JsonKey(includeToJson: false) this.isWorking = false,
-      @JsonKey(includeToJson: false) this.sendingTime});
+      @JsonKey(includeToJson: false) this.sendingTime,
+      this.preRequestScript = "",
+      this.postRequestScript = ""});
 
   factory _$RequestModelImpl.fromJson(Map<String, dynamic> json) =>
       _$$RequestModelImplFromJson(json);
@@ -321,10 +349,16 @@ class _$RequestModelImpl implements _RequestModel {
   @override
   @JsonKey(includeToJson: false)
   final DateTime? sendingTime;
+  @override
+  @JsonKey()
+  final String preRequestScript;
+  @override
+  @JsonKey()
+  final String postRequestScript;
 
   @override
   String toString() {
-    return 'RequestModel(id: $id, apiType: $apiType, name: $name, description: $description, requestTabIndex: $requestTabIndex, httpRequestModel: $httpRequestModel, responseStatus: $responseStatus, message: $message, httpResponseModel: $httpResponseModel, isWorking: $isWorking, sendingTime: $sendingTime)';
+    return 'RequestModel(id: $id, apiType: $apiType, name: $name, description: $description, requestTabIndex: $requestTabIndex, httpRequestModel: $httpRequestModel, responseStatus: $responseStatus, message: $message, httpResponseModel: $httpResponseModel, isWorking: $isWorking, sendingTime: $sendingTime, preRequestScript: $preRequestScript, postRequestScript: $postRequestScript)';
   }
 
   @override
@@ -349,7 +383,11 @@ class _$RequestModelImpl implements _RequestModel {
             (identical(other.isWorking, isWorking) ||
                 other.isWorking == isWorking) &&
             (identical(other.sendingTime, sendingTime) ||
-                other.sendingTime == sendingTime));
+                other.sendingTime == sendingTime) &&
+            (identical(other.preRequestScript, preRequestScript) ||
+                other.preRequestScript == preRequestScript) &&
+            (identical(other.postRequestScript, postRequestScript) ||
+                other.postRequestScript == postRequestScript));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
@@ -366,7 +404,9 @@ class _$RequestModelImpl implements _RequestModel {
       message,
       httpResponseModel,
       isWorking,
-      sendingTime);
+      sendingTime,
+      preRequestScript,
+      postRequestScript);
 
   /// Create a copy of RequestModel
   /// with the given fields replaced by the non-null parameter values.
@@ -386,18 +426,19 @@ class _$RequestModelImpl implements _RequestModel {
 
 abstract class _RequestModel implements RequestModel {
   const factory _RequestModel(
-          {required final String id,
-          final APIType apiType,
-          final String name,
-          final String description,
-          @JsonKey(includeToJson: false) final dynamic requestTabIndex,
-          final HttpRequestModel? httpRequestModel,
-          final int? responseStatus,
-          final String? message,
-          final HttpResponseModel? httpResponseModel,
-          @JsonKey(includeToJson: false) final bool isWorking,
-          @JsonKey(includeToJson: false) final DateTime? sendingTime}) =
-      _$RequestModelImpl;
+      {required final String id,
+      final APIType apiType,
+      final String name,
+      final String description,
+      @JsonKey(includeToJson: false) final dynamic requestTabIndex,
+      final HttpRequestModel? httpRequestModel,
+      final int? responseStatus,
+      final String? message,
+      final HttpResponseModel? httpResponseModel,
+      @JsonKey(includeToJson: false) final bool isWorking,
+      @JsonKey(includeToJson: false) final DateTime? sendingTime,
+      final String preRequestScript,
+      final String postRequestScript}) = _$RequestModelImpl;
 
   factory _RequestModel.fromJson(Map<String, dynamic> json) =
       _$RequestModelImpl.fromJson;
@@ -427,6 +468,10 @@ abstract class _RequestModel implements RequestModel {
   @override
   @JsonKey(includeToJson: false)
   DateTime? get sendingTime;
+  @override
+  String get preRequestScript;
+  @override
+  String get postRequestScript;
 
   /// Create a copy of RequestModel
   /// with the given fields replaced by the non-null parameter values.

--- a/lib/models/request_model.g.dart
+++ b/lib/models/request_model.g.dart
@@ -27,6 +27,8 @@ _$RequestModelImpl _$$RequestModelImplFromJson(Map json) => _$RequestModelImpl(
       sendingTime: json['sendingTime'] == null
           ? null
           : DateTime.parse(json['sendingTime'] as String),
+      preRequestScript: json['preRequestScript'] as String? ?? "",
+      postRequestScript: json['postRequestScript'] as String? ?? "",
     );
 
 Map<String, dynamic> _$$RequestModelImplToJson(_$RequestModelImpl instance) =>
@@ -39,6 +41,8 @@ Map<String, dynamic> _$$RequestModelImplToJson(_$RequestModelImpl instance) =>
       'responseStatus': instance.responseStatus,
       'message': instance.message,
       'httpResponseModel': instance.httpResponseModel?.toJson(),
+      'preRequestScript': instance.preRequestScript,
+      'postRequestScript': instance.postRequestScript,
     };
 
 const _$APITypeEnumMap = {

--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -223,6 +223,8 @@ class CollectionStateNotifier
     int? responseStatus,
     String? message,
     HttpResponseModel? httpResponseModel,
+    String? preRequestScript,
+    String? postRequestScript,
   }) {
     final rId = id ?? ref.read(selectedIdStateProvider);
     if (rId == null) {
@@ -254,6 +256,8 @@ class CollectionStateNotifier
       responseStatus: responseStatus ?? currentModel.responseStatus,
       message: message ?? currentModel.message,
       httpResponseModel: httpResponseModel ?? currentModel.httpResponseModel,
+      preRequestScript: preRequestScript ?? currentModel.preRequestScript,
+      postRequestScript: postRequestScript ?? currentModel.postRequestScript,
     );
 
     var map = {...state!};

--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -1,3 +1,6 @@
+import 'dart:developer';
+
+import 'package:apidash/services/flutter_js_service.dart';
 import 'package:apidash_core/apidash_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -278,6 +281,18 @@ class CollectionStateNotifier
 
     if (requestModel?.httpRequestModel == null) {
       return;
+    }
+
+    if (requestModel != null && requestModel.preRequestScript.isNotEmpty) {
+      final res = await executePreRequestScript(
+        currentRequestModel: requestModel,
+        activeEnvironment: {},
+      );
+      requestModel =
+          requestModel.copyWith(httpRequestModel: res.updatedRequest);
+      log(res.updatedRequest.url);
+      log(res.updatedRequest.headersMap.toString());
+      log(res.updatedRequest.body.toString());
     }
 
     APIType apiType = requestModel!.apiType;

--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -386,7 +386,7 @@ class CollectionStateNotifier
           "Skipped environment update as originalEnvironmentModel was null.");
       if (scriptResult.updatedEnvironment.isNotEmpty) {
         debugPrint(
-            "Warning: Pre-request script updated environment variables, but no active environment was selected to save them to.");
+            "Warning: Post-response script updated environment variables, but no active environment was selected to save them to.");
       }
     }
   }
@@ -467,7 +467,9 @@ class CollectionStateNotifier
         httpRequestModel: substitutedHttpRequestModel,
         httpResponseModel: httpResponseModel,
       );
-      handlePostResponseScript(newRequestModel, originalEnvironmentModel);
+      if (requestModel.postRequestScript.isNotEmpty) {
+        handlePostResponseScript(newRequestModel, originalEnvironmentModel);
+      }
       ref.read(historyMetaStateNotifier.notifier).addHistoryRequest(model);
     }
 

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_pane_rest.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_pane_rest.dart
@@ -44,16 +44,19 @@ class EditRestRequestPane extends ConsumerWidget {
         paramLength > 0,
         headerLength > 0,
         hasBody,
+        false, // TODO: Add indicator condition once it is added to [selectedRequestModelProvider]
       ],
       tabLabels: const [
         kLabelURLParams,
         kLabelHeaders,
         kLabelBody,
+        kLabelScripts,
       ],
       children: const [
         EditRequestURLParams(),
         EditRequestHeaders(),
         EditRequestBody(),
+        SizedBox.shrink(),
       ],
     );
   }

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_pane_rest.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_pane_rest.dart
@@ -28,6 +28,12 @@ class EditRestRequestPane extends ConsumerWidget {
             .select((value) => value?.httpRequestModel?.hasBody)) ??
         false;
 
+    final scriptsLength = ref.watch(selectedRequestModelProvider
+            .select((value) => value?.preRequestScript.length)) ??
+        ref.watch(selectedRequestModelProvider
+            .select((value) => value?.postRequestScript.length)) ??
+        0;
+
     return RequestPane(
       selectedId: selectedId,
       codePaneVisible: codePaneVisible,
@@ -45,7 +51,7 @@ class EditRestRequestPane extends ConsumerWidget {
         paramLength > 0,
         headerLength > 0,
         hasBody,
-        false, // TODO: Add indicator condition once it is added to [selectedRequestModelProvider]
+        scriptsLength > 0,
       ],
       tabLabels: const [
         kLabelURLParams,

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_pane_rest.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_pane_rest.dart
@@ -1,4 +1,5 @@
 import 'package:apidash/consts.dart';
+import 'package:apidash/screens/home_page/editor_pane/details_card/request_pane/scripts_code_pane.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:apidash/providers/providers.dart';
@@ -56,7 +57,7 @@ class EditRestRequestPane extends ConsumerWidget {
         EditRequestURLParams(),
         EditRequestHeaders(),
         EditRequestBody(),
-        SizedBox.shrink(),
+        ScriptsCodePane(),
       ],
     );
   }

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/scripts_code_pane.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/scripts_code_pane.dart
@@ -1,28 +1,45 @@
 import 'package:apidash/widgets/scripts_editor_pane.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_code_editor/flutter_code_editor.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:highlight/languages/javascript.dart';
+import 'package:apidash/providers/providers.dart';
 
-class ScriptsCodePane extends StatefulWidget {
+class ScriptsCodePane extends ConsumerStatefulWidget {
   const ScriptsCodePane({super.key});
 
   @override
-  State<ScriptsCodePane> createState() => _ScriptsCodePaneState();
+  ConsumerState<ScriptsCodePane> createState() => _ScriptsCodePaneState();
 }
 
-class _ScriptsCodePaneState extends State<ScriptsCodePane> {
-  int _selectedTabIndex = 0;
-  final preReqCodeController = CodeController(
-    text: '// Use javascript to modify this request dynamically',
-    language: javascript,
-  );
-  final postResCodeController = CodeController(
-    text: '...',
-    language: javascript,
-  );
-
+class _ScriptsCodePaneState extends ConsumerState<ScriptsCodePane> {
   @override
   Widget build(BuildContext context) {
+    int _selectedTabIndex = 0;
+    final requestModel = ref.read(selectedRequestModelProvider);
+
+    final preReqCodeController = CodeController(
+      text: requestModel?.preRequestScript,
+      language: javascript,
+    );
+
+    final postResCodeController = CodeController(
+      text: requestModel?.postRequestScript,
+      language: javascript,
+    );
+
+    preReqCodeController.addListener(() {
+      ref.read(collectionStateNotifierProvider.notifier).update(
+            preRequestScript: preReqCodeController.text,
+          );
+    });
+
+    postResCodeController.addListener(() {
+      ref.read(collectionStateNotifierProvider.notifier).update(
+            postRequestScript: postResCodeController.text,
+          );
+    });
+
     final tabs = ["Pre-Req", "Post-Res"];
     final content = [
       ScriptsEditorPane(

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/scripts_code_pane.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/scripts_code_pane.dart
@@ -1,0 +1,81 @@
+import 'package:apidash/widgets/scripts_editor_pane.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_code_editor/flutter_code_editor.dart';
+import 'package:highlight/languages/javascript.dart';
+
+class ScriptsCodePane extends StatefulWidget {
+  const ScriptsCodePane({super.key});
+
+  @override
+  State<ScriptsCodePane> createState() => _ScriptsCodePaneState();
+}
+
+class _ScriptsCodePaneState extends State<ScriptsCodePane> {
+  int _selectedTabIndex = 0;
+  final preReqCodeController = CodeController(
+    text: '// Use javascript to modify this request dynamically',
+    language: javascript,
+  );
+  final postResCodeController = CodeController(
+    text: '...',
+    language: javascript,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    final tabs = ["Pre-Req", "Post-Res"];
+    final content = [
+      ScriptsEditorPane(
+        controller: preReqCodeController,
+      ),
+      ScriptsEditorPane(
+        controller: postResCodeController,
+      ),
+    ];
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          width: 100,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              for (int i = 0; i < tabs.length; i++)
+                ListTile(
+                  dense: true,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                  selectedTileColor: _selectedTabIndex == i
+                      ? Theme.of(context).colorScheme.secondaryFixed
+                      : Theme.of(context).colorScheme.surface,
+                  title: Text(
+                    tabs[i],
+                    style: TextStyle(
+                      fontSize: 12,
+                    ),
+                  ),
+                  selected: _selectedTabIndex == i,
+                  onTap: () {
+                    setState(() {
+                      _selectedTabIndex = i;
+                    });
+                  },
+                ),
+            ],
+          ),
+        ),
+        const VerticalDivider(width: 1),
+        Expanded(
+          child: Container(
+            color: Theme.of(context).colorScheme.surfaceContainerLowest,
+            child: content[_selectedTabIndex],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/scripts_code_pane.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/scripts_code_pane.dart
@@ -73,6 +73,11 @@ class _ScriptsCodePaneState extends ConsumerState<ScriptsCodePane> {
                     tabs[i],
                     style: TextStyle(
                       fontSize: 12,
+                      color: _selectedTabIndex == i
+                          ? Theme.of(context)
+                              .colorScheme
+                              .onSecondaryFixedVariant
+                          : Theme.of(context).colorScheme.onSurface,
                     ),
                   ),
                   selected: _selectedTabIndex == i,

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/scripts_code_pane.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/scripts_code_pane.dart
@@ -13,9 +13,9 @@ class ScriptsCodePane extends ConsumerStatefulWidget {
 }
 
 class _ScriptsCodePaneState extends ConsumerState<ScriptsCodePane> {
+  int _selectedTabIndex = 0;
   @override
   Widget build(BuildContext context) {
-    int _selectedTabIndex = 0;
     final requestModel = ref.read(selectedRequestModelProvider);
 
     final preReqCodeController = CodeController(

--- a/lib/services/flutter_js_service.dart
+++ b/lib/services/flutter_js_service.dart
@@ -1,3 +1,6 @@
+import 'dart:developer';
+
+import 'package:flutter/services.dart';
 import 'package:flutter_js/flutter_js.dart';
 
 late JavascriptRuntime jsRuntime;
@@ -8,4 +11,13 @@ void initializeJsRuntime() {
 
 void disposeJsRuntime() {
   jsRuntime.dispose();
+}
+
+void evaluate(String code) {
+  try {
+    JsEvalResult jsResult = jsRuntime.evaluate(code);
+    log(jsResult.stringResult);
+  } on PlatformException catch (e) {
+    log('ERROR: ${e.details}');
+  }
 }

--- a/lib/services/flutter_js_service.dart
+++ b/lib/services/flutter_js_service.dart
@@ -34,55 +34,54 @@ void evaluate(String code) {
 void setupJsBridge() {
   jsRuntime.onMessage('consoleLog', (args) {
     try {
-      final decodedArgs = jsonDecode(args as String);
-      if (decodedArgs is List) {
-        print('[JS LOG]: ${decodedArgs.map((e) => e.toString()).join(' ')}');
+      if (args is List) {
+        print('[JS LOG]: ${args.map((e) => e.toString()).join(' ')}');
       } else {
-        print('[JS LOG]: $decodedArgs');
+        print('[JS LOG]: $args');
       }
     } catch (e) {
-      print('[JS LOG ERROR decoding]: $args, Error: $e');
+      print('[JS LOG ERROR]: $args, Error: $e');
     }
   });
 
   jsRuntime.onMessage('consoleWarn', (args) {
     try {
-      final decodedArgs = jsonDecode(args as String);
-      if (decodedArgs is List) {
-        print('[JS WARN]: ${decodedArgs.map((e) => e.toString()).join(' ')}');
+      if (args is List) {
+        print('[JS WARN]: ${args.map((e) => e.toString()).join(' ')}');
       } else {
-        print('[JS WARN]: $decodedArgs');
+        print('[JS WARN]: $args');
       }
     } catch (e) {
-      print('[JS WARN ERROR decoding]: $args, Error: $e');
+      print('[JS WARN ERROR]: $args, Error: $e');
     }
   });
 
   jsRuntime.onMessage('consoleError', (args) {
     try {
-      final decodedArgs = jsonDecode(args as String);
-      if (decodedArgs is List) {
-        print('[JS ERROR]: ${decodedArgs.map((e) => e.toString()).join(' ')}');
+      if (args is List) {
+        print('[JS ERROR]: ${args.map((e) => e.toString()).join(' ')}');
       } else {
-        print('[JS ERROR]: $decodedArgs');
+        print('[JS ERROR]: $args');
       }
     } catch (e) {
-      print('[JS ERROR ERROR decoding]: $args, Error: $e');
+      print('[JS ERROR ERROR]: $args, Error: $e');
     }
   });
 
   jsRuntime.onMessage('fatalError', (args) {
     try {
-      final errorDetails = jsonDecode(args as String);
-      print('[JS FATAL ERROR]: ${errorDetails['message']}');
-      if (errorDetails['error']) print('  Error: ${errorDetails['error']}');
-      if (errorDetails['stack']) print('  Stack: ${errorDetails['stack']}');
+      // 'fatalError' message is constructed as a JSON object in setupScript
+      if (args is Map<String, dynamic>) {
+        print('[JS FATAL ERROR]: ${args['message']}');
+        if (args['error'] != null) print('  Error: ${args['error']}');
+        if (args['stack'] != null) print('  Stack: ${args['stack']}');
+      } else {
+        print('[JS FATAL ERROR decoding error]: $args, Expected a Map.');
+      }
     } catch (e) {
       print('[JS FATAL ERROR decoding error]: $args, Error: $e');
     }
   });
-
-  //TODO: Add handlers for 'testResult'
 }
 
 Future<
@@ -154,6 +153,8 @@ Future<
           try {
             resultingRequest = HttpRequestModel.fromJson(
                 Map<String, Object?>.from(resultMap['request']));
+            log(resultingRequest.toString());
+            log("Resmap req/; ${resultMap['request'].toString()}");
           } catch (e) {
             print("Error deserializing modified request from script: $e");
             //TODO: Handle error - maybe keep original request?
@@ -242,7 +243,6 @@ Future<
       // TODO: Handle error - maybe show in UI, keep original request/env
     } else if (result.stringResult.isNotEmpty) {
       final resultMap = jsonDecode(result.stringResult);
-      log(resultMap['response'].toString());
       if (resultMap is Map<String, dynamic>) {
         // Deserialize Request
         if (resultMap.containsKey('response') && resultMap['response'] is Map) {

--- a/lib/services/flutter_js_service.dart
+++ b/lib/services/flutter_js_service.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_js/flutter_js.dart';
+
+late JavascriptRuntime jsRuntime;
+
+void initializeJsRuntime() {
+  jsRuntime = getJavascriptRuntime();
+}
+
+void disposeJsRuntime() {
+  jsRuntime.dispose();
+}

--- a/lib/services/flutter_js_service.dart
+++ b/lib/services/flutter_js_service.dart
@@ -6,6 +6,7 @@ import 'dart:developer';
 import 'package:apidash/consts.dart';
 import 'package:apidash/models/request_model.dart';
 import 'package:apidash_core/models/http_request_model.dart';
+import 'package:apidash_core/models/http_response_model.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_js/flutter_js.dart';
 
@@ -133,7 +134,6 @@ Future<
   })(); // Immediately invoke the function
   """;
 
-
   // TODO: Do something better to avoid null check here.
   HttpRequestModel resultingRequest = httpRequest!;
   Map<String, dynamic> resultingEnvironment = Map.from(activeEnvironment);
@@ -173,6 +173,101 @@ Future<
 
   return (
     updatedRequest: resultingRequest,
+    updatedEnvironment: resultingEnvironment
+  );
+}
+
+Future<
+    ({
+      HttpResponseModel updatedResponse,
+      Map<String, dynamic> updatedEnvironment
+    })> executePostResponseScript({
+  required RequestModel currentRequestModel,
+  required Map<String, dynamic> activeEnvironment,
+}) async {
+  if (currentRequestModel.postRequestScript.trim().isEmpty) {
+    // No script, return original data
+    // return (
+    //   updatedRequest: currentRequestModel.httpRequestModel,
+    //   updatedEnvironment: activeEnvironment
+    // );
+  }
+
+  final httpRequest = currentRequestModel.httpRequestModel;
+  final httpResponse = currentRequestModel.httpResponseModel;
+  final userScript = currentRequestModel.postRequestScript;
+
+  // Prepare Data
+  final requestJson = jsonEncode(httpRequest?.toJson());
+  final responseJson = jsonEncode(httpResponse?.toJson());
+  final environmentJson = jsonEncode(activeEnvironment);
+
+  // Inject data as JS variables
+  // Escape strings properly if embedding directly
+  final dataInjection = """
+  var injectedRequestJson = ${jsEscapeString(requestJson)};
+  var injectedEnvironmentJson = ${jsEscapeString(environmentJson)};
+  var injectedResponseJson = ${jsEscapeString(responseJson)};
+  """;
+
+  // Concatenate & Add Return
+  final fullScript = """
+  (function() {
+    // --- Data Injection (now constants within the IIFE scope) ---
+    $dataInjection
+
+    // --- Setup Script (will declare variables within the IIFE scope) ---
+    $setupScript
+
+    // --- User Script (will execute within the IIFE scope)---
+    $userScript
+
+    // --- Return Result (accesses variables from the IIFE scope) ---
+    return JSON.stringify({ response: response, environment: environment });
+  })(); // Immediately invoke the function
+  """;
+
+  // TODO: Do something better to avoid null check here.
+  // HttpRequestModel resultingRequest = httpRequest!;
+  HttpResponseModel resultingResponse = httpResponse!;
+  Map<String, dynamic> resultingEnvironment = Map.from(activeEnvironment);
+
+  try {
+    // Execute
+    final JsEvalResult result = jsRuntime.evaluate(fullScript);
+
+    // Process Results
+    if (result.isError) {
+      print("Post-Response script execution error: ${result.stringResult}");
+      // TODO: Handle error - maybe show in UI, keep original request/env
+    } else if (result.stringResult.isNotEmpty) {
+      final resultMap = jsonDecode(result.stringResult);
+      log(resultMap['response'].toString());
+      if (resultMap is Map<String, dynamic>) {
+        // Deserialize Request
+        if (resultMap.containsKey('response') && resultMap['response'] is Map) {
+          try {
+            resultingResponse = HttpResponseModel.fromJson(
+                Map<String, Object?>.from(resultMap['response']));
+          } catch (e) {
+            print("Error deserializing modified response from script: $e");
+            //TODO: Handle error - maybe keep original response?
+          }
+        }
+        // Get Environment Modifications
+        if (resultMap.containsKey('environment') &&
+            resultMap['environment'] is Map) {
+          resultingEnvironment =
+              Map<String, dynamic>.from(resultMap['environment']);
+        }
+      }
+    }
+  } catch (e) {
+    print("Dart-level error during post-response script execution: $e");
+  }
+
+  return (
+    updatedResponse: resultingResponse,
     updatedEnvironment: resultingEnvironment
   );
 }

--- a/lib/widgets/previewer_code.dart
+++ b/lib/widgets/previewer_code.dart
@@ -1,7 +1,7 @@
 import 'package:apidash_core/apidash_core.dart';
 import 'package:flutter/material.dart';
-import 'package:highlighter/highlighter.dart' show highlight, Node;
 import 'package:apidash/consts.dart';
+import 'package:highlight/highlight.dart';
 import 'error_message.dart';
 
 (String, bool) sanitize(String input) {

--- a/lib/widgets/previewer_codegen.dart
+++ b/lib/widgets/previewer_codegen.dart
@@ -1,8 +1,8 @@
 import 'package:apidash_design_system/apidash_design_system.dart';
 import 'package:flutter/material.dart';
-import 'package:highlighter/highlighter.dart' show highlight;
 import 'package:apidash/consts.dart';
 import 'package:apidash/utils/utils.dart';
+import 'package:highlight/highlight.dart';
 import 'button_copy.dart';
 import 'button_save_download.dart';
 import 'button_share.dart';

--- a/lib/widgets/scripts_editor_pane.dart
+++ b/lib/widgets/scripts_editor_pane.dart
@@ -1,0 +1,44 @@
+import 'package:apidash/providers/settings_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_code_editor/flutter_code_editor.dart';
+import 'package:flutter_highlight/themes/monokai.dart';
+import 'package:flutter_highlight/themes/xcode.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class ScriptsEditorPane extends ConsumerStatefulWidget {
+  final CodeController controller;
+  const ScriptsEditorPane({super.key, required this.controller});
+
+  @override
+  ConsumerState<ScriptsEditorPane> createState() => _ScriptsEditorPaneState();
+}
+
+class _ScriptsEditorPaneState extends ConsumerState<ScriptsEditorPane> {
+  @override
+  Widget build(BuildContext context) {
+    final settings = ref.watch(settingsProvider);
+    return CodeTheme(
+      data: CodeThemeData(
+        styles: settings.isDark ? monokaiTheme : xcodeTheme,
+      ),
+      child: SingleChildScrollView(
+        child: CodeField(
+          smartDashesType: SmartDashesType.enabled,
+          smartQuotesType: SmartQuotesType.enabled,
+          background: Theme.of(context).colorScheme.surfaceContainerLowest,
+          gutterStyle: GutterStyle(
+            width: 40, // TODO: Fix numbers size
+            margin: 2,
+            textAlign: TextAlign.left,
+          ),
+          cursorColor: Theme.of(context).colorScheme.primary,
+          controller: widget.controller,
+          textStyle: TextStyle(
+            fontSize: 12,
+            fontFamily: 'monospace',
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/apidash_core/lib/models/http_response_model.dart
+++ b/packages/apidash_core/lib/models/http_response_model.dart
@@ -12,12 +12,13 @@ import '../consts.dart';
 part 'http_response_model.freezed.dart';
 part 'http_response_model.g.dart';
 
-class Uint8ListConverter implements JsonConverter<Uint8List?, List<int>?> {
+class Uint8ListConverter implements JsonConverter<Uint8List?, List<dynamic>?> {
   const Uint8ListConverter();
 
   @override
-  Uint8List? fromJson(List<int>? json) {
-    return json == null ? null : Uint8List.fromList(json);
+  Uint8List? fromJson(List<dynamic>? json) {
+    if (json == null) return null;
+    return Uint8List.fromList(json.cast<int>());
   }
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -79,6 +79,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.25"
+  autotrie:
+    dependency: transitive
+    description:
+      name: autotrie
+      sha256: "55da6faefb53cfcb0abb2f2ca8636123fb40e35286bb57440d2cf467568188f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   barcode:
     dependency: transitive
     description:
@@ -523,19 +531,27 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_code_editor:
+    dependency: "direct main"
+    description:
+      name: flutter_code_editor
+      sha256: "18cc1200e7481fcf144bc970fdec4e75b83e3f523da60bbf55810a4e8dd6f5fb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.3"
   flutter_driver:
     dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_highlighter:
+  flutter_highlight:
     dependency: "direct main"
     description:
-      name: flutter_highlighter
-      sha256: "93173afd47a9ada53f3176371755e7ea4a1065362763976d06d6adfb4d946e10"
+      name: flutter_highlight
+      sha256: "7b96333867aa07e122e245c033b8ad622e4e3a42a1a2372cbb098a2541d8782c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.1"
+    version: "0.7.0"
   flutter_hooks:
     dependency: "direct main"
     description:
@@ -671,14 +687,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
-  highlighter:
+  highlight:
     dependency: "direct main"
     description:
-      name: highlighter
-      sha256: "92180c72b9da8758e1acf39a45aa305a97dcfe2fdc8f3d1d2947c23f2772bfbc"
+      name: highlight
+      sha256: "5353a83ffe3e3eca7df0abfb72dcf3fa66cc56b953728e7113ad4ad88497cf21"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.1"
+    version: "0.7.0"
   hive:
     dependency: transitive
     description:
@@ -905,6 +921,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  linked_scroll_controller:
+    dependency: transitive
+    description:
+      name: linked_scroll_controller
+      sha256: e6020062bcf4ffc907ee7fd090fa971e65d8dfaac3c62baf601a3ced0b37986a
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   lints:
     dependency: transitive
     description:
@@ -985,6 +1009,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  mocktail:
+    dependency: transitive
+    description:
+      name: mocktail
+      sha256: "890df3f9688106f25755f26b1c60589a92b3ab91a22b8b224947ad041bf172d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   mpv_dart:
     dependency: transitive
     description:
@@ -1628,6 +1660,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  tuple:
+    dependency: transitive
+    description:
+      name: tuple
+      sha256: a97ce2013f240b2f3807bcbaf218765b6f301c3eff91092bcfa23a039e7dd151
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -560,6 +560,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.21.2"
+  flutter_js:
+    dependency: "direct main"
+    description:
+      name: flutter_js
+      sha256: "6b777cd4e468546f046a2f114d078a4596143269f6fa6bad5c29611d5b896369"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.2"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -71,6 +71,7 @@ dependencies:
   flutter_code_editor: ^0.3.3
   highlight: ^0.7.0
   flutter_highlight: ^0.7.0
+  flutter_js: ^0.8.2
 
 dependency_overrides:
   extended_text_field: ^16.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,14 +22,12 @@ dependencies:
   extended_text_field: ^16.0.0
   file_selector: ^1.0.3
   flex_color_scheme: ^8.1.1
-  flutter_highlighter: ^0.1.0
   flutter_hooks: ^0.21.2
   flutter_markdown: ^0.7.6+2
   flutter_portal: ^1.1.4
   flutter_riverpod: ^2.5.1
   flutter_svg: ^2.0.17
   fvp: ^0.30.0
-  highlighter: ^0.1.1
   hive_flutter: ^1.1.0
   hooks_riverpod: ^2.5.2
   intl: ^0.19.0
@@ -70,6 +68,9 @@ dependencies:
       url: https://github.com/google/flutter-desktop-embedding.git
       path: plugins/window_size
   carousel_slider: ^5.0.0
+  flutter_code_editor: ^0.3.3
+  highlight: ^0.7.0
+  flutter_highlight: ^0.7.0
 
 dependency_overrides:
   extended_text_field: ^16.0.0


### PR DESCRIPTION
## PR Description

Adds a simple code editor where we can write JavaScript that runs before and after our requests. 

This would help with:
- Adding auth tokens automatically (no more copy-pasting!)
- Setting up environment variables through code
- Transforming request/response data on the fly
- Chaining API calls (like when you need to get a token first)
- Basic testing and validation

How to use this feature: [scripts_docs.md](https://gist.github.com/Udhay-Adithya/120d602bcf23290fc8c1adbffc2625cd)

## Related Issues

- Closes #557 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Based on the feedback from initial implementation of the feature tests will be added.

## OS on which you have developed and tested the feature?

- [ ] Windows
- [x] macOS
- [ ] Linux
