### PR TITLE
feat: env variable support for text request body

### DIFF
--- a/lib/screens/common_widgets/env_editor.dart
+++ b/lib/screens/common_widgets/env_editor.dart
@@ -1,0 +1,112 @@
+﻿import 'dart:math' as math;
+import 'package:apidash/consts.dart';
+import 'package:apidash/screens/common_widgets/common_widgets.dart';
+import 'package:apidash_design_system/apidash_design_system.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:multi_trigger_autocomplete_plus/multi_trigger_autocomplete_plus.dart';
+
+
+class EnvironmentTextFieldEditor extends StatefulWidget{
+  const EnvironmentTextFieldEditor({
+    super.key,
+    required this.fieldKey,
+    this.onChanged,
+    this.initialValue,
+    this.readOnly = false,
+    this.hintText,
+  });
+
+  final String fieldKey;
+  final Function(String)? onChanged;
+  final String? initialValue;
+  final bool readOnly;
+  final String? hintText;
+
+  @override
+  State<StatefulWidget> createState() => _EnvironmentTextField();
+}
+
+
+class _EnvironmentTextField extends State<EnvironmentTextFieldEditor>{
+  final TextEditingController controller = TextEditingController();
+  late final FocusNode editorFocusNode;
+
+
+  void insertTab() {
+    String sp = "  ";
+    int offset = math.min(
+        controller.selection.baseOffset, controller.selection.extentOffset);
+    String text = controller.text.substring(0, offset) +
+        sp +
+        controller.text.substring(offset);
+    controller.value = TextEditingValue(
+      text: text,
+      selection: controller.selection.copyWith(
+        baseOffset: controller.selection.baseOffset + sp.length,
+        extentOffset: controller.selection.extentOffset + sp.length,
+      ),
+    );
+    widget.onChanged?.call(text);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    editorFocusNode = FocusNode(debugLabel: "Editor Focus Node");
+  }
+
+  @override
+  void dispose() {
+    editorFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CallbackShortcuts(
+      bindings: <ShortcutActivator, VoidCallback>{
+        const SingleActivator(LogicalKeyboardKey.tab): () {
+          insertTab();
+        },
+      },
+      child: EnvironmentTriggerField(
+        keyId: widget.fieldKey,
+        controller: controller,
+        focusNode: editorFocusNode,
+        keyboardType: TextInputType.multiline,
+        expands: true,
+        maxLines: null,
+        readOnly: widget.readOnly,
+        style: kCodeStyle.copyWith(
+          fontSize: Theme.of(context).textTheme.bodyMedium?.fontSize,
+        ),
+        textAlignVertical: TextAlignVertical.top,
+        onChanged: widget.onChanged,
+        decoration: InputDecoration(
+          hintText: widget.hintText ?? kHintContent,
+          hintStyle: TextStyle(
+            color: Theme.of(context).colorScheme.outlineVariant,
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderRadius: kBorderRadius8,
+            borderSide: BorderSide(
+              color: Theme.of(context).colorScheme.outlineVariant,
+            ),
+          ),
+          enabledBorder: OutlineInputBorder(
+            borderRadius: kBorderRadius8,
+            borderSide: BorderSide(
+              color: Theme.of(context).colorScheme.surfaceContainerHighest,
+            ),
+          ),
+          filled: true,
+          hoverColor: kColorTransparent,
+          fillColor: Theme.of(context).colorScheme.surfaceContainerLowest,
+        ),
+        optionsAlignment: OptionsAlignment.topEnd,
+      ),
+    );
+  }
+
+}

--- a/lib/screens/common_widgets/env_trigger_field.dart
+++ b/lib/screens/common_widgets/env_trigger_field.dart
@@ -18,7 +18,12 @@ class EnvironmentTriggerField extends StatefulWidget {
     this.optionsWidthFactor,
     this.autocompleteNoTrigger,
     this.readOnly = false,
-    this.obscureText = false
+    this.obscureText = false,
+    this.expands = false,
+    this.keyboardType,
+    this.maxLines,
+    this.textAlignVertical,
+    this.optionsAlignment = OptionsAlignment.bottom
   }) : assert(
           !(controller != null && initialValue != null),
           'controller and initialValue cannot be simultaneously defined.',
@@ -36,6 +41,11 @@ class EnvironmentTriggerField extends StatefulWidget {
   final AutocompleteNoTrigger? autocompleteNoTrigger;
   final bool readOnly;
   final bool obscureText;
+  final TextInputType ? keyboardType;
+  final bool expands;
+  final int ? maxLines;
+  final TextAlignVertical ? textAlignVertical;
+  final OptionsAlignment optionsAlignment;
 
   @override
   State<EnvironmentTriggerField> createState() =>
@@ -84,6 +94,7 @@ class EnvironmentTriggerFieldState extends State<EnvironmentTriggerField> {
       textEditingController: controller,
       focusNode: _focusNode,
       optionsWidthFactor: widget.optionsWidthFactor ?? 1,
+      optionsAlignment: widget.optionsAlignment,
       autocompleteTriggers: [
         if (widget.autocompleteNoTrigger != null) widget.autocompleteNoTrigger!,
         AutocompleteTrigger(
@@ -130,8 +141,11 @@ class EnvironmentTriggerFieldState extends State<EnvironmentTriggerField> {
             _focusNode.unfocus();
           },
           readOnly: widget.readOnly,
-          obscureText: widget.obscureText
-          
+          obscureText: widget.obscureText,
+          keyboardType: widget.keyboardType,
+          expands: widget.expands,
+          maxLines: widget.maxLines,
+          textAlignVertical: widget.textAlignVertical
         );
       },
     );

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_body.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_body.dart
@@ -1,3 +1,4 @@
+import 'package:apidash/screens/common_widgets/env_editor.dart';
 import 'package:apidash_core/apidash_core.dart';
 import 'package:apidash_design_system/apidash_design_system.dart';
 import 'package:flutter/material.dart';
@@ -62,7 +63,7 @@ class EditRequestBody extends ConsumerWidget {
                   ),
                 _ => Padding(
                     padding: kPt5o10,
-                    child: TextFieldEditor(
+                    child: EnvironmentTextFieldEditor(
                       key: Key("$selectedId-body"),
                       fieldKey: "$selectedId-body-editor",
                       initialValue: requestModel?.httpRequestModel?.body,


### PR DESCRIPTION
## PR Description

added the env variable support when writing request body as text
<img width="1019" height="593" alt="image" src="https://github.com/user-attachments/assets/d0edb9ca-dcb0-4d92-ba86-ff5dd6b38328" />


## Related Issues

- Closes #591 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [] I have run the tests (`flutter test`) and all tests are passing (i tried to run the tests on the latest branch without doing any changes and still getting fails) 

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [x] No, and this is why: i don't think it is needed since it is a visual feature and manual test would be enough 

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux
