### PR TITLE
Web instructions update

### DIFF
--- a/doc/dev_guide/platform_specific_instructions.md
+++ b/doc/dev_guide/platform_specific_instructions.md
@@ -102,6 +102,9 @@ Failed to compile application.
 
 This happens because `.toJS` is no longer required for converting Dart strings to JavaScript strings in recent Dart versions.  
 
+> [!WARNING]  
+> The following fix involves modifying a file in your local pub cache (`.pub-cache`). This is a temporary workaround. Your changes will be lost if you clear your cache or set up the project on a new machine. Use with caution.
+
 **Fix:**  
 Update the `printing_web.dart` file in the cached `printing` package by removing `.toJS` as done in the PR [here](https://github.com/DavBfr/dart_pdf/pull/1739/files)
 


### PR DESCRIPTION
## PR Description

This PR adds a clarification warning to the documentation regarding the temporary fix for removing `.toJS()` from `printing_web.dart` in the `printing` package. Recent Dart versions no longer require `.toJS()` for converting Dart strings to JavaScript strings, as reflected in the upstream change proposed in PR [#1739](https://github.com/DavBfr/dart_pdf/pull/1739/files).

Because the temporary workaround involves modifying files inside the user's local `.pub-cache`, this update adds a clear warning block explaining that such changes are **not persistent** and will be overwritten when:

- running `flutter pub get`
- clearing the pub cache
- upgrading packages
- setting up the project on a different machine

This improves documentation clarity and prevents confusion for users applying local patches.

## Related Issues

- (Doc update) #527 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [ ] Yes  
- [x] No - documentation-only update, tests not required.

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux
