### PR TITLE
FEATURE: add paste-from-text support to import dialog

### DIFF
--- a/lib/widgets/dialog_import.dart
+++ b/lib/widgets/dialog_import.dart
@@ -10,45 +10,141 @@ showImportDialog({
   required ImportFormat importFormat,
   Function(ImportFormat?)? onImportFormatChange,
   Function(XFile)? onFileDropped,
+  Function(String content)? onTextSubmitted,
 }) {
   showDialog(
     context: context,
     builder: (context) {
       var fmt = importFormat;
+      final textController = TextEditingController();
+
       return StatefulBuilder(
         builder: (context, StateSetter setState) {
+          // Use 60% of screen height, capped between 400–600
+          final screenHeight = MediaQuery.of(context).size.height;
+          final dialogHeight = (screenHeight * 0.6).clamp(400.0, 600.0);
+
           return AlertDialog(
             contentPadding: kP12,
-            content: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    const Text(kLabelImport),
-                    kHSpacer8,
-                    DropdownButtonImportFormat(
-                      importFormat: fmt,
-                      onChanged: (format) {
-                        if (format != null) {
-                          onImportFormatChange?.call(format);
-                          setState(() {
-                            fmt = format;
-                          });
-                        }
-                      },
+            content: SizedBox(
+              width: 500,
+              height: dialogHeight,
+              child: Column(
+                children: [
+                  // ── Format selector row ──
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(
+                        kLabelImport,
+                        style: kTextStyleButton,
+                      ),
+                      kHSpacer8,
+                      DropdownButtonImportFormat(
+                        importFormat: fmt,
+                        onChanged: (format) {
+                          if (format != null) {
+                            onImportFormatChange?.call(format);
+                            setState(() {
+                              fmt = format;
+                            });
+                          }
+                        },
+                      ),
+                    ],
+                  ),
+                  kVSpacer6,
+
+                  // ── Drag and drop area (compact) ──
+                  SizedBox(
+                    height: 120,
+                    child: DragAndDropArea(
+                      onFileDropped: onFileDropped,
                     ),
-                  ],
-                ),
-                kVSpacer6,
-                DragAndDropArea(
-                  onFileDropped: onFileDropped,
-                ),
-              ],
+                  ),
+                  kVSpacer6,
+
+                  // ── Divider ──
+                  Row(
+                    children: [
+                      const Expanded(child: Divider()),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                        child: Text(
+                          'OR paste content below',
+                          style: kTextStyleSmall.copyWith(
+                            color: Theme.of(context)
+                                .colorScheme
+                                .onSurface
+                                .withValues(alpha: 0.5),
+                          ),
+                        ),
+                      ),
+                      const Expanded(child: Divider()),
+                    ],
+                  ),
+                  kVSpacer6,
+
+                  // ── Paste text field (takes remaining space) ──
+                  Expanded(
+                    child: TextField(
+                      controller: textController,
+                      expands: true,
+                      maxLines: null,
+                      textAlignVertical: TextAlignVertical.top,
+                      decoration: InputDecoration(
+                        hintText: _hintForFormat(fmt),
+                        hintStyle: kCodeStyle.copyWith(
+                          fontSize: 12,
+                          color: Theme.of(context)
+                              .colorScheme
+                              .onSurface
+                              .withValues(alpha: 0.4),
+                        ),
+                        border: const OutlineInputBorder(),
+                        contentPadding: kP10,
+                      ),
+                      style: kCodeStyle.copyWith(fontSize: 13),
+                    ),
+                  ),
+                  kVSpacer6,
+
+                  // ── Action buttons ──
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      ADTextButton(
+                        onPressed: () => Navigator.of(context).pop(),
+                        label: kLabelCancel,
+                      ),
+                      kHSpacer8,
+                      ADFilledButton(
+                        onPressed: () {
+                          final text = textController.text.trim();
+                          if (text.isNotEmpty) {
+                            onTextSubmitted?.call(text);
+                          }
+                        },
+                        label: kLabelImport,
+                      ),
+                    ],
+                  ),
+                ],
+              ),
             ),
           );
         },
       );
     },
   );
+}
+
+String _hintForFormat(ImportFormat format) {
+  return switch (format) {
+    ImportFormat.curl =>
+      'Paste cURL command here...\ne.g. curl -X GET https://api.example.com',
+    ImportFormat.postman => 'Paste Postman collection JSON here...',
+    ImportFormat.insomnia => 'Paste Insomnia export JSON here...',
+    ImportFormat.har => 'Paste HAR (HTTP Archive) JSON here...',
+  };
 }

--- a/lib/widgets/drag_and_drop_area.dart
+++ b/lib/widgets/drag_and_drop_area.dart
@@ -50,8 +50,8 @@ class _DragAndDropAreaState extends State<DragAndDropArea> {
             color: Theme.of(context).colorScheme.primaryContainer,
           ),
         ),
-        width: 600,
-        height: 400,
+        width: double.infinity,
+        height: double.infinity,
         child: _list.isEmpty
             ? Center(
                 child: Column(


### PR DESCRIPTION
## Summary

Adds the ability to paste cURL commands, Postman collections, Insomnia 
exports, or HAR content directly into the import dialog, instead of 
requiring a file drag-and-drop.

**Resolves TODO** at `lib/importer/import_dialog.dart:13` added by 
@ashitaprasad in commit 4d426dcf:
> // TODO: The dialog must have a feature to paste contents in a text field
> // Also, a mechanism can be added where on importing a file it shows the
> // contents in the text field and then the user presses ok to add it to collection

## Demo Video

https://github.com/user-attachments/assets/a9e5d363-74b5-4adc-88e8-fab6e852c629


## Changes Made

### `lib/widgets/dialog_import.dart`
- Added `onTextSubmitted` callback parameter
- Responsive dialog height via `MediaQuery` (60% of screen, clamped 400-600px)
- Compact drag-and-drop area (120px instead of 400px)
- Multiline paste `TextField` with Source Code Pro font (`kCodeStyle`)
- Format-specific hint text that updates when dropdown changes
- Cancel/Import buttons using design system (`ADTextButton`, `ADFilledButton`)

### `lib/importer/import_dialog.dart`
- Wired `onTextSubmitted` to parse pasted text via `kImporter.getHttpRequestModelList()`
- Dialog closes before showing error snackbar on parse failure
- Removed resolved TODO comment

### `lib/widgets/drag_and_drop_area.dart`
- Replaced hardcoded `width: 600, height: 400` with `double.infinity`
- Makes the widget responsive — fills its parent container

## Design Decisions

1. **Reuses existing parser** — `Importer.getHttpRequestModelList()` already 
   accepts raw string content. No new parsing logic added.
2. **Responsive layout** — Uses `MediaQuery` for cross-platform support 
   (Windows, macOS, Linux, mobile).
3. **Design system compliance** — Uses `kCodeStyle`, `kTextStyleSmall`, 
   `ADTextButton`, `ADFilledButton` from `apidash_design_system`.
4. **Error UX** — Dialog closes before showing error snackbar, so the 
   message appears on the main screen, not hidden behind the dialog.

## Testing

- `flutter analyze` on all modified files: **No issues found ✅**
- Manually tested on Windows:
  - ✅ Pasting valid cURL command → imports successfully
  - ✅ Pasting wrong format → dialog closes, error snackbar shows
  - ✅ Long content scrolls inside text field, no overflow
  - ✅ Hint text updates when switching import format
  - ✅ Both file drag-drop and text paste work simultaneously

resolves #1107 
