### PR TITLE
Add mute functionality to video playback controls

### DIFF
--- a/lib/widgets/previewer.dart
+++ b/lib/widgets/previewer.dart
@@ -29,8 +29,6 @@ class Previewer extends StatefulWidget {
   final String? type;
   final String? subtype;
   final bool hasRaw;
-  /// Forwarded to [VideoPreviewer] and [Uint8AudioPlayer]. Pass [false] when
-  /// showing media in read-only / history contexts.
   final bool autoPlay;
 
   @override

--- a/lib/widgets/previewer_video.dart
+++ b/lib/widgets/previewer_video.dart
@@ -28,14 +28,8 @@ class _VideoPreviewerState extends State<VideoPreviewer> {
   late Future<void> _initializeVideoPlayerFuture;
   late File _tempVideoFile;
   bool _showControls = false;
-  // Whether the controller is ready for playback operations.
   bool _isControllerReady = false;
-  // Tracks the last known tab-visibility from TickerMode. Kept as a plain
-  // field so it can safely be read from async callbacks and setState bodies,
-  // where calling TickerMode.valuesOf(context) directly is not allowed.
   bool _isCurrentlyVisible = true;
-  // Tracks if the video was playing when the tab was hidden, so we can
-  // resume it when the tab becomes visible again.
   bool _wasPlayingBeforeHidden = false;
 
   @override
@@ -52,9 +46,6 @@ class _VideoPreviewerState extends State<VideoPreviewer> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    // Always read TickerMode first so this State registers as a dependent and
-    // didChangeDependencies is called again whenever visibility changes — even
-    // if the controller is not ready yet.
     final isVisible = TickerMode.valuesOf(context).enabled;
     _isCurrentlyVisible = isVisible;
     if (!_isControllerReady) return;
@@ -90,12 +81,6 @@ class _VideoPreviewerState extends State<VideoPreviewer> {
       _isControllerReady = true;
       if (mounted) {
         setState(() {
-          // Only auto-play when both conditions hold:
-          //   1. autoPlay is enabled (false for history, true for requests)
-          //   2. the hosting tab is currently visible
-          // _isCurrentlyVisible is maintained by didChangeDependencies; reading
-          // it here is safe (TickerMode.valuesOf must NOT be called inside a
-          // setState callback — only in build/didChangeDependencies).
           if (widget.autoPlay && _isCurrentlyVisible) {
             _videoController.play();
           }

--- a/lib/widgets/response_body_success.dart
+++ b/lib/widgets/response_body_success.dart
@@ -126,9 +126,6 @@ class _ResponseBodySuccessState extends State<ResponseBodySuccess> {
                         type: widget.mediaType.type,
                         subtype: widget.mediaType.subtype,
                         hasRaw: widget.options.contains(ResponseBodyView.raw),
-                        // Never autoplay in history — the user must press play.
-                        // In the requests pane autoPlay defaults to true so
-                        // video responses start immediately as before.
                         autoPlay: !widget.isPartOfHistory,
                       ),
                     ),

--- a/lib/widgets/uint8_audio_player.dart
+++ b/lib/widgets/uint8_audio_player.dart
@@ -46,9 +46,6 @@ class Uint8AudioPlayer extends StatefulWidget {
   final String type;
   final String subtype;
   final AudioErrorWidgetBuilder errorBuilder;
-  /// Whether to start playback automatically once the source is ready.
-  /// Audio defaults to [false] (user must press play) — this flag is kept
-  /// for symmetry with [VideoPreviewer] and future use.
   final bool autoPlay;
 
   @override
@@ -57,8 +54,6 @@ class Uint8AudioPlayer extends StatefulWidget {
 
 class _Uint8AudioPlayerState extends State<Uint8AudioPlayer> {
   final player = AudioPlayer();
-  // Tracks if the audio was playing when the tab was hidden, so we can
-  // resume it when the tab becomes visible again.
   bool _wasPlayingBeforeHidden = false;
 
   @override
@@ -70,10 +65,6 @@ class _Uint8AudioPlayerState extends State<Uint8AudioPlayer> {
     super.initState();
   }
 
-  /// Called whenever an [InheritedWidget] dependency (including [TickerMode])
-  /// changes. [IndexedStack] uses [Offstage] which wraps hidden children with
-  /// [TickerMode(enabled: false)]. We use this to pause/resume playback
-  /// automatically when the user switches tabs.
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();


### PR DESCRIPTION
## PR Description
**Fix: Video & audio keeps playing when switching tabs**

ApiDash uses `IndexedStack` which keeps all tabs mounted at the same time. Because of this, a video loaded in the Requests tab would also autoplay in the History tab, you couldn't see it, but you could hear it. Switching tabs also didn't pause anything.

**What changed:**
- Added an `autoPlay` flag that flows down to the video/audio widgets. History tab always passes `autoPlay: false`, so it never autoplays
- Used `didChangeDependencies` + `TickerMode` to detect when a tab becomes hidden and pause the player, then resume when you come back
- Added `setVolume(0)` before `pause()` to prevent the CoreAudio audio tail on macOS (frames stop but audio buffer drains for ~100ms without this)
- Replaced a stale `_isPlaying` bool with `ValueListenableBuilder` so the play/pause icon always reflects actual player state

**Before:**
https://artifacts.rishia.in/apidash/1116/Screen%20Recording%202026-02-23%20at%2011.31.41%E2%80%AFAM.mov

**After:**
https://artifacts.rishia.in/apidash/1116/Screen%20Recording%202026-02-23%20at%2011.26.02%E2%80%AFAM.mov

## Related Issues
- Closes #1116

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
- [ ] Yes
- [x] No

## OS tested on
- [x] macOS
- [ ] Windows
- [ ] Linux