### PR TITLE
Fix Video Player Crash

### DIFF
--- a/lib/widgets/previewer.dart
+++ b/lib/widgets/previewer.dart
@@ -21,6 +21,7 @@ class Previewer extends StatefulWidget {
     this.type,
     this.subtype,
     this.hasRaw = false,
+    this.isPartOfHistory = false,
   });
 
   final Uint8List bytes;
@@ -28,6 +29,7 @@ class Previewer extends StatefulWidget {
   final String? type;
   final String? subtype;
   final bool hasRaw;
+  final bool isPartOfHistory;
 
   @override
   State<Previewer> createState() => _PreviewerState();
@@ -124,7 +126,10 @@ class _PreviewerState extends State<Previewer> {
     }
     if (widget.type == kTypeVideo) {
       try {
-        var preview = VideoPreviewer(videoBytes: widget.bytes);
+        var preview = VideoPreviewer(
+          videoBytes: widget.bytes,
+          isPartOfHistory: widget.isPartOfHistory,
+        );
         return preview;
       } catch (e) {
         return ErrorMessage(

--- a/lib/widgets/response_body_success.dart
+++ b/lib/widgets/response_body_success.dart
@@ -126,6 +126,7 @@ class _ResponseBodySuccessState extends State<ResponseBodySuccess> {
                         type: widget.mediaType.type,
                         subtype: widget.mediaType.subtype,
                         hasRaw: widget.options.contains(ResponseBodyView.raw),
+                        isPartOfHistory: widget.isPartOfHistory,
                       ),
                     ),
                   ),


### PR DESCRIPTION
## PR Description
This PR addresses a bug where audio continues playing in the background after pausing a video in the Requests tab, specifically when the application window is maximized (triggering the responsive layout).
### Root Cause
The `IndexedStack` used in the dashboard keeps both the Requests and History tabs alive. In the responsive layout, the History tab also renders the response body, leading to two active [VideoPreviewer](cci:2://file:///Volumes/Sourashis%20Ghosh%20Roy/Google%20Summer%20Of%20Code%202026/API%20Dash/apidash/lib/widgets/previewer_video.dart:10:0-22:1) instances:
1.  One in the **Requests** tab (Visible).
2.  One in the **History** tab (Hidden in stack, but active in memory).
When the user pauses the visible video in the Requests tab, the hidden video player in the History tab continues to play audio if it was also initialized.
### The Fix
I have updated [VideoPreviewer](cci:2://file:///Volumes/Sourashis%20Ghosh%20Roy/Google%20Summer%20Of%20Code%202026/API%20Dash/apidash/lib/widgets/previewer_video.dart:10:0-22:1) to be aware of the application's global navigation state:
1.  **Tab Awareness:** [VideoPreviewer](cci:2://file:///Volumes/Sourashis%20Ghosh%20Roy/Google%20Summer%20Of%20Code%202026/API%20Dash/apidash/lib/widgets/previewer_video.dart:10:0-22:1) now watches `navRailIndexStateProvider` to know the currently active tab.
2.  **Context Flag:** Introduced an `isPartOfHistory` flag passed down from [ResponseBody](cci:2://file:///Volumes/Sourashis%20Ghosh%20Roy/Google%20Summer%20Of%20Code%202026/API%20Dash/apidash/lib/widgets/response_body.dart:8:0-79:1) -> [ResponseBodySuccess](cci:2://file:///Volumes/Sourashis%20Ghosh%20Roy/Google%20Summer%20Of%20Code%202026/API%20Dash/apidash/lib/widgets/response_body_success.dart:9:0-36:1) -> [Previewer](cci:2://file:///Volumes/Sourashis%20Ghosh%20Roy/Google%20Summer%20Of%20Code%202026/API%20Dash/apidash/lib/widgets/previewer.dart:15:0-35:1) -> [VideoPreviewer](cci:2://file:///Volumes/Sourashis%20Ghosh%20Roy/Google%20Summer%20Of%20Code%202026/API%20Dash/apidash/lib/widgets/previewer_video.dart:10:0-22:1).
3.  **Playback Control:** The player now automatically pauses if it detects it is not in the currently active tab (e.g., a History tab player knowing the user is on the Requests tab).
## Related Issues
- Closes #627 
### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing
## Added/updated tests?
- [ ] Yes
- [x] No, and this is why: The fix involves complex UI/Audio interaction with the native video player plugin and `IndexedStack` visibility integration which is difficult to cover with standard widget tests. Manual verification was performed.
## OS on which you have developed and tested the feature?
- [ ] Windows
- [x] macOS
- [ ] Linux

