### PR TITLE
Fix 987 - Resolve horizontal overflow in import dialog header

### DIFF
--- a/lib/widgets/dialog_import.dart
+++ b/lib/widgets/dialog_import.dart
@@ -22,23 +22,26 @@ showImportDialog({
             content: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    const Text(kLabelImport),
-                    kHSpacer8,
-                    DropdownButtonImportFormat(
-                      importFormat: fmt,
-                      onChanged: (format) {
-                        if (format != null) {
-                          onImportFormatChange?.call(format);
-                          setState(() {
-                            fmt = format;
-                          });
-                        }
-                      },
-                    ),
-                  ],
+                SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const Text(kLabelImport),
+                      kHSpacer8,
+                      DropdownButtonImportFormat(
+                        importFormat: fmt,
+                        onChanged: (format) {
+                          if (format != null) {
+                            onImportFormatChange?.call(format);
+                            setState(() {
+                              fmt = format;
+                            });
+                          }
+                        },
+                      ),
+                    ],
+                  ),
                 ),
                 kVSpacer6,
                 DragAndDropArea(


### PR DESCRIPTION
## PR Description
This PR resolves a horizontal layout overflow in the Import Dialog header. On narrow window widths, the header row containing the "Import" label and the format selection dropdown would exceed the available horizontal space, triggering a RIGHT OVERFLOWED BY 28 PIXELS error.

I have wrapped the header Row in a SingleChildScrollView with Axis.horizontal, which allows the content to handle restricted widths gracefully without crashing the layout.


 https://www.loom.com/share/673e150840f447a980cb00c464cff96e

## Related Issues

- Closes #987

### Checklist
- [x] I have gone through the [contributing guide]
- [x] I have updated my branch and synced it with project main branch before making this PR
- [x] I am using the latest Flutter stable branch (run flutter upgrade and verify)
- [x] I have run the tests (flutter test) and all tests are passing

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: This is a purely visual UI/UX layout fix using standard Flutter widgets (SingleChildScrollView) to resolve a RenderFlex overflow. Existing widget tests for dialog functionality should remain unaffected.

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux
