### PR TITLE
Fix: enable continuous text selection in response preview using SelectableArea

### DIFF
--- a/packages/json_explorer/lib/src/json_explorer.dart
+++ b/packages/json_explorer/lib/src/json_explorer.dart
@@ -163,7 +163,8 @@ class JsonExplorer extends StatelessWidget {
         super(key: key);
 
   @override
-  Widget build(BuildContext context) => ScrollablePositionedList.builder(
+  Widget build(BuildContext context) => SelectionArea(
+          child: ScrollablePositionedList.builder(
         itemCount: nodes.length,
         itemScrollController: itemScrollController,
         itemPositionsListener: itemPositionsListener,
@@ -192,7 +193,7 @@ class JsonExplorer extends StatelessWidget {
           ),
         ),
         physics: physics,
-      );
+      ));
 }
 
 class JsonAttribute extends StatelessWidget {
@@ -354,7 +355,7 @@ class JsonAttribute extends StatelessWidget {
                       padding: EdgeInsets.symmetric(vertical: spacing),
                       child: SizedBox(
                         width: 8,
-                        child: SelectableText(
+                        child: Text(
                           ':',
                           style: theme.rootKeyTextStyle,
                         ),
@@ -480,7 +481,7 @@ class _RootNodeWidget extends StatelessWidget {
     final text = _keyName();
 
     if (!showHighlightedText) {
-      return SelectableText(text, style: attributeKeyStyle);
+      return Text(text, style: attributeKeyStyle);
     }
 
     final focusedSearchMatchIndex =
@@ -543,7 +544,7 @@ class _PropertyNodeWidget extends StatelessWidget {
     final text = valueFormatter?.call(node.value) ?? node.value.toString();
 
     if (!showHighlightedText) {
-      return SelectableText(text, style: style);
+      return Text(text, style: style);
     }
 
     final focusedSearchMatchIndex =
@@ -664,7 +665,7 @@ class _HighlightedText extends StatelessWidget {
     final lowerCaseQuery = highlightedText.toLowerCase();
 
     if (highlightedText.isEmpty || !lowerCaseText.contains(lowerCaseQuery)) {
-      return SelectableText(text, style: style);
+      return Text(text, style: style);
     }
 
     final spans = <TextSpan>[];
@@ -698,7 +699,7 @@ class _HighlightedText extends StatelessWidget {
       start = index + highlightedText.length;
     }
 
-    return SelectableText.rich(
+    return Text.rich(
       TextSpan(
         children: spans,
       ),


### PR DESCRIPTION
## PR Description

This PR fixes an issue in the response body Preview mode where text selection was fragmented, forcing users to select keys, colons and values separately.
The preview content is now wrapped with ```SelectionArea```, enabling smooth, continuous text selection across entire lines and paragraphs, making copying content much more user-friendly.

## Related Issues

- Closes #1007 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [ ] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [x] No, and this is why: This change is a UI-level interaction improvement related to text selection behavior. Existing widget tests do not cover text selection mechanics, and no logical behavior was altered.

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux
