### PR TITLE
Add Inherit Authentication Credentials Feature

### DIFF
--- a/lib/models/settings_model.dart
+++ b/lib/models/settings_model.dart
@@ -1,4 +1,5 @@
 import 'package:apidash_core/apidash_core.dart';
+import 'package:better_networking/better_networking.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:apidash/consts.dart';
@@ -20,6 +21,7 @@ class SettingsModel {
     this.isSSLDisabled = false,
     this.isDashBotEnabled = true,
     this.defaultAIModel,
+    this.globalAuthModel,
   });
 
   final bool isDark;
@@ -36,6 +38,7 @@ class SettingsModel {
   final bool isSSLDisabled;
   final bool isDashBotEnabled;
   final Map<String, Object?>? defaultAIModel;
+  final AuthModel? globalAuthModel;
 
   SettingsModel copyWith({
     bool? isDark,
@@ -52,6 +55,7 @@ class SettingsModel {
     bool? isSSLDisabled,
     bool? isDashBotEnabled,
     Map<String, Object?>? defaultAIModel,
+    AuthModel? globalAuthModel,
   }) {
     return SettingsModel(
       isDark: isDark ?? this.isDark,
@@ -70,6 +74,7 @@ class SettingsModel {
       isSSLDisabled: isSSLDisabled ?? this.isSSLDisabled,
       isDashBotEnabled: isDashBotEnabled ?? this.isDashBotEnabled,
       defaultAIModel: defaultAIModel ?? this.defaultAIModel,
+      globalAuthModel: globalAuthModel ?? this.globalAuthModel,
     );
   }
 
@@ -91,6 +96,7 @@ class SettingsModel {
       isSSLDisabled: isSSLDisabled,
       isDashBotEnabled: isDashBotEnabled,
       defaultAIModel: defaultAIModel,
+      globalAuthModel: globalAuthModel,
     );
   }
 
@@ -149,6 +155,10 @@ class SettingsModel {
     final defaultAIModel = data["defaultAIModel"] == null
         ? null
         : Map<String, Object?>.from(data["defaultAIModel"]);
+    final globalAuthModel = data["globalAuthModel"] == null
+        ? null
+        : AuthModel.fromJson(
+            Map<String, dynamic>.from(data["globalAuthModel"]));
     const sm = SettingsModel();
 
     return sm.copyWith(
@@ -167,6 +177,7 @@ class SettingsModel {
       isSSLDisabled: isSSLDisabled,
       isDashBotEnabled: isDashBotEnabled,
       defaultAIModel: defaultAIModel,
+      globalAuthModel: globalAuthModel,
     );
   }
 
@@ -188,6 +199,7 @@ class SettingsModel {
       "isSSLDisabled": isSSLDisabled,
       "isDashBotEnabled": isDashBotEnabled,
       "defaultAIModel": defaultAIModel,
+      "globalAuthModel": globalAuthModel?.toJson(),
     };
   }
 
@@ -214,7 +226,8 @@ class SettingsModel {
         other.workspaceFolderPath == workspaceFolderPath &&
         other.isSSLDisabled == isSSLDisabled &&
         other.isDashBotEnabled == isDashBotEnabled &&
-        mapEquals(other.defaultAIModel, defaultAIModel);
+        mapEquals(other.defaultAIModel, defaultAIModel) &&
+        other.globalAuthModel == globalAuthModel;
   }
 
   @override
@@ -235,6 +248,7 @@ class SettingsModel {
       isSSLDisabled,
       isDashBotEnabled,
       defaultAIModel,
+      globalAuthModel,
     );
   }
 }

--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -387,12 +387,18 @@ class CollectionStateNotifier
     };
     bool streamingMode = true; //Default: Streaming First
 
+    // Retrieve environment and global auth for cascading auth resolution
+    final environmentAuth = originalEnvironmentModel?.authModel;
+    final globalAuth = ref.read(settingsProvider).globalAuthModel;
+
     final stream = await streamHttpRequest(
       requestId,
       apiType,
       substitutedHttpRequestModel,
       defaultUriScheme: defaultUriScheme,
       noSSL: noSSL,
+      environmentAuth: environmentAuth,
+      globalAuth: globalAuth,
     );
 
     HttpResponseModel? httpResponseModel;

--- a/lib/providers/environment_providers.dart
+++ b/lib/providers/environment_providers.dart
@@ -2,6 +2,7 @@ import 'package:apidash/consts.dart';
 import 'package:apidash/providers/providers.dart';
 import 'package:apidash/utils/file_utils.dart';
 import 'package:apidash_core/apidash_core.dart';
+import 'package:better_networking/better_networking.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../services/services.dart' show hiveHandler, HiveHandler;
 
@@ -95,6 +96,7 @@ class EnvironmentsStateNotifier
             id: environmentModelFromJson.id,
             name: environmentModelFromJson.name,
             values: environmentModelFromJson.values,
+            authModel: environmentModelFromJson.authModel,
           );
           environmentsMap[environmentId] = environmentModel;
         }
@@ -126,11 +128,13 @@ class EnvironmentsStateNotifier
     String id, {
     String? name,
     List<EnvironmentVariableModel>? values,
+    AuthModel? authModel,
   }) {
     final environment = state![id]!;
     final updatedEnvironment = environment.copyWith(
       name: name ?? environment.name,
       values: values ?? environment.values,
+      authModel: authModel ?? environment.authModel,
     );
     state = {
       ...state!,

--- a/lib/providers/settings_providers.dart
+++ b/lib/providers/settings_providers.dart
@@ -1,4 +1,5 @@
 import 'package:apidash_core/apidash_core.dart';
+import 'package:better_networking/better_networking.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/models.dart';
@@ -35,6 +36,7 @@ class ThemeStateNotifier extends StateNotifier<SettingsModel> {
     bool? isSSLDisabled,
     bool? isDashBotEnabled,
     Map<String, Object?>? defaultAIModel,
+    AuthModel? globalAuthModel,
   }) async {
     state = state.copyWith(
       isDark: isDark,
@@ -51,6 +53,7 @@ class ThemeStateNotifier extends StateNotifier<SettingsModel> {
       isSSLDisabled: isSSLDisabled,
       isDashBotEnabled: isDashBotEnabled,
       defaultAIModel: defaultAIModel,
+      globalAuthModel: globalAuthModel,
     );
     await setSettingsToSharedPrefs(state);
   }

--- a/lib/screens/envvar/editor_pane/environment_auth_pane.dart
+++ b/lib/screens/envvar/editor_pane/environment_auth_pane.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:better_networking/better_networking.dart';
+import 'package:apidash/providers/providers.dart';
+import '../../common_widgets/auth/auth_page.dart';
+
+class EnvironmentAuthPane extends ConsumerWidget {
+  const EnvironmentAuthPane({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final environmentModel = ref.watch(selectedEnvironmentModelProvider);
+    final authModel = environmentModel?.authModel;
+
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Environment Authentication',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Configure authentication for all requests in this environment. Requests without authentication will inherit these credentials.',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 24),
+            AuthPage(
+              authModel: authModel ?? const AuthModel(type: APIAuthType.none),
+              onChangedAuthType: (newType) {
+                if (environmentModel != null) {
+                  ref
+                      .read(environmentsStateNotifierProvider.notifier)
+                      .updateEnvironment(
+                        environmentModel.id,
+                        authModel: AuthModel(type: newType!),
+                      );
+                }
+              },
+              updateAuthData: (newAuthModel) {
+                if (environmentModel != null && newAuthModel != null) {
+                  ref
+                      .read(environmentsStateNotifierProvider.notifier)
+                      .updateEnvironment(
+                        environmentModel.id,
+                        authModel: newAuthModel,
+                      );
+                }
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/envvar/environment_editor.dart
+++ b/lib/screens/envvar/environment_editor.dart
@@ -6,12 +6,33 @@ import 'package:apidash/widgets/widgets.dart';
 import 'package:apidash/consts.dart';
 import '../common_widgets/common_widgets.dart';
 import './editor_pane/variables_pane.dart';
+import './editor_pane/environment_auth_pane.dart';
 
-class EnvironmentEditor extends ConsumerWidget {
+class EnvironmentEditor extends ConsumerStatefulWidget {
   const EnvironmentEditor({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<EnvironmentEditor> createState() => _EnvironmentEditorState();
+}
+
+class _EnvironmentEditorState extends ConsumerState<EnvironmentEditor>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final id = ref.watch(selectedEnvironmentIdStateProvider);
     final name = ref
         .watch(selectedEnvironmentModelProvider.select((value) => value?.name));
@@ -66,46 +87,88 @@ class EnvironmentEditor extends ConsumerWidget {
                 )
               : const SizedBox.shrink(),
           kVSpacer5,
+          // Tab Bar
+          Container(
+            margin: context.isMediumWindow
+                ? null
+                : const EdgeInsets.symmetric(horizontal: 4),
+            child: TabBar(
+              controller: _tabController,
+              tabs: const [
+                Tab(text: 'Variables'),
+                Tab(text: 'Authentication'),
+              ],
+            ),
+          ),
+          kVSpacer10,
+          // Tab Bar View
           Expanded(
-            child: Container(
-              margin: context.isMediumWindow ? null : kP4,
-              child: Card(
-                margin: EdgeInsets.zero,
-                color: kColorTransparent,
-                surfaceTintColor: kColorTransparent,
-                shape: context.isMediumWindow
-                    ? null
-                    : RoundedRectangleBorder(
-                        side: BorderSide(
-                          color: Theme.of(context)
-                              .colorScheme
-                              .surfaceContainerHighest,
-                        ),
-                        borderRadius: kBorderRadius12,
-                      ),
-                elevation: 0,
-                child: const Padding(
-                  padding: kPv6,
-                  child: Column(
-                    children: [
-                      kHSpacer40,
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            child: TabBarView(
+              controller: _tabController,
+              children: [
+                // Variables Tab
+                Container(
+                  margin: context.isMediumWindow ? null : kP4,
+                  child: Card(
+                    margin: EdgeInsets.zero,
+                    color: kColorTransparent,
+                    surfaceTintColor: kColorTransparent,
+                    shape: context.isMediumWindow
+                        ? null
+                        : RoundedRectangleBorder(
+                            side: BorderSide(
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .surfaceContainerHighest,
+                            ),
+                            borderRadius: kBorderRadius12,
+                          ),
+                    elevation: 0,
+                    child: const Padding(
+                      padding: kPv6,
+                      child: Column(
                         children: [
-                          SizedBox(width: 30),
-                          Text("Variable"),
-                          SizedBox(width: 30),
-                          Text("Value"),
-                          SizedBox(width: 40),
+                          kHSpacer40,
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              SizedBox(width: 30),
+                              Text("Variable"),
+                              SizedBox(width: 30),
+                              Text("Value"),
+                              SizedBox(width: 40),
+                            ],
+                          ),
+                          kHSpacer40,
+                          Divider(),
+                          Expanded(child: EditEnvironmentVariables())
                         ],
                       ),
-                      kHSpacer40,
-                      Divider(),
-                      Expanded(child: EditEnvironmentVariables())
-                    ],
+                    ),
                   ),
                 ),
-              ),
+                // Authentication Tab
+                Container(
+                  margin: context.isMediumWindow ? null : kP4,
+                  child: Card(
+                    margin: EdgeInsets.zero,
+                    color: kColorTransparent,
+                    surfaceTintColor: kColorTransparent,
+                    shape: context.isMediumWindow
+                        ? null
+                        : RoundedRectangleBorder(
+                            side: BorderSide(
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .surfaceContainerHighest,
+                            ),
+                            borderRadius: kBorderRadius12,
+                          ),
+                    elevation: 0,
+                    child: const EnvironmentAuthPane(),
+                  ),
+                ),
+              ],
             ),
           ),
         ],

--- a/lib/screens/settings_page.dart
+++ b/lib/screens/settings_page.dart
@@ -1,4 +1,5 @@
 import 'package:apidash_core/apidash_core.dart';
+import 'package:better_networking/better_networking.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -9,6 +10,7 @@ import '../utils/utils.dart';
 import '../widgets/widgets.dart';
 import '../consts.dart';
 import 'common_widgets/common_widgets.dart';
+import 'common_widgets/auth/auth_page.dart';
 
 class SettingsPage extends ConsumerWidget {
   const SettingsPage({super.key});
@@ -153,6 +155,34 @@ class SettingsPage extends ConsumerWidget {
                       .read(settingsProvider.notifier)
                       .update(promptBeforeClosing: value);
                 },
+              ),
+              // Global Authentication
+              ExpansionTile(
+                title: const Text('Global Authentication'),
+                subtitle: const Text(
+                    'Set default authentication for all requests. Can be overridden at environment or request level.'),
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 16.0, vertical: 8.0),
+                    child: AuthPage(
+                      authModel: settings.globalAuthModel ??
+                          const AuthModel(type: APIAuthType.none),
+                      onChangedAuthType: (newType) {
+                        ref.read(settingsProvider.notifier).update(
+                              globalAuthModel: AuthModel(type: newType!),
+                            );
+                      },
+                      updateAuthData: (newAuthModel) {
+                        if (newAuthModel != null) {
+                          ref.read(settingsProvider.notifier).update(
+                                globalAuthModel: newAuthModel,
+                              );
+                        }
+                      },
+                    ),
+                  ),
+                ],
               ),
               ListTile(
                 hoverColor: kColorTransparent,

--- a/packages/apidash_core/lib/models/environment_model.dart
+++ b/packages/apidash_core/lib/models/environment_model.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:better_networking/better_networking.dart';
 import '../consts.dart';
 
 part 'environment_model.freezed.dart';
@@ -15,6 +16,7 @@ class EnvironmentModel with _$EnvironmentModel {
     required String id,
     @Default("") String name,
     @Default([]) List<EnvironmentVariableModel> values,
+    AuthModel? authModel,
   }) = _EnvironmentModel;
 
   factory EnvironmentModel.fromJson(Map<String, Object?> json) =>

--- a/packages/apidash_core/lib/models/environment_model.freezed.dart
+++ b/packages/apidash_core/lib/models/environment_model.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,95 +9,72 @@ part of 'environment_model.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-EnvironmentModel _$EnvironmentModelFromJson(Map<String, dynamic> json) {
-  return _EnvironmentModel.fromJson(json);
-}
 
 /// @nodoc
 mixin _$EnvironmentModel {
-  String get id => throw _privateConstructorUsedError;
-  String get name => throw _privateConstructorUsedError;
-  List<EnvironmentVariableModel> get values =>
-      throw _privateConstructorUsedError;
-
-  /// Serializes this EnvironmentModel to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  String get id;
+  String get name;
+  List<EnvironmentVariableModel> get values;
+  AuthModel? get authModel;
 
   /// Create a copy of EnvironmentModel
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $EnvironmentModelCopyWith<EnvironmentModel> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $EnvironmentModelCopyWith<$Res> {
-  factory $EnvironmentModelCopyWith(
-          EnvironmentModel value, $Res Function(EnvironmentModel) then) =
-      _$EnvironmentModelCopyWithImpl<$Res, EnvironmentModel>;
-  @useResult
-  $Res call({String id, String name, List<EnvironmentVariableModel> values});
-}
-
-/// @nodoc
-class _$EnvironmentModelCopyWithImpl<$Res, $Val extends EnvironmentModel>
-    implements $EnvironmentModelCopyWith<$Res> {
-  _$EnvironmentModelCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of EnvironmentModel
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
+  $EnvironmentModelCopyWith<EnvironmentModel> get copyWith =>
+      _$EnvironmentModelCopyWithImpl<EnvironmentModel>(
+          this as EnvironmentModel, _$identity);
+
+  /// Serializes this EnvironmentModel to a JSON map.
+  Map<String, dynamic> toJson();
+
   @override
-  $Res call({
-    Object? id = null,
-    Object? name = null,
-    Object? values = null,
-  }) {
-    return _then(_value.copyWith(
-      id: null == id
-          ? _value.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      name: null == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      values: null == values
-          ? _value.values
-          : values // ignore: cast_nullable_to_non_nullable
-              as List<EnvironmentVariableModel>,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is EnvironmentModel &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            const DeepCollectionEquality().equals(other.values, values) &&
+            (identical(other.authModel, authModel) ||
+                other.authModel == authModel));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, name,
+      const DeepCollectionEquality().hash(values), authModel);
+
+  @override
+  String toString() {
+    return 'EnvironmentModel(id: $id, name: $name, values: $values, authModel: $authModel)';
   }
 }
 
 /// @nodoc
-abstract class _$$EnvironmentModelImplCopyWith<$Res>
-    implements $EnvironmentModelCopyWith<$Res> {
-  factory _$$EnvironmentModelImplCopyWith(_$EnvironmentModelImpl value,
-          $Res Function(_$EnvironmentModelImpl) then) =
-      __$$EnvironmentModelImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $EnvironmentModelCopyWith<$Res> {
+  factory $EnvironmentModelCopyWith(
+          EnvironmentModel value, $Res Function(EnvironmentModel) _then) =
+      _$EnvironmentModelCopyWithImpl;
   @useResult
-  $Res call({String id, String name, List<EnvironmentVariableModel> values});
+  $Res call(
+      {String id,
+      String name,
+      List<EnvironmentVariableModel> values,
+      AuthModel? authModel});
+
+  $AuthModelCopyWith<$Res>? get authModel;
 }
 
 /// @nodoc
-class __$$EnvironmentModelImplCopyWithImpl<$Res>
-    extends _$EnvironmentModelCopyWithImpl<$Res, _$EnvironmentModelImpl>
-    implements _$$EnvironmentModelImplCopyWith<$Res> {
-  __$$EnvironmentModelImplCopyWithImpl(_$EnvironmentModelImpl _value,
-      $Res Function(_$EnvironmentModelImpl) _then)
-      : super(_value, _then);
+class _$EnvironmentModelCopyWithImpl<$Res>
+    implements $EnvironmentModelCopyWith<$Res> {
+  _$EnvironmentModelCopyWithImpl(this._self, this._then);
+
+  final EnvironmentModel _self;
+  final $Res Function(EnvironmentModel) _then;
 
   /// Create a copy of EnvironmentModel
   /// with the given fields replaced by the non-null parameter values.
@@ -107,36 +84,218 @@ class __$$EnvironmentModelImplCopyWithImpl<$Res>
     Object? id = null,
     Object? name = null,
     Object? values = null,
+    Object? authModel = freezed,
   }) {
-    return _then(_$EnvironmentModelImpl(
+    return _then(_self.copyWith(
       id: null == id
-          ? _value.id
+          ? _self.id
           : id // ignore: cast_nullable_to_non_nullable
               as String,
       name: null == name
-          ? _value.name
+          ? _self.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
       values: null == values
-          ? _value._values
+          ? _self.values
           : values // ignore: cast_nullable_to_non_nullable
               as List<EnvironmentVariableModel>,
+      authModel: freezed == authModel
+          ? _self.authModel
+          : authModel // ignore: cast_nullable_to_non_nullable
+              as AuthModel?,
     ));
+  }
+
+  /// Create a copy of EnvironmentModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $AuthModelCopyWith<$Res>? get authModel {
+    if (_self.authModel == null) {
+      return null;
+    }
+
+    return $AuthModelCopyWith<$Res>(_self.authModel!, (value) {
+      return _then(_self.copyWith(authModel: value));
+    });
+  }
+}
+
+/// Adds pattern-matching-related methods to [EnvironmentModel].
+extension EnvironmentModelPatterns on EnvironmentModel {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_EnvironmentModel value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _EnvironmentModel() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_EnvironmentModel value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _EnvironmentModel():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_EnvironmentModel value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _EnvironmentModel() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String id, String name,
+            List<EnvironmentVariableModel> values, AuthModel? authModel)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _EnvironmentModel() when $default != null:
+        return $default(_that.id, _that.name, _that.values, _that.authModel);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String id, String name,
+            List<EnvironmentVariableModel> values, AuthModel? authModel)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _EnvironmentModel():
+        return $default(_that.id, _that.name, _that.values, _that.authModel);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String id, String name,
+            List<EnvironmentVariableModel> values, AuthModel? authModel)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _EnvironmentModel() when $default != null:
+        return $default(_that.id, _that.name, _that.values, _that.authModel);
+      case _:
+        return null;
+    }
   }
 }
 
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true, anyMap: true)
-class _$EnvironmentModelImpl implements _EnvironmentModel {
-  const _$EnvironmentModelImpl(
+class _EnvironmentModel implements EnvironmentModel {
+  const _EnvironmentModel(
       {required this.id,
       this.name = "",
-      final List<EnvironmentVariableModel> values = const []})
+      final List<EnvironmentVariableModel> values = const [],
+      this.authModel})
       : _values = values;
-
-  factory _$EnvironmentModelImpl.fromJson(Map<String, dynamic> json) =>
-      _$$EnvironmentModelImplFromJson(json);
+  factory _EnvironmentModel.fromJson(Map<String, dynamic> json) =>
+      _$EnvironmentModelFromJson(json);
 
   @override
   final String id;
@@ -153,162 +312,173 @@ class _$EnvironmentModelImpl implements _EnvironmentModel {
   }
 
   @override
-  String toString() {
-    return 'EnvironmentModel(id: $id, name: $name, values: $values)';
+  final AuthModel? authModel;
+
+  /// Create a copy of EnvironmentModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$EnvironmentModelCopyWith<_EnvironmentModel> get copyWith =>
+      __$EnvironmentModelCopyWithImpl<_EnvironmentModel>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$EnvironmentModelToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$EnvironmentModelImpl &&
+            other is _EnvironmentModel &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.name, name) || other.name == name) &&
-            const DeepCollectionEquality().equals(other._values, _values));
+            const DeepCollectionEquality().equals(other._values, _values) &&
+            (identical(other.authModel, authModel) ||
+                other.authModel == authModel));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(
-      runtimeType, id, name, const DeepCollectionEquality().hash(_values));
+  int get hashCode => Object.hash(runtimeType, id, name,
+      const DeepCollectionEquality().hash(_values), authModel);
+
+  @override
+  String toString() {
+    return 'EnvironmentModel(id: $id, name: $name, values: $values, authModel: $authModel)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$EnvironmentModelCopyWith<$Res>
+    implements $EnvironmentModelCopyWith<$Res> {
+  factory _$EnvironmentModelCopyWith(
+          _EnvironmentModel value, $Res Function(_EnvironmentModel) _then) =
+      __$EnvironmentModelCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String name,
+      List<EnvironmentVariableModel> values,
+      AuthModel? authModel});
+
+  @override
+  $AuthModelCopyWith<$Res>? get authModel;
+}
+
+/// @nodoc
+class __$EnvironmentModelCopyWithImpl<$Res>
+    implements _$EnvironmentModelCopyWith<$Res> {
+  __$EnvironmentModelCopyWithImpl(this._self, this._then);
+
+  final _EnvironmentModel _self;
+  final $Res Function(_EnvironmentModel) _then;
 
   /// Create a copy of EnvironmentModel
   /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$EnvironmentModelImplCopyWith<_$EnvironmentModelImpl> get copyWith =>
-      __$$EnvironmentModelImplCopyWithImpl<_$EnvironmentModelImpl>(
-          this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$EnvironmentModelImplToJson(
-      this,
-    );
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? values = null,
+    Object? authModel = freezed,
+  }) {
+    return _then(_EnvironmentModel(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      values: null == values
+          ? _self._values
+          : values // ignore: cast_nullable_to_non_nullable
+              as List<EnvironmentVariableModel>,
+      authModel: freezed == authModel
+          ? _self.authModel
+          : authModel // ignore: cast_nullable_to_non_nullable
+              as AuthModel?,
+    ));
   }
-}
-
-abstract class _EnvironmentModel implements EnvironmentModel {
-  const factory _EnvironmentModel(
-      {required final String id,
-      final String name,
-      final List<EnvironmentVariableModel> values}) = _$EnvironmentModelImpl;
-
-  factory _EnvironmentModel.fromJson(Map<String, dynamic> json) =
-      _$EnvironmentModelImpl.fromJson;
-
-  @override
-  String get id;
-  @override
-  String get name;
-  @override
-  List<EnvironmentVariableModel> get values;
 
   /// Create a copy of EnvironmentModel
   /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$EnvironmentModelImplCopyWith<_$EnvironmentModelImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+  @pragma('vm:prefer-inline')
+  $AuthModelCopyWith<$Res>? get authModel {
+    if (_self.authModel == null) {
+      return null;
+    }
 
-EnvironmentVariableModel _$EnvironmentVariableModelFromJson(
-    Map<String, dynamic> json) {
-  return _EnvironmentVariableModel.fromJson(json);
+    return $AuthModelCopyWith<$Res>(_self.authModel!, (value) {
+      return _then(_self.copyWith(authModel: value));
+    });
+  }
 }
 
 /// @nodoc
 mixin _$EnvironmentVariableModel {
-  String get key => throw _privateConstructorUsedError;
-  String get value => throw _privateConstructorUsedError;
-  EnvironmentVariableType get type => throw _privateConstructorUsedError;
-  bool get enabled => throw _privateConstructorUsedError;
-
-  /// Serializes this EnvironmentVariableModel to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  String get key;
+  String get value;
+  EnvironmentVariableType get type;
+  bool get enabled;
 
   /// Create a copy of EnvironmentVariableModel
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $EnvironmentVariableModelCopyWith<EnvironmentVariableModel> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $EnvironmentVariableModelCopyWith<$Res> {
-  factory $EnvironmentVariableModelCopyWith(EnvironmentVariableModel value,
-          $Res Function(EnvironmentVariableModel) then) =
-      _$EnvironmentVariableModelCopyWithImpl<$Res, EnvironmentVariableModel>;
-  @useResult
-  $Res call(
-      {String key, String value, EnvironmentVariableType type, bool enabled});
-}
-
-/// @nodoc
-class _$EnvironmentVariableModelCopyWithImpl<$Res,
-        $Val extends EnvironmentVariableModel>
-    implements $EnvironmentVariableModelCopyWith<$Res> {
-  _$EnvironmentVariableModelCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of EnvironmentVariableModel
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
+  $EnvironmentVariableModelCopyWith<EnvironmentVariableModel> get copyWith =>
+      _$EnvironmentVariableModelCopyWithImpl<EnvironmentVariableModel>(
+          this as EnvironmentVariableModel, _$identity);
+
+  /// Serializes this EnvironmentVariableModel to a JSON map.
+  Map<String, dynamic> toJson();
+
   @override
-  $Res call({
-    Object? key = null,
-    Object? value = null,
-    Object? type = null,
-    Object? enabled = null,
-  }) {
-    return _then(_value.copyWith(
-      key: null == key
-          ? _value.key
-          : key // ignore: cast_nullable_to_non_nullable
-              as String,
-      value: null == value
-          ? _value.value
-          : value // ignore: cast_nullable_to_non_nullable
-              as String,
-      type: null == type
-          ? _value.type
-          : type // ignore: cast_nullable_to_non_nullable
-              as EnvironmentVariableType,
-      enabled: null == enabled
-          ? _value.enabled
-          : enabled // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is EnvironmentVariableModel &&
+            (identical(other.key, key) || other.key == key) &&
+            (identical(other.value, value) || other.value == value) &&
+            (identical(other.type, type) || other.type == type) &&
+            (identical(other.enabled, enabled) || other.enabled == enabled));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, key, value, type, enabled);
+
+  @override
+  String toString() {
+    return 'EnvironmentVariableModel(key: $key, value: $value, type: $type, enabled: $enabled)';
   }
 }
 
 /// @nodoc
-abstract class _$$EnvironmentVariableModelImplCopyWith<$Res>
-    implements $EnvironmentVariableModelCopyWith<$Res> {
-  factory _$$EnvironmentVariableModelImplCopyWith(
-          _$EnvironmentVariableModelImpl value,
-          $Res Function(_$EnvironmentVariableModelImpl) then) =
-      __$$EnvironmentVariableModelImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $EnvironmentVariableModelCopyWith<$Res> {
+  factory $EnvironmentVariableModelCopyWith(EnvironmentVariableModel value,
+          $Res Function(EnvironmentVariableModel) _then) =
+      _$EnvironmentVariableModelCopyWithImpl;
   @useResult
   $Res call(
       {String key, String value, EnvironmentVariableType type, bool enabled});
 }
 
 /// @nodoc
-class __$$EnvironmentVariableModelImplCopyWithImpl<$Res>
-    extends _$EnvironmentVariableModelCopyWithImpl<$Res,
-        _$EnvironmentVariableModelImpl>
-    implements _$$EnvironmentVariableModelImplCopyWith<$Res> {
-  __$$EnvironmentVariableModelImplCopyWithImpl(
-      _$EnvironmentVariableModelImpl _value,
-      $Res Function(_$EnvironmentVariableModelImpl) _then)
-      : super(_value, _then);
+class _$EnvironmentVariableModelCopyWithImpl<$Res>
+    implements $EnvironmentVariableModelCopyWith<$Res> {
+  _$EnvironmentVariableModelCopyWithImpl(this._self, this._then);
+
+  final EnvironmentVariableModel _self;
+  final $Res Function(EnvironmentVariableModel) _then;
 
   /// Create a copy of EnvironmentVariableModel
   /// with the given fields replaced by the non-null parameter values.
@@ -320,39 +490,201 @@ class __$$EnvironmentVariableModelImplCopyWithImpl<$Res>
     Object? type = null,
     Object? enabled = null,
   }) {
-    return _then(_$EnvironmentVariableModelImpl(
+    return _then(_self.copyWith(
       key: null == key
-          ? _value.key
+          ? _self.key
           : key // ignore: cast_nullable_to_non_nullable
               as String,
       value: null == value
-          ? _value.value
+          ? _self.value
           : value // ignore: cast_nullable_to_non_nullable
               as String,
       type: null == type
-          ? _value.type
+          ? _self.type
           : type // ignore: cast_nullable_to_non_nullable
               as EnvironmentVariableType,
       enabled: null == enabled
-          ? _value.enabled
+          ? _self.enabled
           : enabled // ignore: cast_nullable_to_non_nullable
               as bool,
     ));
   }
 }
 
+/// Adds pattern-matching-related methods to [EnvironmentVariableModel].
+extension EnvironmentVariableModelPatterns on EnvironmentVariableModel {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_EnvironmentVariableModel value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _EnvironmentVariableModel() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_EnvironmentVariableModel value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _EnvironmentVariableModel():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_EnvironmentVariableModel value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _EnvironmentVariableModel() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String key, String value, EnvironmentVariableType type,
+            bool enabled)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _EnvironmentVariableModel() when $default != null:
+        return $default(_that.key, _that.value, _that.type, _that.enabled);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String key, String value, EnvironmentVariableType type,
+            bool enabled)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _EnvironmentVariableModel():
+        return $default(_that.key, _that.value, _that.type, _that.enabled);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String key, String value, EnvironmentVariableType type,
+            bool enabled)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _EnvironmentVariableModel() when $default != null:
+        return $default(_that.key, _that.value, _that.type, _that.enabled);
+      case _:
+        return null;
+    }
+  }
+}
+
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true, anyMap: true)
-class _$EnvironmentVariableModelImpl implements _EnvironmentVariableModel {
-  const _$EnvironmentVariableModelImpl(
+class _EnvironmentVariableModel implements EnvironmentVariableModel {
+  const _EnvironmentVariableModel(
       {required this.key,
       required this.value,
       this.type = EnvironmentVariableType.variable,
       this.enabled = false});
-
-  factory _$EnvironmentVariableModelImpl.fromJson(Map<String, dynamic> json) =>
-      _$$EnvironmentVariableModelImplFromJson(json);
+  factory _EnvironmentVariableModel.fromJson(Map<String, dynamic> json) =>
+      _$EnvironmentVariableModelFromJson(json);
 
   @override
   final String key;
@@ -365,16 +697,27 @@ class _$EnvironmentVariableModelImpl implements _EnvironmentVariableModel {
   @JsonKey()
   final bool enabled;
 
+  /// Create a copy of EnvironmentVariableModel
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'EnvironmentVariableModel(key: $key, value: $value, type: $type, enabled: $enabled)';
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$EnvironmentVariableModelCopyWith<_EnvironmentVariableModel> get copyWith =>
+      __$EnvironmentVariableModelCopyWithImpl<_EnvironmentVariableModel>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$EnvironmentVariableModelToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$EnvironmentVariableModelImpl &&
+            other is _EnvironmentVariableModel &&
             (identical(other.key, key) || other.key == key) &&
             (identical(other.value, value) || other.value == value) &&
             (identical(other.type, type) || other.type == type) &&
@@ -385,46 +728,61 @@ class _$EnvironmentVariableModelImpl implements _EnvironmentVariableModel {
   @override
   int get hashCode => Object.hash(runtimeType, key, value, type, enabled);
 
-  /// Create a copy of EnvironmentVariableModel
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$EnvironmentVariableModelImplCopyWith<_$EnvironmentVariableModelImpl>
-      get copyWith => __$$EnvironmentVariableModelImplCopyWithImpl<
-          _$EnvironmentVariableModelImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$EnvironmentVariableModelImplToJson(
-      this,
-    );
+  String toString() {
+    return 'EnvironmentVariableModel(key: $key, value: $value, type: $type, enabled: $enabled)';
   }
 }
 
-abstract class _EnvironmentVariableModel implements EnvironmentVariableModel {
-  const factory _EnvironmentVariableModel(
-      {required final String key,
-      required final String value,
-      final EnvironmentVariableType type,
-      final bool enabled}) = _$EnvironmentVariableModelImpl;
+/// @nodoc
+abstract mixin class _$EnvironmentVariableModelCopyWith<$Res>
+    implements $EnvironmentVariableModelCopyWith<$Res> {
+  factory _$EnvironmentVariableModelCopyWith(_EnvironmentVariableModel value,
+          $Res Function(_EnvironmentVariableModel) _then) =
+      __$EnvironmentVariableModelCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String key, String value, EnvironmentVariableType type, bool enabled});
+}
 
-  factory _EnvironmentVariableModel.fromJson(Map<String, dynamic> json) =
-      _$EnvironmentVariableModelImpl.fromJson;
+/// @nodoc
+class __$EnvironmentVariableModelCopyWithImpl<$Res>
+    implements _$EnvironmentVariableModelCopyWith<$Res> {
+  __$EnvironmentVariableModelCopyWithImpl(this._self, this._then);
 
-  @override
-  String get key;
-  @override
-  String get value;
-  @override
-  EnvironmentVariableType get type;
-  @override
-  bool get enabled;
+  final _EnvironmentVariableModel _self;
+  final $Res Function(_EnvironmentVariableModel) _then;
 
   /// Create a copy of EnvironmentVariableModel
   /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$EnvironmentVariableModelImplCopyWith<_$EnvironmentVariableModelImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? key = null,
+    Object? value = null,
+    Object? type = null,
+    Object? enabled = null,
+  }) {
+    return _then(_EnvironmentVariableModel(
+      key: null == key
+          ? _self.key
+          : key // ignore: cast_nullable_to_non_nullable
+              as String,
+      value: null == value
+          ? _self.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as String,
+      type: null == type
+          ? _self.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as EnvironmentVariableType,
+      enabled: null == enabled
+          ? _self.enabled
+          : enabled // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
 }
+
+// dart format on

--- a/packages/apidash_core/lib/models/environment_model.g.dart
+++ b/packages/apidash_core/lib/models/environment_model.g.dart
@@ -6,8 +6,7 @@ part of 'environment_model.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$EnvironmentModelImpl _$$EnvironmentModelImplFromJson(Map json) =>
-    _$EnvironmentModelImpl(
+_EnvironmentModel _$EnvironmentModelFromJson(Map json) => _EnvironmentModel(
       id: json['id'] as String,
       name: json['name'] as String? ?? "",
       values: (json['values'] as List<dynamic>?)
@@ -15,19 +14,22 @@ _$EnvironmentModelImpl _$$EnvironmentModelImplFromJson(Map json) =>
                   Map<String, Object?>.from(e as Map)))
               .toList() ??
           const [],
+      authModel: json['authModel'] == null
+          ? null
+          : AuthModel.fromJson(
+              Map<String, dynamic>.from(json['authModel'] as Map)),
     );
 
-Map<String, dynamic> _$$EnvironmentModelImplToJson(
-        _$EnvironmentModelImpl instance) =>
+Map<String, dynamic> _$EnvironmentModelToJson(_EnvironmentModel instance) =>
     <String, dynamic>{
       'id': instance.id,
       'name': instance.name,
       'values': instance.values.map((e) => e.toJson()).toList(),
+      'authModel': instance.authModel?.toJson(),
     };
 
-_$EnvironmentVariableModelImpl _$$EnvironmentVariableModelImplFromJson(
-        Map json) =>
-    _$EnvironmentVariableModelImpl(
+_EnvironmentVariableModel _$EnvironmentVariableModelFromJson(Map json) =>
+    _EnvironmentVariableModel(
       key: json['key'] as String,
       value: json['value'] as String,
       type:
@@ -36,8 +38,8 @@ _$EnvironmentVariableModelImpl _$$EnvironmentVariableModelImplFromJson(
       enabled: json['enabled'] as bool? ?? false,
     );
 
-Map<String, dynamic> _$$EnvironmentVariableModelImplToJson(
-        _$EnvironmentVariableModelImpl instance) =>
+Map<String, dynamic> _$EnvironmentVariableModelToJson(
+        _EnvironmentVariableModel instance) =>
     <String, dynamic>{
       'key': instance.key,
       'value': instance.value,

--- a/packages/apidash_core/pubspec.yaml
+++ b/packages/apidash_core/pubspec.yaml
@@ -1,7 +1,6 @@
 name: apidash_core
 description: "API Dash Core"
 version: 0.0.1
-homepage:
 publish_to: none
 
 environment:
@@ -11,6 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  better_networking:
+    path: ../better_networking
   curl_parser:
     path: ../curl_parser
   freezed_annotation: ^3.0.0

--- a/packages/better_networking/lib/utils/auth/auth_resolver.dart
+++ b/packages/better_networking/lib/utils/auth/auth_resolver.dart
@@ -1,0 +1,32 @@
+import 'package:better_networking/better_networking.dart';
+
+/// Resolves authentication model with cascading priority:
+/// 1. Request-level auth (if defined and not 'none')
+/// 2. Environment-level auth (if defined and not 'none')
+/// 3. Global-level auth (if defined and not 'none')
+/// 4. null (no authentication)
+///
+/// Returns the resolved AuthModel or null if no authentication is configured.
+AuthModel? resolveAuth({
+  AuthModel? requestAuth,
+  AuthModel? environmentAuth,
+  AuthModel? globalAuth,
+}) {
+  // Check request-level auth first
+  if (requestAuth != null && requestAuth.type != APIAuthType.none) {
+    return requestAuth;
+  }
+
+  // Fall back to environment-level auth
+  if (environmentAuth != null && environmentAuth.type != APIAuthType.none) {
+    return environmentAuth;
+  }
+
+  // Fall back to global-level auth
+  if (globalAuth != null && globalAuth.type != APIAuthType.none) {
+    return globalAuth;
+  }
+
+  // No authentication configured
+  return null;
+}


### PR DESCRIPTION
## PR Description

This PR implements a hierarchical authentication system that allows credentials to be inherited across three levels with cascading priority: Request → Environment → Global.

### Background
Previously, authentication credentials could only be configured at the request level, requiring users to manually configure auth for each request. This PR introduces environment-level and global-level authentication that requests can inherit, significantly improving workflow efficiency for API collections that share common authentication schemes.

### Implementation

The authentication resolution follows this cascading priority:
1. **Request-level auth** (highest priority) - If configured, always takes precedence
2. **Environment-level auth** - Used when request has no auth configured
3. **Global-level auth** (fallback) - Default for all requests without specific auth
4. **No auth** - When all levels are null or set to "none"

### Key Changes

**Model Layer:**
- Added `authModel` field to [EnvironmentModel](cci:2://file:///Volumes/Sourashis%20Ghosh%20Roy/Google%20Summer%20Of%20Code%202026/API%20Dash/apidash/packages/apidash_core/lib/models/environment_model.dart:8:0-23:1) for environment-specific authentication
- Added `globalAuthModel` field to [SettingsModel](cci:2://file:///Volumes/Sourashis%20Ghosh%20Roy/Google%20Summer%20Of%20Code%202026/API%20Dash/apidash/lib/models/settings_model.dart:6:0-253:1) for application-wide default authentication
- Updated JSON serialization/deserialization with backward compatibility

**Authentication Logic:**
- Created [auth_resolver.dart](cci:7://file:///Volumes/Sourashis%20Ghosh%20Roy/Google%20Summer%20Of%20Code%202026/API%20Dash/apidash/packages/better_networking/lib/utils/auth/auth_resolver.dart:0:0-0:0) utility implementing cascading priority algorithm
- Enhanced [handleAuth()](cci:1://file:///Volumes/Sourashis%20Ghosh%20Roy/Google%20Summer%20Of%20Code%202026/API%20Dash/apidash/packages/better_networking/lib/utils/auth/handle_auth.dart:12:0-287:1) to accept optional `environmentAuth` and `globalAuth` parameters
- Updated [sendHttpRequestV1](cci:1://file:///Volumes/Sourashis%20Ghosh%20Roy/Google%20Summer%20Of%20Code%202026/API%20Dash/apidash/packages/better_networking/lib/services/http_service.dart:22:0-162:1) and [streamHttpRequest](cci:1://file:///Volumes/Sourashis%20Ghosh%20Roy/Google%20Summer%20Of%20Code%202026/API%20Dash/apidash/packages/better_networking/lib/services/http_service.dart:214:0-348:1) to pass environment/global auth through the chain
- Modified collection providers to retrieve and pass auth from environment and settings

**UI Components:**
- Converted environment editor to tabbed interface (Variables | Authentication)
- Created [EnvironmentAuthPane](cci:2://file:///Volumes/Sourashis%20Ghosh%20Roy/Google%20Summer%20Of%20Code%202026/API%20Dash/apidash/lib/screens/envvar/editor_pane/environment_auth_pane.dart:6:0-60:1) for configuring environment-level authentication
- Added "Global Authentication" expansion tile to settings page
- Reused existing [AuthPage](cci:2://file:///Volumes/Sourashis%20Ghosh%20Roy/Google%20Summer%20Of%20Code%202026/API%20Dash/apidash/lib/screens/common_widgets/auth/auth_page.dart:12:0-100:1) widget for consistency across all auth configuration points

**Provider Updates:**
- Updated `EnvironmentsStateNotifier.updateEnvironment()` to handle auth updates
- Modified `ThemeStateNotifier.update()` to persist global auth to settings
- Integrated auth retrieval in `CollectionStateNotifier.sendRequest()`

### Backward Compatibility

All changes maintain full backward compatibility:
- Existing requests continue to work without modification
- New auth fields default to null in deserialization
- Optional named parameters prevent breaking changes in method signatures
- Settings and environment data from older versions load correctly

## Related Issues

- Closes #881 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project [main](cci:1://file:///Volumes/Sourashis%20Ghosh%20Roy/Google%20Summer%20Of%20Code%202026/API%20Dash/apidash/test/models/environment_models_test.dart:5:0-218:1) branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] No, and this is why: Initial implementation focused on core functionality and UI integration. Unit tests for [auth_resolver.dart](cci:7://file:///Volumes/Sourashis%20Ghosh%20Roy/Google%20Summer%20Of%20Code%202026/API%20Dash/apidash/packages/better_networking/lib/utils/auth/auth_resolver.dart:0:0-0:0) and integration tests for cascading behavior should be added in a follow-up PR to ensure comprehensive coverage of edge cases and auth type combinations.

## OS on which you have developed and tested the feature?

- [ ] Windows
- [x] macOS
- [ ] Linux