### PR TITLE
fix: prevent invalid text selection crash in environment field

### DIFF
--- a/lib/screens/common_widgets/env_trigger_field.dart
+++ b/lib/screens/common_widgets/env_trigger_field.dart
@@ -82,7 +82,8 @@ class EnvironmentTriggerFieldState extends State<EnvironmentTriggerField> {
       final currentSelection = controller.selection;
       controller.text = widget.initialValue!;
       // Restore the selection if it's still valid
-      if (currentSelection.baseOffset <= controller.text.length) {
+      if (currentSelection.isValid &&
+          currentSelection.end <= controller.text.length) {
         controller.selection = currentSelection;
       }
     }


### PR DESCRIPTION
## PR Description
Hey team! 👋 This PR fixes the invalid text selection crash (RangeError) that occurs in the EnvironmentTriggerField when switching between overall request types (e.g., changing from HTTP to AI or GraphQL) while text is currently highlighted in the URL bar.

## Related Issues
During the layout rebuild, didUpdateWidget attempts to restore the previous text selection. However, the logic was only checking if the start (baseOffset) of the selection was within the new string's bounds. Because switching request types often changes the text length, Flutter would throw a red screen when trying to stretch the old highlight to an index that no longer existed. Additionally, right-to-left highlighting completely bypassed the original check.

##The fix:
Updated the validation to use currentSelection.end <= controller.text.length. This strictly ensures that the entire selection range is valid within the new string before applying it. This safely handles both left-to-right and right-to-left cursor actions and prevents the crash entirely, allowing the UI state to update smoothly.

- Closes #1138 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [x] No, and this is why: This is a single-line defensive bounds check for a highly specific UI rendering edge case (involving active mouse drag selections during a major layout swap). Existing tests pass successfully, and this safely catches the out-of-bounds rendering exception.

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux
