### PR TITLE
fix: show env variable in Variables tab after cURL import

### DIFF
--- a/lib/widgets/field_cell.dart
+++ b/lib/widgets/field_cell.dart
@@ -1,7 +1,7 @@
 import 'package:apidash_design_system/apidash_design_system.dart';
 import 'package:flutter/material.dart';
 
-class CellField extends StatelessWidget {
+class CellField extends StatefulWidget {
   const CellField({
     super.key,
     required this.keyId,
@@ -18,14 +18,42 @@ class CellField extends StatelessWidget {
   final ColorScheme? colorScheme;
 
   @override
+  State<CellField> createState() => _CellFieldState();
+}
+
+class _CellFieldState extends State<CellField> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialValue ?? "");
+  }
+
+  @override
+  void didUpdateWidget(covariant CellField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final newValue = widget.initialValue ?? "";
+    if (_controller.text != newValue) {
+      _controller.text = newValue;
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return ADOutlinedTextField(
-      keyId: keyId,
-      initialValue: initialValue,
-      hintText: hintText,
+      keyId: widget.keyId,
+      controller: _controller,
+      hintText: widget.hintText,
       hintTextFontSize: Theme.of(context).textTheme.bodySmall?.fontSize,
-      onChanged: onChanged,
-      colorScheme: colorScheme,
+      onChanged: widget.onChanged,
+      colorScheme: widget.colorScheme,
     );
   }
 }

--- a/packages/apidash_design_system/lib/widgets/textfield_outlined.dart
+++ b/packages/apidash_design_system/lib/widgets/textfield_outlined.dart
@@ -60,7 +60,7 @@ class ADOutlinedTextField extends StatelessWidget {
       enabled: enabled,
       maxLines: maxLines,
       expands: expands,
-      initialValue: initialValue,
+        initialValue: controller == null ? initialValue : null,
       style: textStyle ??
           kCodeStyle.copyWith(
             fontSize: textFontSize,


### PR DESCRIPTION
## PR Description
This pull request fixes an issue where environment variables created during **cURL import** were correctly stored in state but appeared **blank in the Variables tab UI**.  

The root cause was the use of `initialValue` without a synchronized `TextEditingController`, which prevented Flutter text fields from updating after rebuilds.  
This PR updates the variable cell input to use a controller-based approach with proper state synchronization so newly created environment variables display correctly.

---

## Related Issues
Closes #1065 

---

## Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing
---

## Added / Updated Tests
- [ ] Yes  
- [x] No, this change fixes UI state synchronization in the environment variables editor and does not alter existing business logic or data models.

---

## OS Tested On
- [ ] macOS  
- [x] Windows  
- [ ] Linux  
