### PR TITLE
fix: pause video playback on screen change using VisibilityDetector

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,6 +74,7 @@ dependencies:
     git:
       url: https://github.com/google/flutter-desktop-embedding.git
       path: plugins/window_size
+  visibility_detector: ^0.4.0+2
 
 dependency_overrides:
   extended_text_field: ^16.0.0


### PR DESCRIPTION
## PR Description
This PR fixes the issue where the video player continued playing in the background even after navigating away from the screen.

🛠️ How It’s Fixed
- Integrated VisibilityDetector to monitor the visibility of the video widget.
- When the widget is no longer visible (i.e. screen changes), the video playback is paused.

🎯 Why This Approach
- VisibilityDetector is a lightweight and effective way to track widget visibility without relying on screen lifecycle events.
- It avoids unnecessary resource usage and ensures a cleaner user experience.

## Related Issues

- Closes #848

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [ ] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: it's been manually tested, and we can consider writing a test later if needed based on feedback.

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux
