### PR TITLE
Add onboarding dialog to guide first-time users

### DIFF
--- a/lib/screens/home_page/editor_pane/editor_default.dart
+++ b/lib/screens/home_page/editor_pane/editor_default.dart
@@ -3,42 +3,30 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:apidash/providers/providers.dart';
 import 'package:apidash/consts.dart';
+import '../../mobile/widgets/request_onboarding_panel.dart';
 
 class RequestEditorDefault extends ConsumerWidget {
   const RequestEditorDefault({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        Text.rich(
-          TextSpan(
-            children: [
-              TextSpan(
-                text: "Click  ",
-                style: Theme.of(context).textTheme.titleMedium,
-              ),
-              WidgetSpan(
-                alignment: PlaceholderAlignment.middle,
-                child: ElevatedButton(
-                  onPressed: () {
-                    ref.read(collectionStateNotifierProvider.notifier).add();
-                  },
-                  child: const Text(
-                    kLabelPlusNew,
-                    style: kTextStyleButton,
-                  ),
-                ),
-              ),
-              TextSpan(
-                text: "  to start drafting a new API request.",
-                style: Theme.of(context).textTheme.titleMedium,
-              ),
-            ],
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const RequestOnboardingPanel(),
+          const SizedBox(height: 24),
+          ElevatedButton(
+            onPressed: () {
+              ref.read(collectionStateNotifierProvider.notifier).add();
+            },
+            child: const Text(
+              kLabelPlusNew,
+              style: kTextStyleButton,
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/lib/screens/home_page/home_page.dart
+++ b/lib/screens/home_page/home_page.dart
@@ -4,12 +4,30 @@ import 'package:apidash/widgets/widgets.dart';
 import '../mobile/requests_page/requests_page.dart';
 import 'editor_pane/editor_pane.dart';
 import 'collection_pane.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import '../mobile/widgets/request_onboarding_panel.dart';
 
-class HomePage extends StatelessWidget {
+class HomePage extends HookWidget {
   const HomePage({super.key});
 
   @override
   Widget build(BuildContext context) {
+    useEffect(() {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        showDialog(
+          context: context,
+          barrierDismissible: true,
+          builder: (_) => const Dialog(
+            insetPadding: EdgeInsets.all(24),
+            child: SizedBox(
+              width: 500,
+              child: RequestOnboardingPanel(),
+            ),
+          ),
+        );
+      });
+      return null;
+    }, const []);
     return context.isMediumWindow
         ? const RequestResponsePage()
         : const Column(

--- a/lib/screens/mobile/requests_page/requests_page.dart
+++ b/lib/screens/mobile/requests_page/requests_page.dart
@@ -8,9 +8,9 @@ import 'package:apidash/widgets/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../home_page/collection_pane.dart';
 import '../../home_page/editor_pane/url_card.dart';
-import '../../home_page/editor_pane/editor_default.dart';
 import '../../common_widgets/common_widgets.dart';
 import 'request_tabs.dart';
+import '../widgets/request_onboarding_panel.dart';
 
 class RequestResponsePage extends StatefulHookConsumerWidget {
   const RequestResponsePage({
@@ -26,11 +26,12 @@ class _RequestResponsePageState extends ConsumerState<RequestResponsePage>
     with TickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
-    final id = ref.watch(selectedIdStateProvider);
-    final name = getRequestTitleFromUrl(
-        ref.watch(selectedRequestModelProvider.select((value) => value?.name)));
+    final request = ref.watch(selectedRequestModelProvider);
+    final name = getRequestTitleFromUrl(request?.name);
+
     final TabController requestTabController =
         useTabController(initialLength: 4, vsync: this);
+
     return DrawerSplitView(
       scaffoldKey: kHomeScaffoldKey,
       title: Row(
@@ -62,11 +63,9 @@ class _RequestResponsePageState extends ConsumerState<RequestResponsePage>
       ),
       leftDrawerContent: const CollectionPane(),
       actions: const [kHSpacer12],
-      mainContent: id == null
-          ? const RequestEditorDefault()
-          : RequestTabs(
-              controller: requestTabController,
-            ),
+      mainContent: RequestTabs(
+        controller: requestTabController,
+      ),
       bottomNavigationBar: RequestResponsePageBottombar(
         requestTabController: requestTabController,
       ),

--- a/lib/screens/mobile/widgets/request_onboarding_panel.dart
+++ b/lib/screens/mobile/widgets/request_onboarding_panel.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'onboarding_slide.dart';
+
+class RequestOnboardingPanel extends StatelessWidget {
+  const RequestOnboardingPanel({super.key});
+
+  static const sampleUrl = "https://jsonplaceholder.typicode.com/posts";
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        OnboardingSlide(
+          context: context,
+          assetPath: "assets/sending.json",
+          assetSize: 260,
+          title: "Create your first API request",
+          description:
+              "Get started by selecting or creating a request from the left panel.\n\nYou can try this sample API:",
+        ),
+        const SizedBox(height: 8),
+        GestureDetector(
+          onTap: () {
+            Clipboard.setData(const ClipboardData(text: sampleUrl));
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text("Sample URL copied to clipboard")),
+            );
+          },
+          child: Text(
+            sampleUrl,
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.primary,
+              decoration: TextDecoration.underline,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+        const Text(
+          "Steps:\n1. Click + New\n2. Enter API URL\n3. Press Send",
+          textAlign: TextAlign.center,
+        ),
+      ],
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1170,10 +1170,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1932,26 +1932,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.12"
   textwrap:
     dependency: transitive
     description:


### PR DESCRIPTION
## PR Description

This PR introduces an onboarding guidance panel that appears as a modal dialog when the application is opened.

The goal is to improve first-time user experience by guiding users on how to create their first API request, without interfering with the existing default "untitled" request workflow.

The onboarding is displayed as a non-blocking dialog, keeping the editor and request layout unchanged while providing helpful guidance.

This ensures:
- Existing behavior remains intact.
- Users receive clear instructions immediately on first view.
- No impact on request creation logic.

---

## Related Issues

- Closes #1019

---

## Checklist

- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

---

## Added/updated tests?

- [ ] Yes  
- [x] No, and this is why:  
  This PR introduces a UI onboarding dialog only and does not modify any business logic or request handling behavior.

---

## OS on which you have developed and tested the feature?

- [x] Windows  
- [ ] macOS  
- [ ] Linux  

---

### Reviewer Note

Please let me know if you'd prefer the onboarding dialog to be shown conditionally (for example, only on first launch using local persistence). I would be happy to update the implementation accordingly.
