### PR TITLE
fix: prevent horizontal overflow in import dialog header on narrow widths

### DIFF
--- a/lib/widgets/dialog_import.dart
+++ b/lib/widgets/dialog_import.dart
@@ -19,32 +19,41 @@ showImportDialog({
         builder: (context, StateSetter setState) {
           return AlertDialog(
             contentPadding: kP12,
-            content: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    const Text(kLabelImport),
-                    kHSpacer8,
-                    DropdownButtonImportFormat(
-                      importFormat: fmt,
-                      onChanged: (format) {
-                        if (format != null) {
-                          onImportFormatChange?.call(format);
-                          setState(() {
-                            fmt = format;
-                          });
-                        }
-                      },
-                    ),
-                  ],
-                ),
-                kVSpacer6,
-                DragAndDropArea(
-                  onFileDropped: onFileDropped,
-                ),
-              ],
+            content: ConstrainedBox(
+              constraints: const BoxConstraints(
+                maxWidth: 500,
+                minWidth: 280,
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  // Use Wrap instead of Row to handle overflow gracefully
+                  Wrap(
+                    alignment: WrapAlignment.center,
+                    crossAxisAlignment: WrapCrossAlignment.center,
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: [
+                      const Text(kLabelImport),
+                      DropdownButtonImportFormat(
+                        importFormat: fmt,
+                        onChanged: (format) {
+                          if (format != null) {
+                            onImportFormatChange?.call(format);
+                            setState(() {
+                              fmt = format;
+                            });
+                          }
+                        },
+                      ),
+                    ],
+                  ),
+                  kVSpacer6,
+                  DragAndDropArea(
+                    onFileDropped: onFileDropped,
+                  ),
+                ],
+              ),
             ),
           );
         },


### PR DESCRIPTION
## Summary
Fixes horizontal overflow in the import dialog header when window width is narrowed.

## Problem
The import dialog triggers a "RIGHT OVERFLOWED" warning when the window width is narrowed. While UI elements remain functional, a yellow-and-black striped overflow indicator appears, degrading the user experience.

## Solution
- Replace `Row` with `Wrap` widget for flexible layout
- Add `ConstrainedBox` to set reasonable min/max widths (280px - 500px)
- Configure `Wrap` with center alignment and proper spacing
- Elements now wrap to next line on narrow screens instead of overflowing

## Changes
- Replaced `Row` with `Wrap` in dialog header
- Set `alignment: WrapAlignment.center`
- Set `crossAxisAlignment: WrapCrossAlignment.center`
- Added `spacing: 8` and `runSpacing: 8` for consistent gaps
- Wrapped content in `ConstrainedBox` with `maxWidth: 500, minWidth: 280`

## Benefits
✅ Eliminates "RIGHT OVERFLOWED" warning on narrow windows  
✅ Maintains functionality across all window sizes  
✅ Improves responsive design  
✅ Better mobile and small screen support  
✅ Professional appearance at all screen sizes

## Testing
- Tested at various window widths (from 280px to 1920px)
- Verified elements wrap correctly on narrow screens
- Confirmed dropdown remains functional after wrapping
- Checked dialog appearance on mobile-sized screens

## Visual Changes
Before: Overflow warning with striped indicator  
After: Clean layout with elements wrapping gracefully

Fixes #987