### PR TITLE
Fix: SSE raw response not showing all entries (#873)

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1170,10 +1170,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1932,26 +1932,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.12"
   textwrap:
     dependency: transitive
     description:


### PR DESCRIPTION
hey @animator

i hope your doing well!

I have a fixed issue once check it out


  Fix: SSE raw response not showing all entries (#873)


The when we send a request to and it returns SSE and a raw response but in SSE response option it is feching all output for the request but the raw it is only showing the last set of output not complete output. so there is an small bug in code file(the location of code file is ./apidash/packages/better_networking/lib/services/http_service.dart) in this file from line 306 to line 325 the written code When SSE events come in the  bytes contains only the latest chunk, not the full response,They convert each chunk to a "full response" using "_createResponseFromBytes(bytes)" because of this the old SSE events disapper and only the last event get displayed

Example:-

This PR fixes issue #873 where the SSE Raw Response view did not show all
incoming entries. The problem occurred because the previous stream handler
ignored intermediate SSE chunks. This update ensures all SSE messages are
collected and rendered properly.
<img width="1489" height="983" alt="Screenshot 2025-12-07 155431" src="https://github.com/user-attachments/assets/f9bec053-4852-4a29-aaa1-c310112bffc8" />
<img width="1480" height="986" alt="Screenshot 2025-12-07 155437" src="https://github.com/user-attachments/assets/f499e67c-7470-49a1-a51c-83b69ab40d8d" />
<img width="778" height="484" alt="Screenshot 2025-12-07 160127" src="https://github.com/user-attachments/assets/cc5989ff-6d4a-4ca8-82f5-e745a370ac9c" />

