### PR TITLE
loading indicator issue fix

### DIFF
--- a/lib/screens/common_widgets/ai/ai_model_selector_dialog.dart
+++ b/lib/screens/common_widgets/ai/ai_model_selector_dialog.dart
@@ -138,7 +138,7 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
             ),
           );
         }
-        return CircularProgressIndicator();
+        return Center(child: CircularProgressIndicator());
       },
     );
   }


### PR DESCRIPTION
## PR Description

Simple issue fix of expanded CircularProgressIndicator while clicking on the select model button. Fixed by wrapping the widget by a Center widget. Fixes #936 


