### PR TITLE
fix ui state not being consistent with the original request model

### DIFF
--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -281,9 +281,10 @@ class CollectionStateNotifier
       return;
     }
 
-    if (requestModel != null &&
-        !requestModel.preRequestScript.isNullOrEmpty()) {
-      requestModel = await handlePreRequestScript(
+    RequestModel executionRequestModel = requestModel!;
+
+    if (!requestModel.preRequestScript.isNullOrEmpty()) {
+      executionRequestModel = await handlePreRequestScript(
         requestModel,
         originalEnvironmentModel,
         (envModel, updatedValues) {
@@ -298,9 +299,9 @@ class CollectionStateNotifier
       );
     }
 
-    APIType apiType = requestModel!.apiType;
+    APIType apiType = executionRequestModel.apiType;
     HttpRequestModel substitutedHttpRequestModel =
-        getSubstitutedHttpRequestModel(requestModel.httpRequestModel!);
+        getSubstitutedHttpRequestModel(executionRequestModel.httpRequestModel!);
 
     // set current model's isWorking to true and update state
     var map = {...state!};

--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -270,7 +270,7 @@ class CollectionStateNotifier
     ref.read(codePaneVisibleStateProvider.notifier).state = false;
     final defaultUriScheme = ref.read(settingsProvider).defaultUriScheme;
     final EnvironmentModel? originalEnvironmentModel =
-        ref.read(selectedEnvironmentModelProvider);
+        ref.read(activeEnvironmentModelProvider);
 
     if (requestId == null || state == null) {
       return;

--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -281,11 +281,11 @@ class CollectionStateNotifier
       return;
     }
 
-    RequestModel executionRequestModel = requestModel!;
+    RequestModel executionRequestModel = requestModel!.copyWith();
 
     if (!requestModel.preRequestScript.isNullOrEmpty()) {
       executionRequestModel = await handlePreRequestScript(
-        requestModel,
+        executionRequestModel,
         originalEnvironmentModel,
         (envModel, updatedValues) {
           ref

--- a/lib/providers/environment_providers.dart
+++ b/lib/providers/environment_providers.dart
@@ -15,6 +15,15 @@ final selectedEnvironmentModelProvider =
   return selectedId != null ? environments![selectedId] : null;
 });
 
+final activeEnvironmentModelProvider = StateProvider<EnvironmentModel?>((ref) {
+  final activeId = ref.watch(activeEnvironmentIdStateProvider);
+  final environments = ref.watch(environmentsStateNotifierProvider);
+  if (activeId != null && environments != null) {
+    return environments[activeId];
+  }
+  return null;
+});
+
 final availableEnvironmentVariablesStateProvider =
     StateProvider<Map<String, List<EnvironmentVariableModel>>>((ref) {
   Map<String, List<EnvironmentVariableModel>> result = {};

--- a/lib/screens/history/history_widgets/his_scripts_tab.dart
+++ b/lib/screens/history/history_widgets/his_scripts_tab.dart
@@ -61,7 +61,7 @@ class _ScriptsCodePaneState extends ConsumerState<HistoryScriptsTab> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Padding(
-          padding: const EdgeInsets.all(8.0),
+          padding: kP6,
           child: ADDropdownButton<int>(
             value: _selectedTabIndex,
             values: tabs,
@@ -75,7 +75,10 @@ class _ScriptsCodePaneState extends ConsumerState<HistoryScriptsTab> {
           ),
         ),
         Expanded(
-          child: content[_selectedTabIndex],
+          child: Padding(
+            padding: kPt5o10,
+            child: content[_selectedTabIndex],
+          ),
         ),
       ],
     );

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_scripts.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_scripts.dart
@@ -59,7 +59,7 @@ class _EditRequestScriptsState extends ConsumerState<EditRequestScripts> {
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         Padding(
-          padding: EdgeInsets.symmetric(vertical: 5, horizontal: 8),
+          padding: kPh8b6,
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_scripts.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_scripts.dart
@@ -59,7 +59,7 @@ class _EditRequestScriptsState extends ConsumerState<EditRequestScripts> {
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         Padding(
-          padding: kPh8b6,
+          padding: EdgeInsets.symmetric(vertical: 5, horizontal: 8),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [

--- a/lib/utils/pre_post_script_utils.dart
+++ b/lib/utils/pre_post_script_utils.dart
@@ -59,7 +59,7 @@ Future<RequestModel> handlePreRequestScript(
       debugPrint(
           "Warning: Pre-request script updated environment variables, but no active environment was selected to save them to.");
     }
-    return requestModel;
+    return newRequestModel;
   }
   return newRequestModel;
 }
@@ -71,7 +71,7 @@ Future<RequestModel> handlePostResponseScript(
 ) async {
   final scriptResult = await executePostResponseScript(
     currentRequestModel: requestModel,
-    activeEnvironment: originalEnvironmentModel?.toJson() ?? {},
+    activeEnvironment: originalEnvironmentModel?.toJson() ?? {"values": []},
   );
 
   final newRequestModel =


### PR DESCRIPTION
## PR Description

- The UI state remains consistent with the original request model
- The user sees the request they originally created, not the modified version from scripts
- The execution still uses the script-modified data for sending the actual HTTP request

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: this is a minor fix

## OS on which you have developed and tested the feature?

- [ ] Windows
- [x] macOS
- [ ] Linux
