### PR TITLE
PageBranch widget for Dashboard (#848)

### DIFF
--- a/lib/screens/common_widgets/common_widgets.dart
+++ b/lib/screens/common_widgets/common_widgets.dart
@@ -16,3 +16,4 @@ export 'envvar_span.dart';
 export 'sidebar_filter.dart';
 export 'sidebar_header.dart';
 export 'sidebar_save_button.dart';
+export 'dashboard_page_branch.dart';

--- a/lib/screens/common_widgets/dashboard_page_branch.dart
+++ b/lib/screens/common_widgets/dashboard_page_branch.dart
@@ -1,0 +1,50 @@
+import 'package:apidash_design_system/apidash_design_system.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../mobile/requests_page/requests_page.dart';
+import '../envvar/environment_page.dart';
+import '../history/history_page.dart';
+import '../settings_page.dart';
+import '../mobile/widgets/page_base.dart';
+import '../home_page/home_page.dart';
+
+class PageBranch extends ConsumerWidget {
+  const PageBranch({
+    super.key,
+    required this.pageIndex,
+  });
+
+  final int pageIndex;
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (context.isMediumWindow) {
+      switch (pageIndex) {
+        case 1:
+          return const EnvironmentPage();
+        case 2:
+          return const HistoryPage();
+        case 3:
+          return const PageBase(
+            title: 'Settings',
+            scaffoldBody: SettingsPage(),
+          );
+        default:
+          return const RequestResponsePage();
+      }
+    } else {
+      switch (pageIndex) {
+        case 0:
+          return const HomePage();
+        case 1:
+          return const EnvironmentPage();
+        case 2:
+          return const HistoryPage();
+        case 3:
+          return const SettingsPage();
+        default:
+          return const HomePage();
+      }
+
+    }
+  }
+}

--- a/lib/screens/dashboard.dart
+++ b/lib/screens/dashboard.dart
@@ -6,10 +6,6 @@ import 'package:apidash/widgets/widgets.dart';
 import 'package:apidash/consts.dart';
 import 'package:apidash/dashbot/dashbot.dart';
 import 'common_widgets/common_widgets.dart';
-import 'envvar/environment_page.dart';
-import 'home_page/home_page.dart';
-import 'history/history_page.dart';
-import 'settings_page.dart';
 
 class Dashboard extends ConsumerWidget {
   const Dashboard({super.key});
@@ -112,14 +108,11 @@ class Dashboard extends ConsumerWidget {
               color: Theme.of(context).colorScheme.surfaceContainerHigh,
             ),
             Expanded(
-              child: IndexedStack(
-                alignment: AlignmentDirectional.topCenter,
-                index: railIdx,
-                children: const [
-                  HomePage(),
-                  EnvironmentPage(),
-                  HistoryPage(),
-                  SettingsPage(),
+              child: Stack(
+                children: [
+                  PageBranch(
+                    pageIndex: railIdx,
+                  ),
                 ],
               ),
             )

--- a/lib/screens/mobile/dashboard.dart
+++ b/lib/screens/mobile/dashboard.dart
@@ -4,12 +4,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:apidash/providers/providers.dart';
-import 'requests_page/requests_page.dart';
-import '../envvar/environment_page.dart';
-import '../history/history_page.dart';
-import '../settings_page.dart';
-import 'widgets/page_base.dart';
 import 'navbar.dart';
+import '../common_widgets/common_widgets.dart';
 
 class MobileDashboard extends ConsumerStatefulWidget {
   const MobileDashboard({super.key});
@@ -55,30 +51,5 @@ class _MobileDashboardState extends ConsumerState<MobileDashboard> {
         ],
       ),
     );
-  }
-}
-
-class PageBranch extends ConsumerWidget {
-  const PageBranch({
-    super.key,
-    required this.pageIndex,
-  });
-
-  final int pageIndex;
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    switch (pageIndex) {
-      case 1:
-        return const EnvironmentPage();
-      case 2:
-        return const HistoryPage();
-      case 3:
-        return const PageBase(
-          title: 'Settings',
-          scaffoldBody: SettingsPage(),
-        );
-      default:
-        return const RequestResponsePage();
-    }
   }
 }


### PR DESCRIPTION


## PR Description

* Removed the use of `IndexedStack` widget for retrieving page screens in dashboard, which kept the not-current screen active in the background
* Isolated and modified `PageBranch` widget to be used for both mobile and desktop dashboard

## Related Issues

- Closes #848 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [ ] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [x] No, and this is why: Ongoing implementation + waiting code review

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux
