### PR TITLE
fix: escape regex special characters in env var substitution

### DIFF
--- a/lib/utils/envvar_utils.dart
+++ b/lib/utils/envvar_utils.dart
@@ -44,7 +44,8 @@ String? substituteVariables(
   if (envVarMap.keys.isEmpty) {
     return input;
   }
-  final regex = RegExp("{{(${envVarMap.keys.join('|')})}}");
+  final escapedKeys = envVarMap.keys.map(RegExp.escape).join('|');
+  final regex = RegExp("{{($escapedKeys)}}");
 
   String result = input.replaceAllMapped(regex, (match) {
     final key = match.group(1)?.trim() ?? '';

--- a/test/utils/envvar_utils_test.dart
+++ b/test/utils/envvar_utils_test.dart
@@ -182,6 +182,27 @@ void main() {
           expected);
     });
 
+    test('substituteVariables with dot in variable name (api.url)', () {
+      const input = 'https://{{api.url}}/endpoint';
+      final envMap = {'api.url': 'example.com'};
+      expect(
+          substituteVariables(input, envMap), 'https://example.com/endpoint');
+    });
+
+    test('substituteVariables does NOT substitute similar‑looking keys', () {
+      const input = 'https://{{apiXurl}}/endpoint';
+      final envMap = {'api.url': 'example.com'};
+      expect(
+          substituteVariables(input, envMap), 'https://{{apiXurl}}/endpoint');
+    });
+
+    test('substituteVariables with regex‑special chars in key does not throw',
+        () {
+      const input = 'token={{auth(v2)}}';
+      final envMap = {'auth(v2)': 'secret'};
+      expect(substituteVariables(input, envMap), 'token=secret');
+    });
+
     test("Testing substituteHttpRequestModel with non-empty", () {
       const httpRequestModel = HttpRequestModel(
         url: "{{url}}/humanize/social",


### PR DESCRIPTION
## PR Description

This PR fixes a critical bug in [substituteVariables] where environment variable keys were not being escaped before being used in a regular expression. 

**Key Fixes:**
- **Regex Character Escaping:** Utilized `RegExp.escape()` for each variable key. This ensures that variable names containing characters like `.` (dot), [()] (parentheses), or `[]` (brackets) are matched literally. 
- **Prevented Substitution Failures:** Previously, a variable named `auth(v2)` would fail to substitute because the regex engine interpreted the parentheses as a capturing group. After this fix, it matches exactly `{{auth(v2)}}`.
- **Improved Security/Stability:** Prevents unintentional matching (e.g., `api.url` matching `apiXurl`) and stops potential `FormatException` crashes caused by malformed key strings.

## Related Issues

- closes #1164 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project [main] branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [x] Yes
- Added 3 new regression tests in [test/utils/envvar_utils_test.dart] to verify literal matching for dots, support for parentheses in keys, and ensuring no accidental pattern matches.

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux
