### PR TITLE
fix(ui): prevent empty text on Select Model button. Closes #942

### DIFF
--- a/lib/screens/common_widgets/ai/ai_model_selector_button.dart
+++ b/lib/screens/common_widgets/ai/ai_model_selector_button.dart
@@ -45,7 +45,11 @@ class AIModelSelectorButton extends StatelessWidget {
               if (newAIRequestModel == null) return;
               onModelUpdated?.call(newAIRequestModel);
             },
-      child: Text(aiRequestModel?.model ?? 'Select Model'),
+      child: Text(
+        aiRequestModel?.model?.isNotEmpty == true
+            ? aiRequestModel!.model!
+            : 'Select Model',
+      ),
     );
   }
 }


### PR DESCRIPTION
When selecting AI model, if user choses the model from the options of Ollama, OpenAI, Anthropic, Gemini, Azure OpenAI but not the exact model, the Select button previously displayed empty text. This PR explicitly checks for empty strings instead of just null values in the model name, falling back to 'Select Model'. Closes #942.