### PR TITLE
Fixed the issue where jsonplaceholder's api was returning 403. Solves issue #1109

### DIFF
--- a/packages/better_networking/lib/services/http_service.dart
+++ b/packages/better_networking/lib/services/http_service.dart
@@ -9,6 +9,14 @@ import '../models/models.dart';
 import '../utils/utils.dart';
 import 'http_client_manager.dart';
 
+//  Default headers to include in all requests to help avoid 403 errors from Cloudflare and similar services.
+const Map<String, String> kDefaultRequestHeaders = {
+  'User-Agent': 'APIDash (https://apidash.dev)',
+  'Accept': '*/*',
+  'Accept-Language': 'en-US,en;q=0.9',
+  'Connection': 'keep-alive',
+};
+
 typedef HttpResponse = http.Response;
 
 typedef HttpStreamOutput = (
@@ -51,7 +59,10 @@ Future<(HttpResponse?, Duration?, String?)> sendHttpRequestV1(
 
   if (uriRec.$1 != null) {
     Uri requestUrl = uriRec.$1!;
-    Map<String, String> headers = authenticatedRequestModel.enabledHeadersMap;
+    Map<String, String> headers = {
+      ...kDefaultRequestHeaders,
+      ...authenticatedRequestModel.enabledHeadersMap,
+    };
     bool overrideContentType = false;
     HttpResponse? response;
     String? body;
@@ -339,7 +350,10 @@ Future<http.StreamedResponse> makeStreamedRequest({
   required HttpRequestModel requestModel,
   required APIType apiType,
 }) async {
-  final headers = requestModel.enabledHeadersMap;
+  final headers = {
+    ...kDefaultRequestHeaders,
+    ...requestModel.enabledHeadersMap,
+  };
   final hasBody = kMethodsWithBody.contains(requestModel.method);
   final isMultipart = requestModel.bodyContentType == ContentType.formdata;
 


### PR DESCRIPTION
## PR Description

Adds default HTTP headers to all outgoing requests in the better_networking package to prevent 403 Forbidden errors from Cloudflare-protected APIs.

Problem
When making requests to APIs protected by Cloudflare (e.g., https://jsonplaceholder.typicode.com), users receive a 403 response. This occurs because requests lack standard browser-like headers, causing Cloudflare's bot protection to flag them as suspicious requests .

Before
<img width="983" height="616" alt="Screenshot 2026-02-22 at 11 39 47 AM" src="https://github.com/user-attachments/assets/460a98ae-1e71-4526-b17a-1dd16e80561b" />

After
<img width="987" height="691" alt="Screenshot 2026-02-22 at 11 38 05 AM" src="https://github.com/user-attachments/assets/00806f1a-7119-4733-a9ae-fa20402aedd0" />

Solution

Added default headers that are automatically included in all HTTP requests:
```
const Map<String, String> kDefaultRequestHeaders = {
  'User-Agent': 'APIDash (https://apidash.dev)',
  'Accept': '*/*',
  'Accept-Language': 'en-US,en;q=0.9',
  'Connection': 'keep-alive',
};
```

These defaults are merged with user-provided headers, with user headers taking priority (so users can still override any default header if needed).

## Related Issues

- Closes #1109 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [] No, and this is why: _please replace this line with details on why tests have not been included_

## OS on which you have developed and tested the feature?

- [ ] Windows
- [x] macOS
- [ ] Linux
