### PR TITLE
use find.descendant for ExtendedTextField widgets

### DIFF
--- a/test/screens/common_widgets/auth/api_key_auth_fields_test.dart
+++ b/test/screens/common_widgets/auth/api_key_auth_fields_test.dart
@@ -69,12 +69,16 @@ void main() {
       final authFields = find.byType(EnvAuthField);
       expect(authFields, findsNWidgets(2));
 
-      // Find ExtendedTextField widgets within the EnvAuthField widgets
-      final textFields = find.byType(ExtendedTextField);
-      expect(textFields, findsAtLeastNWidgets(2));
+      // Find the last EnvAuthField (API key value field)
+      final lastAuthField = authFields.last;
 
-      // Use testTextInput to directly input text
-      final lastField = textFields.last;
+      // Find ExtendedTextField within the last EnvAuthField using find.descendant
+      final lastField = find.descendant(
+        of: lastAuthField,
+        matching: find.byType(ExtendedTextField),
+      );
+      expect(lastField, findsOneWidget);
+
       await tester.tap(lastField);
       await tester.pumpAndSettle();
 
@@ -218,12 +222,22 @@ void main() {
       // Wait for the widget to settle
       await tester.pumpAndSettle();
 
-      // Find ExtendedTextField widgets
-      final textFields = find.byType(ExtendedTextField);
-      expect(textFields, findsAtLeastNWidgets(2));
+      // Find EnvAuthField widgets
+      final authFields = find.byType(EnvAuthField);
+      expect(authFields, findsNWidgets(2));
 
-      // Tap and enter text in the name field (should be the first text field)
-      await tester.tap(textFields.first);
+      // Find the first EnvAuthField (API key name field)
+      final firstAuthField = authFields.first;
+
+      // Find ExtendedTextField within the first EnvAuthField using find.descendant
+      final nameField = find.descendant(
+        of: firstAuthField,
+        matching: find.byType(ExtendedTextField),
+      );
+      expect(nameField, findsOneWidget);
+
+      // Tap and enter text in the name field
+      await tester.tap(nameField);
       await tester.pumpAndSettle();
 
       // Use tester.testTextInput to enter text directly
@@ -266,15 +280,21 @@ void main() {
       await tester.pumpAndSettle();
 
       // Find EnvAuthField widgets
-      final textFields = find.byType(EnvAuthField);
-      expect(textFields, findsNWidgets(2));
+      final authFields = find.byType(EnvAuthField);
+      expect(authFields, findsNWidgets(2));
 
-      // Find the underlying ExtendedTextField widgets
-      final extendedTextFields = find.byType(ExtendedTextField);
-      expect(extendedTextFields, findsAtLeastNWidgets(2));
+      // Find the last EnvAuthField (API key value field)
+      final lastAuthField = authFields.last;
 
-      // Tap and enter text in the key field (should be the last text field)
-      await tester.tap(extendedTextFields.last);
+      // Find ExtendedTextField within the last EnvAuthField using find.descendant
+      final keyField = find.descendant(
+        of: lastAuthField,
+        matching: find.byType(ExtendedTextField),
+      );
+      expect(keyField, findsOneWidget);
+
+      // Tap and enter text in the key field
+      await tester.tap(keyField);
       await tester.pumpAndSettle();
 
       // Use tester.testTextInput to enter text directly

--- a/test/screens/common_widgets/auth/basic_auth_fields_test.dart
+++ b/test/screens/common_widgets/auth/basic_auth_fields_test.dart
@@ -91,11 +91,20 @@ void main() {
         ),
       );
 
-      // Find the username field (first ExtendedTextField)
-      final textFields = find.byType(ExtendedTextField);
-      expect(textFields, findsAtLeastNWidgets(2));
+      // Find EnvAuthField widgets
+      final authFields = find.byType(EnvAuthField);
+      expect(authFields, findsNWidgets(2));
 
-      final usernameField = textFields.first;
+      // Find the first EnvAuthField (username field)
+      final firstAuthField = authFields.first;
+
+      // Find ExtendedTextField within the first EnvAuthField using find.descendant
+      final usernameField = find.descendant(
+        of: firstAuthField,
+        matching: find.byType(ExtendedTextField),
+      );
+      expect(usernameField, findsOneWidget);
+
       await tester.tap(usernameField);
       await tester.pumpAndSettle();
 
@@ -133,11 +142,20 @@ void main() {
         ),
       );
 
-      // Find the password field (second ExtendedTextField)
-      final textFields = find.byType(ExtendedTextField);
-      expect(textFields, findsAtLeastNWidgets(2));
+      // Find EnvAuthField widgets
+      final authFields = find.byType(EnvAuthField);
+      expect(authFields, findsNWidgets(2));
 
-      final passwordField = textFields.last;
+      // Find the last EnvAuthField (password field)
+      final lastAuthField = authFields.last;
+
+      // Find ExtendedTextField within the last EnvAuthField using find.descendant
+      final passwordField = find.descendant(
+        of: lastAuthField,
+        matching: find.byType(ExtendedTextField),
+      );
+      expect(passwordField, findsOneWidget);
+
       await tester.tap(passwordField);
       await tester.pumpAndSettle();
 
@@ -245,10 +263,19 @@ void main() {
       );
 
       // Enter username
-      final textFields = find.byType(ExtendedTextField);
-      expect(textFields, findsAtLeastNWidgets(2));
+      final authFields = find.byType(EnvAuthField);
+      expect(authFields, findsNWidgets(2));
 
-      final usernameField = textFields.first;
+      // Find the first EnvAuthField (username field)
+      final firstAuthField = authFields.first;
+
+      // Find ExtendedTextField within the first EnvAuthField using find.descendant
+      final usernameField = find.descendant(
+        of: firstAuthField,
+        matching: find.byType(ExtendedTextField),
+      );
+      expect(usernameField, findsOneWidget);
+
       await tester.tap(usernameField);
       await tester.pumpAndSettle();
 

--- a/test/screens/common_widgets/auth/bearer_auth_fields_test.dart
+++ b/test/screens/common_widgets/auth/bearer_auth_fields_test.dart
@@ -88,10 +88,16 @@ void main() {
       );
 
       // Find the token field
-      final textFields = find.byType(ExtendedTextField);
-      expect(textFields, findsAtLeastNWidgets(1));
+      final authField = find.byType(EnvAuthField);
+      expect(authField, findsOneWidget);
 
-      final tokenField = textFields.first;
+      // Find ExtendedTextField within the EnvAuthField using find.descendant
+      final tokenField = find.descendant(
+        of: authField,
+        matching: find.byType(ExtendedTextField),
+      );
+      expect(tokenField, findsOneWidget);
+
       await tester.tap(tokenField);
       await tester.pumpAndSettle();
 
@@ -197,10 +203,16 @@ void main() {
       );
 
       // Enter token
-      final textFields = find.byType(ExtendedTextField);
-      expect(textFields, findsAtLeastNWidgets(1));
+      final authField = find.byType(EnvAuthField);
+      expect(authField, findsOneWidget);
 
-      final tokenField = textFields.first;
+      // Find ExtendedTextField within the EnvAuthField using find.descendant
+      final tokenField = find.descendant(
+        of: authField,
+        matching: find.byType(ExtendedTextField),
+      );
+      expect(tokenField, findsOneWidget);
+
       await tester.tap(tokenField);
       await tester.pumpAndSettle();
 
@@ -254,10 +266,16 @@ void main() {
       );
 
       // Enter token with whitespace
-      final textFields = find.byType(ExtendedTextField);
-      expect(textFields, findsAtLeastNWidgets(1));
+      final authField = find.byType(EnvAuthField);
+      expect(authField, findsOneWidget);
 
-      final tokenField = textFields.first;
+      // Find ExtendedTextField within the EnvAuthField using find.descendant
+      final tokenField = find.descendant(
+        of: authField,
+        matching: find.byType(ExtendedTextField),
+      );
+      expect(tokenField, findsOneWidget);
+
       await tester.tap(tokenField);
       await tester.pumpAndSettle();
 

--- a/test/screens/common_widgets/auth/digest_auth_fields_test.dart
+++ b/test/screens/common_widgets/auth/digest_auth_fields_test.dart
@@ -109,11 +109,20 @@ void main() {
         ),
       );
 
