### PR TITLE
added-focussed-tap-toCopy

### DIFF
--- a/lib/widgets/previewer_json.dart
+++ b/lib/widgets/previewer_json.dart
@@ -271,7 +271,7 @@ class _JsonPreviewerState extends State<JsonPreviewer> {
                       ),
                       trailingBuilder: (context, node) => node.isFocused
                           ? Padding(
-                              padding: const EdgeInsets.only(right: 12),
+                              padding: const EdgeInsets.only(right: 6),
                               child: IconButton(
                                 padding: EdgeInsets.zero,
                                 constraints:

--- a/packages/json_explorer/lib/src/json_explorer.dart
+++ b/packages/json_explorer/lib/src/json_explorer.dart
@@ -316,8 +316,6 @@ class JsonAttribute extends StatelessWidget {
                 if (valueStyle.onTap != null) {
                   valueStyle.onTap!.call();
                 } else {
-                  // On mobile, only focus root nodes (for copy button)
-                  // Expand/collapse is handled by arrow icon tap
                   if (_isMobile && node.isRoot) {
                     final jsonExplorerStore = Provider.of<JsonExplorerStore>(
                       context,

--- a/packages/json_explorer/lib/src/json_explorer.dart
+++ b/packages/json_explorer/lib/src/json_explorer.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
@@ -262,6 +264,9 @@ class JsonAttribute extends StatelessWidget {
     this.maxRootNodeWidth,
   }) : super(key: key);
 
+  static bool get _isMobile =>
+      !kIsWeb && (Platform.isIOS || Platform.isAndroid);
+
   @override
   Widget build(BuildContext context) {
     final searchTerm =
@@ -290,12 +295,45 @@ class JsonAttribute extends StatelessWidget {
       },
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
+        onTapDown: _isMobile && !node.isRoot && !hasInteraction
+            ? (_) {
+                final jsonExplorerStore = Provider.of<JsonExplorerStore>(
+                  context,
+                  listen: false,
+                );
+                if (node.isFocused) {
+                  node.focus(isFocused: false);
+                  node.highlight(isHighlighted: false);
+                } else {
+                  node.focus();
+                  node.highlight();
+                  jsonExplorerStore.unfocusAllExcept(node);
+                }
+              }
+            : null,
         onTap: hasInteraction
             ? () {
                 if (valueStyle.onTap != null) {
                   valueStyle.onTap!.call();
                 } else {
-                  _onTap(context);
+                  // On mobile, only focus root nodes (for copy button)
+                  // Expand/collapse is handled by arrow icon tap
+                  if (_isMobile && node.isRoot) {
+                    final jsonExplorerStore = Provider.of<JsonExplorerStore>(
+                      context,
+                      listen: false,
+                    );
+                    if (node.isFocused) {
+                      node.focus(isFocused: false);
+                      node.highlight(isHighlighted: false);
+                    } else {
+                      node.focus();
+                      node.highlight();
+                      jsonExplorerStore.unfocusAllExcept(node);
+                    }
+                  } else {
+                    _onTap(context);
+                  }
                 }
               }
             : null,
@@ -322,10 +360,13 @@ class JsonAttribute extends StatelessWidget {
                       lineColor: theme.indentationLineColor,
                     ),
                     if (node.isRoot)
-                      SizedBox(
-                        width: 24,
-                        child: collapsableToggleBuilder?.call(context, node) ??
-                            _defaultCollapsableToggleBuilder(context, node),
+                      GestureDetector(
+                        onTap: () => _onTap(context),
+                        child: SizedBox(
+                          width: 24,
+                          child: collapsableToggleBuilder?.call(context, node) ??
+                              _defaultCollapsableToggleBuilder(context, node),
+                        ),
                       ),
                     Padding(
                       padding: EdgeInsets.symmetric(vertical: spacing),
@@ -542,21 +583,20 @@ class _PropertyNodeWidget extends StatelessWidget {
 
     final text = valueFormatter?.call(node.value) ?? node.value.toString();
 
-    if (!showHighlightedText) {
-      return SelectableText(text, style: style);
+    final isMobile = !kIsWeb && (Platform.isIOS || Platform.isAndroid);
+    
+    if (showHighlightedText) {
+      return _HighlightedText(
+        text: text,
+        highlightedText: searchTerm,
+        style: style,
+        primaryMatchStyle: focusedSearchHighlightStyle,
+        secondaryMatchStyle: searchHighlightStyle,
+        focusedSearchMatchIndex: context
+            .select<JsonExplorerStore, int?>(_getFocusedSearchMatchIndex),
+      );
     }
-
-    final focusedSearchMatchIndex =
-        context.select<JsonExplorerStore, int?>(_getFocusedSearchMatchIndex);
-
-    return _HighlightedText(
-      text: text,
-      highlightedText: searchTerm,
-      style: style,
-      primaryMatchStyle: focusedSearchHighlightStyle,
-      secondaryMatchStyle: searchHighlightStyle,
-      focusedSearchMatchIndex: focusedSearchMatchIndex,
-    );
+    return isMobile ? Text(text, style: style) : SelectableText(text, style: style);
   }
 }
 

--- a/packages/json_explorer/lib/src/json_explorer_store.dart
+++ b/packages/json_explorer/lib/src/json_explorer_store.dart
@@ -624,6 +624,17 @@ class JsonExplorerStore extends ChangeNotifier {
     }
   }
 
+  /// Unfocuses all nodes except the given [node].
+  /// [notifyListeners] is called to notify all registered listeners.
+  void unfocusAllExcept(NodeViewModelState node) {
+    for (final n in _allNodes) {
+      if (n != node && n.isFocused) {
+        n.focus(isFocused: false);
+        n.highlight(isHighlighted: false);
+      }
+    }
+  }
+
   /// Uses the given [jsonObject] to build the [displayNodes] list.
   ///
   /// If [areAllCollapsed] is true, then all nodes will be collapsed, and


### PR DESCRIPTION
## PR Description

Added tap-to-focus functionality for JSON previewer on mobile/tablet devices to enable easy copying of values (like authentication tokens). This mimics the existing hover-to-focus behavior on desktop, ensuring consistent UX across all platforms.

## Related Issues

- Closes #824 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [ ] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [x] No, and this is why: This feature adds mobile-specific gesture handling that requires manual testing on actual devices.

## OS on which you have developed and tested the feature?

- [ ] Windows
- [x] macOS
- [ ] Linux


**Demo video attached showing tap-to-focus functionality on mobile device.**



https://github.com/user-attachments/assets/6660d30a-0f87-4b2d-8b6d-0358a8113a3c

