### PR TITLE
fix: prevent horizontal overflow in logs toolbar on narrow window widths

### DIFF
--- a/lib/screens/terminal/terminal_page.dart
+++ b/lib/screens/terminal/terminal_page.dart
@@ -43,61 +43,139 @@ class _TerminalPageState extends ConsumerState<TerminalPage> {
         children: [
           Padding(
             padding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
-            child: Row(
-              children: [
-                Expanded(
-                  child: SearchField(
-                    controller: _searchCtrl,
-                    hintText: 'Search logs',
-                    onChanged: (_) => setState(() {}),
-                  ),
-                ),
-                const SizedBox(width: 8),
-                // Filter button
-                TerminalLevelFilterMenu(
-                  selected: _selectedLevels,
-                  onChanged: (set) => setState(() {
-                    _selectedLevels
-                      ..clear()
-                      ..addAll(set);
-                  }),
-                ),
-                const SizedBox(width: 4),
-                Tooltip(
-                  message: 'Show timestamps',
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Checkbox(
-                        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                        value: _showTimestamps,
-                        onChanged: (v) =>
-                            setState(() => _showTimestamps = v ?? false),
-                      ),
-                      const Text('Timestamp', style: TextStyle(fontSize: 12)),
-                    ],
-                  ),
-                ),
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                // Determine if we should use compact layout
+                final isCompact = constraints.maxWidth < 600;
 
-                const Spacer(),
-                // Clear button
-                ADIconButton(
-                  tooltip: 'Clear logs',
-                  icon: Icons.delete_outline,
-                  iconSize: 22,
-                  onPressed: () {
-                    ref.read(terminalStateProvider.notifier).clear();
-                  },
-                ),
-                const SizedBox(width: 4),
-                // Copy all button
-                CopyButton(
-                  showLabel: false,
-                  toCopy: ref
-                      .read(terminalStateProvider.notifier)
-                      .serializeAll(entries: allEntries),
-                ),
-              ],
+                if (isCompact) {
+                  // Compact layout for narrow screens
+                  return Column(
+                    children: [
+                      // First row: Search field
+                      Row(
+                        children: [
+                          Expanded(
+                            child: SearchField(
+                              controller: _searchCtrl,
+                              hintText: 'Search logs',
+                              onChanged: (_) => setState(() {}),
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 8),
+                      // Second row: Controls
+                      Row(
+                        children: [
+                          TerminalLevelFilterMenu(
+                            selected: _selectedLevels,
+                            onChanged: (set) => setState(() {
+                              _selectedLevels
+                                ..clear()
+                                ..addAll(set);
+                            }),
+                          ),
+                          const SizedBox(width: 4),
+                          Expanded(
+                            child: Tooltip(
+                              message: 'Show timestamps',
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Checkbox(
+                                    materialTapTargetSize:
+                                        MaterialTapTargetSize.shrinkWrap,
+                                    value: _showTimestamps,
+                                    onChanged: (v) => setState(
+                                        () => _showTimestamps = v ?? false),
+                                  ),
+                                  const Flexible(
+                                    child: Text('Timestamp',
+                                        style: TextStyle(fontSize: 12)),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                          const Spacer(),
+                          ADIconButton(
+                            tooltip: 'Clear logs',
+                            icon: Icons.delete_outline,
+                            iconSize: 22,
+                            onPressed: () {
+                              ref.read(terminalStateProvider.notifier).clear();
+                            },
+                          ),
+                          const SizedBox(width: 4),
+                          CopyButton(
+                            showLabel: false,
+                            toCopy: ref
+                                .read(terminalStateProvider.notifier)
+                                .serializeAll(entries: allEntries),
+                          ),
+                        ],
+                      ),
+                    ],
+                  );
+                } else {
+                  // Standard layout for wider screens
+                  return Row(
+                    children: [
+                      Expanded(
+                        child: SearchField(
+                          controller: _searchCtrl,
+                          hintText: 'Search logs',
+                          onChanged: (_) => setState(() {}),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      TerminalLevelFilterMenu(
+                        selected: _selectedLevels,
+                        onChanged: (set) => setState(() {
+                          _selectedLevels
+                            ..clear()
+                            ..addAll(set);
+                        }),
+                      ),
+                      const SizedBox(width: 4),
+                      Tooltip(
+                        message: 'Show timestamps',
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Checkbox(
+                              materialTapTargetSize:
+                                  MaterialTapTargetSize.shrinkWrap,
+                              value: _showTimestamps,
+                              onChanged: (v) =>
+                                  setState(() => _showTimestamps = v ?? false),
+                            ),
+                            const Text('Timestamp',
+                                style: TextStyle(fontSize: 12)),
+                          ],
+                        ),
+                      ),
+                      const Spacer(),
+                      ADIconButton(
+                        tooltip: 'Clear logs',
+                        icon: Icons.delete_outline,
+                        iconSize: 22,
+                        onPressed: () {
+                          ref.read(terminalStateProvider.notifier).clear();
+                        },
+                      ),
+                      const SizedBox(width: 4),
+                      CopyButton(
+                        showLabel: false,
+                        toCopy: ref
+                            .read(terminalStateProvider.notifier)
+                            .serializeAll(entries: allEntries),
+                      ),
+                    ],
+                  );
+                }
+              },
             ),
           ),
           const Divider(height: 1),


### PR DESCRIPTION
## Summary
Fixes horizontal overflow in the Logs toolbar that renders the search bar inaccessible on narrow window widths.

## Problem
In the Logs pane, the toolbar containing the search bar and action buttons does not handle narrow window widths correctly, triggering a "RIGHT OVERFLOWED" error. While some elements remain functional, the search bar becomes partially or fully inaccessible.

## Solution
Implement responsive layout using `LayoutBuilder`:
- **Wide screens (≥ 600px)**: Single-row layout (current behavior)
- **Narrow screens (< 600px)**: Two-row compact layout
  - Row 1: Search field (full width)
  - Row 2: Filter, timestamp checkbox, clear, and copy buttons

## Changes
- Wrapped toolbar in `LayoutBuilder` to detect available width
- Added compact layout for screens < 600px width
- Kept standard single-row layout for wider screens
- Wrapped "Timestamp" text in `Flexible` widget to prevent overflow
- Added proper spacing between rows in compact mode (8px)

## Benefits
✅ Eliminates "RIGHT OVERFLOWED" error on narrow windows  
✅ Search bar remains fully accessible at all window sizes  
✅ All controls remain functional and visible  
✅ Smooth responsive behavior with clear breakpoint  
✅ Better mobile and small screen support  
✅ Maintains existing behavior on wide screens

## Testing
- Tested at various window widths (from 320px to 1920px)
- Verified layout switches at 600px breakpoint
- Confirmed all controls remain functional in both layouts
- Tested search functionality in compact mode
- Verified filter menu, checkbox, and buttons work correctly

## Visual Changes
**Wide screens (≥ 600px)**: No change - single row layout  
**Narrow screens (< 600px)**: Two-row layout with search on top

Fixes #984