-      // Find the username field (first ExtendedTextField)
-      final textFields = find.byType(ExtendedTextField);
-      expect(textFields, findsAtLeastNWidgets(6));
+      // Find EnvAuthField widgets
+      final authFields = find.byType(EnvAuthField);
+      expect(authFields, findsNWidgets(6));
 
-      final usernameField = textFields.first;
+      // Find the first EnvAuthField (username field)
+      final firstAuthField = authFields.first;
+
+      // Find ExtendedTextField within the first EnvAuthField using find.descendant
+      final usernameField = find.descendant(
+        of: firstAuthField,
+        matching: find.byType(ExtendedTextField),
+      );
+      expect(usernameField, findsOneWidget);
+
       await tester.tap(usernameField);
       await tester.pumpAndSettle();
 
@@ -156,11 +165,20 @@ void main() {
         ),
       );
 
-      // Find the password field (second ExtendedTextField)
-      final textFields = find.byType(ExtendedTextField);
-      expect(textFields, findsAtLeastNWidgets(6));
+      // Find EnvAuthField widgets
+      final authFields = find.byType(EnvAuthField);
+      expect(authFields, findsNWidgets(6));
 
-      final passwordField = textFields.at(1);
+      // Find the second EnvAuthField (password field)
+      final secondAuthField = authFields.at(1);
+
+      // Find ExtendedTextField within the second EnvAuthField using find.descendant
+      final passwordField = find.descendant(
+        of: secondAuthField,
+        matching: find.byType(ExtendedTextField),
+      );
+      expect(passwordField, findsOneWidget);
+
       await tester.tap(passwordField);
       await tester.pumpAndSettle();
 
