### PR TITLE
feat: add copy value button to JSON previewer

### DIFF
--- a/lib/widgets/previewer_json.dart
+++ b/lib/widgets/previewer_json.dart
@@ -272,28 +272,46 @@ class _JsonPreviewerState extends State<JsonPreviewer> {
                       trailingBuilder: (context, node) => node.isFocused
                           ? Padding(
                               padding: const EdgeInsets.only(right: 12),
-                              child: IconButton(
-                                padding: EdgeInsets.zero,
-                                constraints:
-                                    const BoxConstraints(maxHeight: 18),
-                                icon: const Icon(
-                                  Icons.copy,
-                                  size: 18,
-                                ),
-                                onPressed: () async {
-                                  final val = toJson(node);
-                                  String toCopy = '';
-                                  if (node.isClass ||
-                                      node.isArray ||
-                                      node.isRoot) {
-                                    toCopy = kJsonEncoder.convert(val);
-                                  } else {
-                                    toCopy = (val.values as Iterable)
-                                        .first
-                                        .toString();
-                                  }
-                                  await _copy(toCopy, sm);
-                                },
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  IconButton(
+                                    tooltip: "Copy Value",
+                                    padding: EdgeInsets.zero,
+                                    constraints:
+                                        const BoxConstraints(maxHeight: 18),
+                                    icon: const Icon(
+                                      Icons.abc,
+                                      size: 18,
+                                    ),
+                                    onPressed: () async {
+                                      final val = toJson(node);
+                                      String toCopy = '';
+                                      if (node.isClass || node.isArray || node.isRoot) {
+                                        toCopy = kJsonEncoder.convert(val);
+                                      } else {
+                                        toCopy = node.value.toString();
+                                      }
+                                      await _copy(toCopy, sm);
+                                    },
+                                  ),
+                                  kHSpacer5,
+                                  IconButton(
+                                    tooltip: "Copy Key-Value Pair",
+                                    padding: EdgeInsets.zero,
+                                    constraints:
+                                        const BoxConstraints(maxHeight: 18),
+                                    icon: const Icon(
+                                      Icons.copy,
+                                      size: 18,
+                                    ),
+                                    onPressed: () async {
+                                      final val = toJson(node);
+                                      String toCopy = kJsonEncoder.convert(val);
+                                      await _copy(toCopy, sm);
+                                    },
+                                  ),
+                                ],
                               ),
                             )
                           : const SizedBox(),


### PR DESCRIPTION
## PR Description

Currently, the copy button in the JSON previewer copies the entire key-value pair as a JSON object (e.g., `{"token": "eyJ..."}`). This PR introduces a second **"Copy Value"** button that extracts only the raw value (e.g., `eyJ...`). 

This is particularly useful for developers who need to quickly grab JWT tokens, IDs, or specific field values without manually deleting the JSON structure (braces and keys) after pasting.

**Changes:**
- Added a `Row` to the `trailingBuilder` in `JsonPreviewer`.
- Included a new `IconButton` with the `Icons.abc` icon for copying the raw value.
- Updated the logic to use `node.value.toString()` for value extraction while maintaining the original `toJson(node)` logic for the full pair copy.
- Added descriptive tooltips for both buttons to improve accessibility.



## Related Issues

- Closes #638

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: This is a UI enhancement to the JSON Explorer trailing builder; existing logic for node extraction was utilized and manually verified with multiple data types.

## OS on which you have developed and tested the feature?

- [ ] Windows
- [ ] macOS
- [x] Linux