### PR TITLE
feat: Auto-beautify JSON in AI response raw view

### DIFF
--- a/lib/widgets/response_body_success.dart
+++ b/lib/widgets/response_body_success.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'package:apidash_core/apidash_core.dart';
 import 'package:apidash_design_system/apidash_design_system.dart';
 import 'package:flutter/foundation.dart';
@@ -38,6 +39,15 @@ class ResponseBodySuccess extends StatefulWidget {
 
 class _ResponseBodySuccessState extends State<ResponseBodySuccess> {
   int segmentIdx = 0;
+
+  String _getBeautifiedBody() {
+    try {
+      final jsonObject = jsonDecode(widget.body);
+      return const JsonEncoder.withIndent('  ').convert(jsonObject);
+    } catch (e) {
+      return widget.body;
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -163,7 +173,7 @@ class _ResponseBodySuccessState extends State<ResponseBodySuccess> {
                       child: SingleChildScrollView(
                         child: SelectableText(
                           widget.isAIResponse
-                              ? widget.body
+                              ? _getBeautifiedBody()
                               : (widget.formattedBody ?? widget.body),
                           style: kCodeStyle,
                         ),


### PR DESCRIPTION
## PR Description

Auto-formats JSON responses in the Raw view for AI requests (Ollama) to improve
readability and debugging.

The Raw response is now:
- Automatically pretty-printed when the response body is valid JSON
- Gracefully falls back to the original response if JSON parsing fails

This brings consistency with other AI providers (e.g., Gemini) and improves the
developer experience when inspecting full AI/LLM responses and metadata.

## Related Issues

- Closes #947 

### Checklist
- [x] I have gone through the contributing guide
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [x] No, and this is why:  
The change is a simple JSON formatting enhancement that uses Dart's built-in jsonDecode and JsonEncoder which are already well-tested. The existing tests pass, and the only failing test is a pre-existing google_fonts asset loading issue unrelated to this change.

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux
