### PR TITLE
fix(macos): add padding to sidebar to prevent traffic light overlap

### DIFF
--- a/lib/screens/dashboard.dart
+++ b/lib/screens/dashboard.dart
@@ -28,110 +28,113 @@ class Dashboard extends ConsumerWidget {
       body: SafeArea(
         child: Row(
           children: <Widget>[
-            Column(
-              children: [
-                SizedBox(
-                  height: kIsMacOS ? 32.0 : 16.0,
-                  width: 64,
-                ),
-                Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    IconButton(
-                      isSelected: railIdx == 0,
-                      onPressed: () {
-                        ref.read(navRailIndexStateProvider.notifier).state = 0;
-                      },
-                      icon: const Icon(Icons.auto_awesome_mosaic_outlined),
-                      selectedIcon: const Icon(Icons.auto_awesome_mosaic),
-                    ),
-                    Text(
-                      'Requests',
-                      style: Theme.of(context).textTheme.labelSmall,
-                    ),
-                    kVSpacer10,
-                    IconButton(
-                      isSelected: railIdx == 1,
-                      onPressed: () {
-                        ref.read(navRailIndexStateProvider.notifier).state = 1;
-                      },
-                      icon: const Icon(Icons.laptop_windows_outlined),
-                      selectedIcon: const Icon(Icons.laptop_windows),
-                    ),
-                    Text(
-                      'Variables',
-                      style: Theme.of(context).textTheme.labelSmall,
-                    ),
-                    kVSpacer10,
-                    IconButton(
-                      isSelected: railIdx == 2,
-                      onPressed: () {
-                        ref.read(navRailIndexStateProvider.notifier).state = 2;
-                      },
-                      icon: const Icon(Icons.history_outlined),
-                      selectedIcon: const Icon(Icons.history_rounded),
-                    ),
-                    Text(
-                      'History',
-                      style: Theme.of(context).textTheme.labelSmall,
-                    ),
-                    kVSpacer10,
-                    Badge(
-                      backgroundColor: Theme.of(context).colorScheme.error,
-                      isLabelVisible:
-                          ref.watch(showTerminalBadgeProvider) && railIdx != 3,
-                      child: IconButton(
-                        isSelected: railIdx == 3,
-                        onPressed: () {
-                          ref.read(navRailIndexStateProvider.notifier).state =
-                              3;
-                          ref.read(showTerminalBadgeProvider.notifier).state =
-                              false;
-                        },
-                        icon: const Icon(Icons.terminal_outlined),
-                        selectedIcon: const Icon(Icons.terminal),
-                      ),
-                    ),
-                    Text(
-                      'Logs',
-                      style: Theme.of(context).textTheme.labelSmall,
-                    ),
-                  ],
-                ),
-                Expanded(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.end,
+            Padding(
+              padding: EdgeInsets.symmetric(horizontal: kIsMacOS ? 8.0 : 0.0),
+              child: Column(
+                children: [
+                  SizedBox(
+                    height: kIsMacOS ? 52.0 : 16.0,
+                    width: 64,
+                  ),
+                  Column(
+                    mainAxisSize: MainAxisSize.min,
                     children: [
-                      Padding(
-                        padding: const EdgeInsets.only(bottom: 16.0),
-                        child: NavbarButton(
-                          railIdx: railIdx,
-                          selectedIcon: Icons.help,
-                          icon: Icons.help_outline,
-                          label: 'About',
-                          showLabel: false,
-                          isCompact: true,
-                          onTap: () {
-                            showAboutAppDialog(context);
+                      IconButton(
+                        isSelected: railIdx == 0,
+                        onPressed: () {
+                          ref.read(navRailIndexStateProvider.notifier).state = 0;
+                        },
+                        icon: const Icon(Icons.auto_awesome_mosaic_outlined),
+                        selectedIcon: const Icon(Icons.auto_awesome_mosaic),
+                      ),
+                      Text(
+                        'Requests',
+                        style: Theme.of(context).textTheme.labelSmall,
+                      ),
+                      kVSpacer10,
+                      IconButton(
+                        isSelected: railIdx == 1,
+                        onPressed: () {
+                          ref.read(navRailIndexStateProvider.notifier).state = 1;
+                        },
+                        icon: const Icon(Icons.laptop_windows_outlined),
+                        selectedIcon: const Icon(Icons.laptop_windows),
+                      ),
+                      Text(
+                        'Variables',
+                        style: Theme.of(context).textTheme.labelSmall,
+                      ),
+                      kVSpacer10,
+                      IconButton(
+                        isSelected: railIdx == 2,
+                        onPressed: () {
+                          ref.read(navRailIndexStateProvider.notifier).state = 2;
+                        },
+                        icon: const Icon(Icons.history_outlined),
+                        selectedIcon: const Icon(Icons.history_rounded),
+                      ),
+                      Text(
+                        'History',
+                        style: Theme.of(context).textTheme.labelSmall,
+                      ),
+                      kVSpacer10,
+                      Badge(
+                        backgroundColor: Theme.of(context).colorScheme.error,
+                        isLabelVisible:
+                            ref.watch(showTerminalBadgeProvider) && railIdx != 3,
+                        child: IconButton(
+                          isSelected: railIdx == 3,
+                          onPressed: () {
+                            ref.read(navRailIndexStateProvider.notifier).state =
+                                3;
+                            ref.read(showTerminalBadgeProvider.notifier).state =
+                                false;
                           },
+                          icon: const Icon(Icons.terminal_outlined),
+                          selectedIcon: const Icon(Icons.terminal),
                         ),
                       ),
-                      Padding(
-                        padding: const EdgeInsets.only(bottom: 16.0),
-                        child: NavbarButton(
-                          railIdx: railIdx,
-                          buttonIdx: 4,
-                          selectedIcon: Icons.settings,
-                          icon: Icons.settings_outlined,
-                          label: 'Settings',
-                          showLabel: false,
-                          isCompact: true,
-                        ),
+                      Text(
+                        'Logs',
+                        style: Theme.of(context).textTheme.labelSmall,
                       ),
                     ],
                   ),
-                ),
-              ],
+                  Expanded(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 16.0),
+                          child: NavbarButton(
+                            railIdx: railIdx,
+                            selectedIcon: Icons.help,
+                            icon: Icons.help_outline,
+                            label: 'About',
+                            showLabel: false,
+                            isCompact: true,
+                            onTap: () {
+                              showAboutAppDialog(context);
+                            },
+                          ),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 16.0),
+                          child: NavbarButton(
+                            railIdx: railIdx,
+                            buttonIdx: 4,
+                            selectedIcon: Icons.settings,
+                            icon: Icons.settings_outlined,
+                            label: 'Settings',
+                            showLabel: false,
+                            isCompact: true,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
             ),
             VerticalDivider(
               thickness: 1,


### PR DESCRIPTION
On macOS, the traffic light icons (close, minimize, maximize) were overlapping with the sidebar navigation icons when the title bar is hidden. Added symmetric horizontal padding to the sidebar column on macOS to ensure proper spacing while keeping icons centered.

## PR Description

On macOS, when the title bar is hidden, the traffic light icons (close, minimize, maximize) were overlapping with the sidebar navigation icons. This PR adds symmetric horizontal padding (8px) to the sidebar column on macOS to ensure proper spacing without making the sidebar too wide, while keeping the icons centered.

### Before
<img width="1312" height="912" alt="2025-12-13_18-17-50" src="https://github.com/user-attachments/assets/b2e9f151-7d6e-49aa-a1b9-64b5dab46caf" />

### After
<img width="1582" height="1034" alt="image" src="https://github.com/user-attachments/assets/d5b4ab60-1e4e-4756-8f5d-1987619ed7ad" />

## Related Issues

- Closes #938 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [ ] I have run the tests (`flutter test`) and all tests are passing - A test 'Testing when type/subtype is video/H264' failed, but it is unrelated to this PR. (I will try to work on it after this.)

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: This is a UI spacing fix that only affects macOS traffic light positioning. Visual verification confirms the fix works correctly.

## OS on which you have developed and tested the feature?

- [ ] Windows
- [x] macOS
- [ ] Linux
