### PR TITLE
Add feature - cUrl paste detection

### DIFF
--- a/lib/screens/common_widgets/envfield_url.dart
+++ b/lib/screens/common_widgets/envfield_url.dart
@@ -11,6 +11,7 @@ class EnvURLField extends StatelessWidget {
     this.onChanged,
     this.onFieldSubmitted,
     this.focusNode,
+    this.onCurlDetected,
   });
 
   final String selectedId;
@@ -18,6 +19,7 @@ class EnvURLField extends StatelessWidget {
   final void Function(String)? onChanged;
   final void Function(String)? onFieldSubmitted;
   final FocusNode? focusNode;
+  final Future<String?> Function(String)? onCurlDetected;
 
   @override
   Widget build(BuildContext context) {
@@ -35,6 +37,7 @@ class EnvURLField extends StatelessWidget {
       ),
       onChanged: onChanged,
       onFieldSubmitted: onFieldSubmitted,
+      onCurlDetected: onCurlDetected,
       optionsWidthFactor: 1,
     );
   }


### PR DESCRIPTION
## PR Description

This PR adds support for automatically parsing a curl command when it is pasted
into the URL field, similar to Postman.

When a curl command is detected on paste:
- The curl is parsed using the existing CurlIO parser
- Request method, URL, headers, query parameters, body, and form data are populated automatically
- The URL field is updated to show only the parsed URL
- Invalid curl commands are handled gracefully with user-friendly feedback

This behavior is limited to REST API requests and does not affect normal typing
or existing URL field functionality.

## Related Issues

- Implements #953

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [x] No, and this is why: This change introduces paste-based curl detection and parsing logic.
  Existing request parsing functionality is already covered, and widget tests for paste
  interactions can be added in a follow-up enhancement.

## OS on which you have developed and tested the feature?

- [ ] Windows
- [x] macOS
- [ ] Linux

https://github.com/user-attachments/assets/4e9f0658-d371-443f-b323-080f08ec6db9