@@ -245,11 +263,20 @@ void main() {
         ),
       );
 
-      // Find the realm field (third ExtendedTextField)
-      final textFields = find.byType(ExtendedTextField);
-      expect(textFields, findsAtLeastNWidgets(6));
+      // Find EnvAuthField widgets
+      final authFields = find.byType(EnvAuthField);
+      expect(authFields, findsNWidgets(6));
 
-      final realmField = textFields.at(2);
+      // Find the third EnvAuthField (realm field)
+      final thirdAuthField = authFields.at(2);
+
+      // Find ExtendedTextField within the third EnvAuthField using find.descendant
+      final realmField = find.descendant(
+        of: thirdAuthField,
+        matching: find.byType(ExtendedTextField),
+      );
+      expect(realmField, findsOneWidget);
+
       await tester.tap(realmField);
       await tester.pumpAndSettle();
 
@@ -370,7 +397,19 @@ void main() {
       );
 
       // Enter username
-      final usernameField = find.byType(ExtendedTextField).first;
+      final authFields = find.byType(EnvAuthField);
+      expect(authFields, findsNWidgets(6));
+
+      // Find the first EnvAuthField (username field)
+      final firstAuthField = authFields.first;
+
+      // Find ExtendedTextField within the first EnvAuthField using find.descendant
+      final usernameField = find.descendant(
+        of: firstAuthField,
+        matching: find.byType(ExtendedTextField),
+      );
+      expect(usernameField, findsOneWidget);
+
       await tester.tap(usernameField);
       tester.testTextInput.enterText('testuser');
       await tester.pumpAndSettle();
@@ -435,10 +474,19 @@ void main() {
       );
 
       // Enter username with whitespace
-      final textFields = find.byType(ExtendedTextField);
-      expect(textFields, findsAtLeastNWidgets(6));
+      final authFields = find.byType(EnvAuthField);
+      expect(authFields, findsNWidgets(6));
 
-      final usernameField = textFields.first;
+      // Find the first EnvAuthField (username field)
+      final firstAuthField = authFields.first;
+
+      // Find ExtendedTextField within the first EnvAuthField using find.descendant
+      final usernameField = find.descendant(
+        of: firstAuthField,
+        matching: find.byType(ExtendedTextField),
+      );
+      expect(usernameField, findsOneWidget);
+
       await tester.tap(usernameField);
       await tester.pumpAndSettle();
 

--- a/test/screens/common_widgets/auth/jwt_auth_fields_test.dart
+++ b/test/screens/common_widgets/auth/jwt_auth_fields_test.dart
@@ -270,7 +270,16 @@ void main() {
       );
 
       // Find the secret field
-      final secretField = find.byType(ExtendedTextField).first;
+      final authField = find.byType(EnvAuthField);
+      expect(authField, findsOneWidget);
+
+      // Find ExtendedTextField within the EnvAuthField using find.descendant
+      final secretField = find.descendant(
+        of: authField,
+        matching: find.byType(ExtendedTextField),
+      );
+      expect(secretField, findsOneWidget);
+
       await tester.tap(secretField);
       tester.testTextInput.enterText('new-secret');
       await tester.pumpAndSettle();


### PR DESCRIPTION
## PR Description

use find.descendant for ExtendedTextField widgets

## Related Issues

- Closes #872 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_

## OS on which you have developed and tested the feature?

- [ ] Windows
- [x] macOS
- [ ] Linux
