### PR TITLE
fix: remove redundant onTap from GestureDetector in NavbarButton to p…

### DIFF
--- a/lib/screens/common_widgets/button_navbar.dart
+++ b/lib/screens/common_widgets/button_navbar.dart
@@ -44,7 +44,6 @@ class NavbarButton extends ConsumerWidget {
       cursor: SystemMouseCursors.click,
       child: GestureDetector(
         behavior: HitTestBehavior.translucent,
-        onTap: onPress,
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [


### PR DESCRIPTION
Fixes #1155

**What does this PR do?**

Removes the redundant `onTap: onPress` from `GestureDetector` in `NavbarButton` inside `button_navbar.dart`.

**Why?**

`GestureDetector` and `TextButton` were both handling the same onPress callback, causing it to fire twice on every tap. Since `TextButton.onPressed` already handles the tap, the `onTap` on `GestureDetector` is unnecessary

**Changes Made**

Removed `onTap: onPress` from `GestureDetector` in `button_navbar.dart`

**How to Test ?**

1.Add `print("onPress fired")` inside the `onPress callback`
2.Before fix — tap `NavbarButton` once, observe it prints twice
3.Apply fix — tap again, observe it prints once
4.Remove the print statement


`GestureDetector` is intentionally kept for `HitTestBehavior.translucent` — only the onTap argument is removed.





