### PR TITLE
Fix: prevent malformed URL error when parsing IP:PORT by adding defau…

### DIFF
--- a/packages/apidash_core/lib/consts.dart
+++ b/packages/apidash_core/lib/consts.dart
@@ -30,6 +30,8 @@ final kSupportedUriSchemes =
     SupportedUriSchemes.values.map((i) => i.name).toList();
 const kDefaultUriScheme = SupportedUriSchemes.https;
 final kLocalhostRegex = RegExp(r'^localhost(:\d+)?(/.*)?$');
+final kIPHostRegex =
+    RegExp(r'^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}(:\d+)?(/.*)?$');
 
 const kMethodsWithBody = [
   HTTPVerb.post,

--- a/packages/apidash_core/lib/utils/uri_utils.dart
+++ b/packages/apidash_core/lib/utils/uri_utils.dart
@@ -32,7 +32,13 @@ String stripUrlParams(String url) {
 
   if (kLocalhostRegex.hasMatch(url)) {
     url = '${SupportedUriSchemes.http.name}://$url';
+  } else {
+    final hasScheme = RegExp(r'^[a-zA-Z][a-zA-Z0-9+.-]*://').hasMatch(url);
+    if (!hasScheme) {
+      url = "${defaultUriScheme.name}://$url";
+    }
   }
+
   Uri? uri = Uri.tryParse(url);
   if (uri == null) {
     return (null, "Check URL (malformed)");

--- a/packages/apidash_core/lib/utils/uri_utils.dart
+++ b/packages/apidash_core/lib/utils/uri_utils.dart
@@ -30,13 +30,8 @@ String stripUrlParams(String url) {
     return (null, "URL is missing!");
   }
 
-  if (kLocalhostRegex.hasMatch(url)) {
+  if (kLocalhostRegex.hasMatch(url) || kIPHostRegex.hasMatch(url)) {
     url = '${SupportedUriSchemes.http.name}://$url';
-  } else {
-    final hasScheme = RegExp(r'^[a-zA-Z][a-zA-Z0-9+.-]*://').hasMatch(url);
-    if (!hasScheme) {
-      url = "${defaultUriScheme.name}://$url";
-    }
   }
 
   Uri? uri = Uri.tryParse(url);

--- a/packages/apidash_core/test/utils/uri_utils_test.dart
+++ b/packages/apidash_core/test/utils/uri_utils_test.dart
@@ -62,6 +62,37 @@ void main() {
       expect(getValidRequestUri(url1, []), (uri1Expected, null));
     });
 
+    test('Testing getValidRequestUri with IP URL without port or path', () {
+      String url1 = "8.8.8.8";
+      Uri uri1Expected = Uri(scheme: 'http', host: '8.8.8.8');
+      expect(getValidRequestUri(url1, []), (uri1Expected, null));
+    });
+
+    test('Testing getValidRequestUri with IP URL with port', () {
+      String url1 = "8.8.8.8:8080";
+      Uri uri1Expected = Uri(scheme: 'http', host: '8.8.8.8', port: 8080);
+      expect(getValidRequestUri(url1, []), (uri1Expected, null));
+    });
+
+    test('Testing getValidRequestUri with IP URL with port and path', () {
+      String url1 = "8.8.8.8:8080/hello";
+      Uri uri1Expected =
+          Uri(scheme: 'http', host: '8.8.8.8', port: 8080, path: '/hello');
+      expect(getValidRequestUri(url1, []), (uri1Expected, null));
+    });
+
+    test('Testing getValidRequestUri with IP URL with http prefix', () {
+      String url1 = "http://8.8.8.8:3080";
+      Uri uri1Expected = Uri(scheme: 'http', host: '8.8.8.8', port: 3080);
+      expect(getValidRequestUri(url1, []), (uri1Expected, null));
+    });
+
+    test('Testing getValidRequestUri with IP URL with https prefix', () {
+      String url1 = "https://8.8.8.8:8080";
+      Uri uri1Expected = Uri(scheme: 'https', host: '8.8.8.8', port: 8080);
+      expect(getValidRequestUri(url1, []), (uri1Expected, null));
+    });
+
     test('Testing getValidRequestUri for normal values', () {
       String url1 = "https://api.apidash.dev/country/data";
       const kvRow1 = NameValueModel(name: "code", value: "US");


### PR DESCRIPTION

## PR Description
This PR fixes an issue where URLs containing IP addresses with ports (e.g., 8.8.8.8:443) were being treated as malformed due to the absence of a URI scheme (http://, https://, etc.).

## Related Issues

- Closes #841

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [ ] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [x] No, and this is why: This is a small, focused fix , tests will be added later if required based on usage or feedback.

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux
