### PR TITLE
Fix 975 via "No history requests" message

### DIFF
--- a/lib/screens/history/history_empty.dart
+++ b/lib/screens/history/history_empty.dart
@@ -1,0 +1,29 @@
+import 'package:apidash_design_system/apidash_design_system.dart';
+import 'package:flutter/material.dart';
+
+class HistoryEmpty extends StatelessWidget {
+  const HistoryEmpty({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.history,
+            size: 40,
+            color: Theme.of(context).colorScheme.outline,
+          ),
+          kVSpacer10,
+          Text(
+            'No history requests',
+            style: kTextStyleMedium.copyWith(
+              color: Theme.of(context).colorScheme.outline,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/history/history_page.dart
+++ b/lib/screens/history/history_page.dart
@@ -5,6 +5,7 @@ import 'package:apidash/widgets/widgets.dart';
 import 'package:apidash/providers/providers.dart';
 import 'package:apidash/utils/utils.dart';
 import 'package:apidash/consts.dart';
+import 'history_empty.dart';
 import 'history_sidebar.dart';
 import 'history_viewer.dart';
 
@@ -19,10 +20,13 @@ class HistoryPage extends ConsumerWidget {
     final title = historyModel != null
         ? getHistoryRequestName(historyModel.metaData)
         : 'History';
+    final hasHistoryKeys =
+        (ref.watch(historySequenceProvider)?.keys.toList() ?? []).isNotEmpty;
     if (context.isMediumWindow) {
       return DrawerSplitView(
         scaffoldKey: kHisScaffoldKey,
-        mainContent: const HistoryViewer(),
+        mainContent:
+            hasHistoryKeys ? const HistoryViewer() : const HistoryEmpty(),
         title: Text(title),
         leftDrawerContent: const HistoryPane(),
         actions: const [SizedBox(width: 16)],
@@ -30,12 +34,13 @@ class HistoryPage extends ConsumerWidget {
             ref.read(leftDrawerStateProvider.notifier).state = value,
       );
     }
-    return const Column(
+    return Column(
       children: [
         Expanded(
           child: DashboardSplitView(
-            sidebarWidget: HistoryPane(),
-            mainWidget: HistoryViewer(),
+            sidebarWidget: const HistoryPane(),
+            mainWidget:
+                hasHistoryKeys ? const HistoryViewer() : const HistoryEmpty(),
           ),
         ),
       ],

--- a/lib/screens/history/history_sidebar.dart
+++ b/lib/screens/history/history_sidebar.dart
@@ -43,28 +43,6 @@ class HistoryList extends HookConsumerWidget {
         .select((value) => value.alwaysShowCollectionPaneScrollbar));
     final List<DateTime>? sortedHistoryKeys = historySequence?.keys.toList();
     sortedHistoryKeys?.sort((a, b) => b.compareTo(a));
-    if (sortedHistoryKeys == null || sortedHistoryKeys.isEmpty) {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.history,
-              size: 40,
-              color: Theme.of(context).colorScheme.outline,
-            ),
-            kVSpacer10,
-            Text(
-              'No history requests',
-              style: TextStyle(
-                color: Theme.of(context).colorScheme.outline,
-                fontSize: 15,
-              ),
-            ),
-          ],
-        ),
-      );
-    }
     ScrollController scrollController = useScrollController();
     return Scrollbar(
       controller: scrollController,
@@ -73,14 +51,14 @@ class HistoryList extends HookConsumerWidget {
       child: ListView.separated(
         padding: EdgeInsets.only(bottom: MediaQuery.paddingOf(context).bottom),
         controller: scrollController,
-        itemCount: sortedHistoryKeys.length,
+        itemCount: sortedHistoryKeys?.length ?? 0,
         separatorBuilder: (context, index) => Divider(
           height: 0,
           thickness: 2,
           color: Theme.of(context).colorScheme.surfaceContainerHigh,
         ),
         itemBuilder: (context, index) {
-          var items = historySequence![sortedHistoryKeys[index]]!;
+          var items = historySequence![sortedHistoryKeys![index]]!;
           final requestGroups = getRequestGroups(items);
           return Padding(
             padding: kPv2,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1170,10 +1170,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1932,26 +1932,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.12"
   textwrap:
     dependency: transitive
     description:


### PR DESCRIPTION
## PR Description
Adds a clear "No history requests" empty state to the History tab. Previously, it showed a blank screen which looked like a loading error.

**Changes:**
- Modified `HistoryPane` to check if `sortedHistoryKeys` is empty.
- Returns a Centered Placeholder (Icon + Text) using theme colors when no history exists.
- Keeps existing behavior when functionality is populated.

## Related Issues
- Closes #975

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch
- [x] I have verified the fix manually

## Added/updated tests?
- [x] No, and this is why: UI state change verified visually.

## OS on which you have developed and tested the feature?
- [x] Windows

## Reference Images

### Before (Windows)
<img width="1912" height="1128" alt="before-windows" src="https://github.com/user-attachments/assets/d13471d5-8b8c-4fee-9c63-3a6ce1130024" />

### After (Windows)
<img width="1916" height="1134" alt="after-windows" src="https://github.com/user-attachments/assets/c5e42f04-3cd6-4f4e-bba3-a860cf13d2c4" />

### Before (Mobile)
<img width="300" alt="before-mobile" src="https://github.com/user-attachments/assets/5a9861d1-9a70-4a9b-b23a-391208ba93da" />

### After (Mobile)
<img width="300" alt="after-mobile" src="https://github.com/user-attachments/assets/67d161b5-0964-46f7-87e4-f10cfd48738a" />



