### PR TITLE
feat: Add markdown formatting toggle for AI response in Answer tab

### DIFF
--- a/lib/widgets/response_body_success.dart
+++ b/lib/widgets/response_body_success.dart
@@ -2,6 +2,7 @@ import 'package:apidash_core/apidash_core.dart';
 import 'package:apidash_design_system/apidash_design_system.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:apidash/utils/utils.dart';
 import 'package:apidash/widgets/widgets.dart';
 import 'package:apidash/consts.dart';
@@ -38,6 +39,7 @@ class ResponseBodySuccess extends StatefulWidget {
 
 class _ResponseBodySuccessState extends State<ResponseBodySuccess> {
   int segmentIdx = 0;
+  bool _enableFormatting = true;
 
   @override
   Widget build(BuildContext context) {
@@ -143,16 +145,57 @@ class _ResponseBodySuccessState extends State<ResponseBodySuccess> {
                     ),
                   ),
                 ResponseBodyView.answer => Expanded(
-                    child: Container(
-                      width: double.maxFinite,
-                      padding: kP8,
-                      decoration: textContainerdecoration,
-                      child: SingleChildScrollView(
-                        child: SelectableText(
-                          widget.formattedBody ?? widget.body,
-                          style: kCodeStyle,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            ADCheckBox(
+                              keyId: 'format-markdown-checkbox',
+                              value: _enableFormatting,
+                              onChanged: (value) {
+                                setState(() {
+                                  _enableFormatting = value ?? false;
+                                });
+                              },
+                            ),
+                            kHSpacer4,
+                            Text(
+                              'Format Markdown',
+                              style: Theme.of(context).textTheme.bodyMedium,
+                            ),
+                          ],
                         ),
-                      ),
+                        kVSpacer8,
+                        Expanded(
+                          child: Container(
+                            width: double.maxFinite,
+                            padding: kP8,
+                            decoration: textContainerdecoration,
+                            child: _enableFormatting
+                                ? Markdown(
+                                    data: widget.formattedBody ?? widget.body,
+                                    selectable: true,
+                                    styleSheet: MarkdownStyleSheet.fromTheme(
+                                      Theme.of(context),
+                                    ).copyWith(
+                                      p: Theme.of(context).textTheme.bodyMedium,
+                                      code: kCodeStyle.copyWith(
+                                        backgroundColor: Theme.of(context)
+                                            .colorScheme
+                                            .surfaceContainerHighest,
+                                      ),
+                                    ),
+                                  )
+                                : SingleChildScrollView(
+                                    child: SelectableText(
+                                      widget.formattedBody ?? widget.body,
+                                      style: kCodeStyle,
+                                    ),
+                                  ),
+                          ),
+                        ),
+                      ],
                     ),
                   ),
                 ResponseBodyView.raw => Expanded(


### PR DESCRIPTION
## PR Description

Add markdown formatting toggle for AI response in the Answer tab. When using AI request mode, the AI responds in markdown format which was previously displayed as raw unformatted text. This PR adds:

- A "Format Markdown" checkbox in the Answer tab
- When enabled: Renders the AI response with proper markdown formatting (headers, bold, lists, code blocks, etc.) using flutter_markdown
- When disabled: Shows the raw unformatted text (original behavior)
- Defaults to enabled for better readability

## Related Issues

- Closes #955 

### Checklist

- [x]  I have gone through the contributing guide
- [x]  I have updated my branch and synced it with project main branch before making this PR
- [x]  I am using the latest Flutter stable branch (run flutter upgrade and verify)
- [x]  I have run the tests (flutter test) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [x] No, and this is why:This is a minor UI enhancement that adds a checkbox toggle and conditional rendering. The change uses existing well-tested components (Markdown widget, ADCheckBox) and was manually tested to confirm functionality.
## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux
