### PR TITLE
fix: prevent duplicate history IDs in addHistoryRequest

### DIFF
--- a/lib/providers/history_providers.dart
+++ b/lib/providers/history_providers.dart
@@ -78,13 +78,12 @@ class HistoryMetaStateNotifier
 
   void addHistoryRequest(HistoryRequestModel model) async {
     final id = model.historyId;
+    final existingKeys = state?.keys.toList() ?? [];
     state = {
       ...state ?? {},
       id: model.metaData,
     };
-    final List<String> updatedHistoryKeys =
-        state == null ? [id] : [...state!.keys, id];
-    hiveHandler.setHistoryIds(updatedHistoryKeys);
+    hiveHandler.setHistoryIds([...existingKeys, id]);
     hiveHandler.setHistoryMeta(id, model.metaData.toJson());
     await hiveHandler.setHistoryRequest(id, model.toJson());
     await loadHistoryRequest(id);


### PR DESCRIPTION
## PR Description

`addHistoryRequest` mutated `state` before checking `state == null`, making the null branch dead code. The else branch then spread `state!.keys` — which already contained the new ID — and appended it again, writing every history ID twice to Hive on every request sent. The UI looked correct because in-memory Maps deduplicate silently, but the on-disk `historyIds` list grew at 2× the correct rate permanently.

Fix: snapshot `existingKeys` from `state` before the mutation, build the persisted list from that snapshot, remove the dead ternary.

## Related Issues

NA

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [x] Yes

## OS on which you have developed and tested the feature

- [ ] Windows
- [x] macOS
- [ ] Linux