### PR TITLE
Fixed losen better networking constraint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: "none"
 version: 0.5.0+5
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.29.0"
+  sdk: ">=3.8.0 <4.0.0"
+  flutter: ">=3.32.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## PR Description

This PR fixes the issue caused in developer experience due to loosen dependency constraint for better_networking_package which required dart 3.8.0 minimum SDK version. The details are addressed in Issue #875.

## Related Issues

- Closes #875 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [ ] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: This PR only updates the SDK constraints. No functional changes that require tests.

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux
