### PR TITLE
Fix: preserve Postman folder hierarchy during v2.1 import (#879)

### DIFF
--- a/packages/postman/lib/utils/postman_utils.dart
+++ b/packages/postman/lib/utils/postman_utils.dart
@@ -1,30 +1,47 @@
 import '../models/postman_collection.dart';
 
+/// Extracts all requests from a Postman collection, preserving folder hierarchy
+/// in the request names (e.g., "Folder/Subfolder/Request Name").
 List<(String?, Request)> getRequestsFromPostmanCollection(
-    PostmanCollection? pc) {
+  PostmanCollection? pc, {
+  String folderPath = '',
+}) {
   if (pc == null || pc.item == null) {
     return [];
   }
   List<(String?, Request)> requests = [];
   if (pc.item!.length > 0) {
     for (var i in pc.item!) {
-      requests.addAll(getRequestsFromPostmanItem(i));
+      requests.addAll(getRequestsFromPostmanItem(i, folderPath: folderPath));
     }
   }
   return requests;
 }
 
-List<(String?, Request)> getRequestsFromPostmanItem(Item? item) {
+/// Recursively extracts requests from a Postman item, tracking the folder path.
+/// [folderPath] accumulates the folder hierarchy as items are traversed.
+List<(String?, Request)> getRequestsFromPostmanItem(
+  Item? item, {
+  String folderPath = '',
+}) {
   if (item == null) {
     return [];
   }
   List<(String?, Request)> requests = [];
   if (item.request != null) {
-    requests.add((item.name, item.request!));
+    // This is a request item - prepend folder path to the name
+    final name = folderPath.isEmpty
+        ? item.name
+        : (item.name != null ? '$folderPath/${item.name}' : folderPath);
+    requests.add((name, item.request!));
   } else {
+    // This is a folder item - recurse into children with updated path
     if (item.item != null && item.item!.length > 0) {
+      final newPath = folderPath.isEmpty
+          ? (item.name ?? '')
+          : (item.name != null ? '$folderPath/${item.name}' : folderPath);
       for (var i in item.item!) {
-        var r = getRequestsFromPostmanItem(i);
+        var r = getRequestsFromPostmanItem(i, folderPath: newPath);
         requests.addAll(r);
       }
     }

--- a/packages/postman/test/postman_folder_hierarchy_test.dart
+++ b/packages/postman/test/postman_folder_hierarchy_test.dart
@@ -1,0 +1,134 @@
+import 'package:postman/postman.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Postman folder hierarchy tests', () {
+    test('getRequestsFromPostmanCollection preserves folder paths', () {
+      // Arrange: Create a collection with nested folder structure
+      final collection = PostmanCollection(
+        info: Info(
+          name: 'Test Collection',
+          schema:
+              'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+        ),
+        item: [
+          // Folder: Users
+          Item(
+            name: 'Users',
+            item: [
+              Item(
+                name: 'Get User',
+                request: Request(
+                    method: 'GET',
+                    url: Url(raw: 'https://api.example.com/users/1')),
+              ),
+              Item(
+                name: 'Create User',
+                request: Request(
+                    method: 'POST',
+                    url: Url(raw: 'https://api.example.com/users')),
+              ),
+            ],
+          ),
+          // Folder: Products with subfolder
+          Item(
+            name: 'Products',
+            item: [
+              Item(
+                name: 'List Products',
+                request: Request(
+                    method: 'GET',
+                    url: Url(raw: 'https://api.example.com/products')),
+              ),
+              // Subfolder: Admin
+              Item(
+                name: 'Admin',
+                item: [
+                  Item(
+                    name: 'Delete Product',
+                    request: Request(
+                        method: 'DELETE',
+                        url: Url(raw: 'https://api.example.com/products/1')),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          // Request at root level (no folder)
+          Item(
+            name: 'Health Check',
+            request: Request(
+                method: 'GET', url: Url(raw: 'https://api.example.com/health')),
+          ),
+        ],
+      );
+
+      // Act
+      final requests = getRequestsFromPostmanCollection(collection);
+
+      // Assert
+      expect(requests.length, 5);
+
+      // Extract names for easier assertions
+      final names = requests.map((r) => r.$1).toList();
+
+      // Verify folder paths are preserved
+      expect(names, contains('Users/Get User'));
+      expect(names, contains('Users/Create User'));
+      expect(names, contains('Products/List Products'));
+      expect(names, contains('Products/Admin/Delete Product'));
+      expect(names, contains('Health Check')); // Root level, no folder prefix
+    });
+
+    test('getRequestsFromPostmanItem handles empty folder path', () {
+      final item = Item(
+        name: 'Simple Request',
+        request:
+            Request(method: 'GET', url: Url(raw: 'https://api.example.com')),
+      );
+
+      final requests = getRequestsFromPostmanItem(item);
+
+      expect(requests.length, 1);
+      expect(requests.first.$1, 'Simple Request');
+    });
+
+    test('getRequestsFromPostmanItem handles custom folder path', () {
+      final item = Item(
+        name: 'Nested Request',
+        request:
+            Request(method: 'GET', url: Url(raw: 'https://api.example.com')),
+      );
+
+      final requests =
+          getRequestsFromPostmanItem(item, folderPath: 'Parent/Child');
+
+      expect(requests.length, 1);
+      expect(requests.first.$1, 'Parent/Child/Nested Request');
+    });
+
+    test('getRequestsFromPostmanCollection handles null item name gracefully',
+        () {
+      final collection = PostmanCollection(
+        item: [
+          Item(
+            name: null, // Folder with no name
+            item: [
+              Item(
+                name: 'Request',
+                request: Request(
+                    method: 'GET', url: Url(raw: 'https://api.example.com')),
+              ),
+            ],
+          ),
+        ],
+      );
+
+      final requests = getRequestsFromPostmanCollection(collection);
+
+      expect(requests.length, 1);
+      // When folder name is null, it should not add path separator
+      expect(requests.first.$1, 'Request');
+    });
+  });
+}


### PR DESCRIPTION
### Summary
Fixes #879. This update preserves the folder hierarchy when importing Postman v2.1 collections by including the folder path in the request name (e.g., `Users/Auth/Login` instead of just `Login`).

### Problem
Previously, when a collection with nested folders was imported, all requests were placed at the root level. This removed context, made organization harder, and broke the structure users set up in Postman.

### Solution
The logic in `postman_utils.dart` has been updated so that:
- Folder paths are tracked recursively while iterating through items
- Request names include the accumulated folder structure using `/`
- Root-level requests continue to import normally with no breaking changes

### Key Changes
- Added an optional `folderPath` parameter to both parsing functions
- Prepended paths for nested folder requests (e.g., `Users/Create User`)
- Updated recursive traversal to build paths safely
- Added new tests to confirm the hierarchy is preserved

### Testing
```bash
# Run Postman package tests
cd packages/postman && dart test

# (Optional) Run full project tests
flutter test
