### PR TITLE
Fix: TabBar overflow on mode change

### DIFF
--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -250,12 +250,15 @@ class CollectionStateNotifier
       newModel = switch (apiType) {
         APIType.rest || APIType.graphql => currentModel.copyWith(
             apiType: apiType,
+            requestTabIndex: 0,
             name: name ?? currentModel.name,
             description: description ?? currentModel.description,
             httpRequestModel: const HttpRequestModel(),
-            aiRequestModel: null),
+            aiRequestModel: null,
+          ),
         APIType.ai => currentModel.copyWith(
             apiType: apiType,
+            requestTabIndex: 0,
             name: name ?? currentModel.name,
             description: description ?? currentModel.description,
             httpRequestModel: null,

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/ai_request/request_pane_ai.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/ai_request/request_pane_ai.dart
@@ -13,12 +13,8 @@ class EditAIRequestPane extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final selectedId = ref.watch(selectedIdStateProvider);
     final codePaneVisible = ref.watch(codePaneVisibleStateProvider);
-    var tabIndex = ref.watch(
+    final tabIndex = ref.watch(
         selectedRequestModelProvider.select((value) => value?.requestTabIndex));
-      
-    if (tabIndex >= 3) {
-      tabIndex = 0;
-    }
 
     return RequestPane(
       selectedId: selectedId,

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_pane_graphql.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_pane_graphql.dart
@@ -15,7 +15,7 @@ class EditGraphQLRequestPane extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final selectedId = ref.watch(selectedIdStateProvider);
-    var tabIndex = ref.watch(
+    final tabIndex = ref.watch(
         selectedRequestModelProvider.select((value) => value?.requestTabIndex));
     final codePaneVisible = ref.watch(codePaneVisibleStateProvider);
     final headerLength = ref.watch(selectedRequestModelProvider
@@ -33,10 +33,6 @@ class EditGraphQLRequestPane extends ConsumerWidget {
 
     final hasAuth = ref.watch(selectedRequestModelProvider.select((value) =>
         value?.httpRequestModel?.authModel?.type != APIAuthType.none));
-
-    if (tabIndex >= 4) {
-      tabIndex = 0;
-    }
 
     return RequestPane(
       selectedId: selectedId,


### PR DESCRIPTION
## PR Description
When changing the request mode from HTTP to AI or GraphQL, if the TabBar Index is set to an index higher than the available tabs in the next mode, the app triggers an error. Attaching a video demo of the same. This PR fixes that error and sets the tabbar to index 0 if it overflows. For GraphQL, the tab on index 3 was also being ignored, hence fixed it as well.

https://github.com/user-attachments/assets/56cf9b65-e701-4265-98f7-70606ff6e77f


## Related Issues
None

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [x] No, and this is why: Tests are not needed

## OS on which you have developed and tested the feature?

- [ ] Windows
- [x] macOS
- [ ] Linux
