### PR TITLE
test: Add unit tests for import/export IO parsers (postman, curl, har, insomnia)

### DIFF
--- a/packages/apidash_core/test/parsers/curl_test.dart
+++ b/packages/apidash_core/test/parsers/curl_test.dart
@@ -140,5 +140,92 @@ void main() {
 
       expect(result, isNull);
     });
+
+    test('should return null for empty string', () {
+      const curl = '';
+      final result = curlImport.getHttpRequestModelList(curl);
+      expect(result, isNull);
+    });
+
+    test('should return null for whitespace-only string', () {
+      const curl = '   \n  \t  ';
+      final result = curlImport.getHttpRequestModelList(curl);
+      expect(result, isNull);
+    });
+
+    test('should parse curl with query parameters in URL', () {
+      const curl =
+          'curl "https://api.apidash.dev/search?q=flutter&page=1"';
+      final result = curlImport.getHttpRequestModelList(curl);
+
+      expect(result, isNotNull);
+      expect(result!.length, 1);
+      expect(result[0].url, 'https://api.apidash.dev/search');
+      expect(result[0].params?.length, 2);
+    });
+
+    test('should parse curl with PUT method', () {
+      const curl = '''
+        curl -X PUT https://api.apidash.dev/users/1 
+        -H "Content-Type: application/json" 
+        -d '{"name": "updated"}'
+      ''';
+
+      final result = curlImport.getHttpRequestModelList(curl);
+
+      expect(result, isNotNull);
+      expect(result![0].method, HTTPVerb.put);
+      expect(result[0].url, 'https://api.apidash.dev/users/1');
+      expect(result[0].body, '{"name": "updated"}');
+    });
+
+    test('should parse curl with DELETE method', () {
+      const curl = 'curl -X DELETE https://api.apidash.dev/users/1';
+      final result = curlImport.getHttpRequestModelList(curl);
+
+      expect(result, isNotNull);
+      expect(result![0].method, HTTPVerb.delete);
+      expect(result[0].url, 'https://api.apidash.dev/users/1');
+    });
+
+    test('should parse curl with PATCH method', () {
+      const curl = '''
+        curl -X PATCH https://api.apidash.dev/users/1 
+        -H "Content-Type: application/json" 
+        -d '{"status": "active"}'
+      ''';
+
+      final result = curlImport.getHttpRequestModelList(curl);
+
+      expect(result, isNotNull);
+      expect(result![0].method, HTTPVerb.patch);
+    });
+
+    test('should parse curl with multiple headers', () {
+      const curl = '''
+        curl https://api.apidash.dev/data 
+        -H "Accept: application/json" 
+        -H "Authorization: Bearer mytoken" 
+        -H "X-Custom-Header: customvalue"
+      ''';
+
+      final result = curlImport.getHttpRequestModelList(curl);
+
+      expect(result, isNotNull);
+      expect(result![0].headers?.length, 3);
+    });
+
+    test('should handle curl with --data flag instead of -d', () {
+      const curl = '''
+        curl -X POST https://api.apidash.dev/data 
+        --data '{"key": "value"}'
+      ''';
+
+      final result = curlImport.getHttpRequestModelList(curl);
+
+      expect(result, isNotNull);
+      expect(result![0].method, HTTPVerb.post);
+      expect(result[0].body, '{"key": "value"}');
+    });
   });
 }

--- a/packages/apidash_core/test/parsers/har_io_test.dart
+++ b/packages/apidash_core/test/parsers/har_io_test.dart
@@ -1,0 +1,804 @@
+import 'package:test/test.dart';
+import 'package:apidash_core/apidash_core.dart';
+
+void main() {
+  group('HarParserIO Tests', () {
+    late HarParserIO harParserIO;
+
+    setUp(() {
+      harParserIO = HarParserIO();
+    });
+
+    group('getHttpRequestModelList', () {
+      test('should parse simple GET request', () {
+        const json = r'''
+{
+  "log": {
+    "version": "1.2",
+    "creator": {"name": "Test", "version": "1.0"},
+    "entries": [
+      {
+        "startedDateTime": "2025-03-25T12:00:00.000Z",
+        "time": 100,
+        "request": {
+          "method": "GET",
+          "url": "https://api.apidash.dev",
+          "headers": [],
+          "queryString": [],
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "headers": [],
+          "bodySize": 0
+        }
+      }
+    ]
+  }
+}''';
+
+        final result = harParserIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$1, 'https://api.apidash.dev');
+        expect(result[0].$2.method, HTTPVerb.get);
+        expect(result[0].$2.url, 'https://api.apidash.dev');
+        expect(result[0].$2.headers, isEmpty);
+        expect(result[0].$2.params, isEmpty);
+        expect(result[0].$2.body, isNull);
+      });
+
+      test('should parse GET request with query parameters', () {
+        const json = r'''
+{
+  "log": {
+    "version": "1.2",
+    "creator": {"name": "Test", "version": "1.0"},
+    "entries": [
+      {
+        "startedDateTime": "2025-03-25T12:01:00.000Z",
+        "time": 150,
+        "request": {
+          "method": "GET",
+          "url": "https://api.apidash.dev/country/data?code=US",
+          "headers": [],
+          "queryString": [
+            {"name": "code", "value": "US"}
+          ],
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "headers": [],
+          "bodySize": 0
+        }
+      }
+    ]
+  }
+}''';
+
+        final result = harParserIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$2.method, HTTPVerb.get);
+        expect(result[0].$2.url, 'https://api.apidash.dev/country/data');
+        expect(result[0].$2.params,
+            [const NameValueModel(name: 'code', value: 'US')]);
+        expect(result[0].$2.isParamEnabledList, [true]);
+      });
+
+      test('should parse GET request with multiple query parameters', () {
+        const json = r'''
+{
+  "log": {
+    "version": "1.2",
+    "creator": {"name": "Test", "version": "1.0"},
+    "entries": [
+      {
+        "startedDateTime": "2025-03-25T12:02:00.000Z",
+        "time": 200,
+        "request": {
+          "method": "GET",
+          "url": "https://api.apidash.dev/humanize/social?num=8700000&digits=3&system=SS&add_space=true&trailing_zeros=true",
+          "headers": [],
+          "queryString": [
+            {"name": "num", "value": "8700000"},
+            {"name": "digits", "value": "3"},
+            {"name": "system", "value": "SS"},
+            {"name": "add_space", "value": "true"},
+            {"name": "trailing_zeros", "value": "true"}
+          ],
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "headers": [],
+          "bodySize": 0
+        }
+      }
+    ]
+  }
+}''';
+
+        final result = harParserIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$2.url, 'https://api.apidash.dev/humanize/social');
+        expect(result[0].$2.params?.length, 5);
+        expect(result[0].$2.params?[0],
+            const NameValueModel(name: 'num', value: '8700000'));
+        expect(result[0].$2.params?[4],
+            const NameValueModel(name: 'trailing_zeros', value: 'true'));
+        expect(result[0].$2.isParamEnabledList,
+            [true, true, true, true, true]);
+      });
+
+      test('should parse POST request with JSON body', () {
+        const json = r'''
+{
+  "log": {
+    "version": "1.2",
+    "creator": {"name": "Test", "version": "1.0"},
+    "entries": [
+      {
+        "startedDateTime": "2025-03-25T12:03:00.000Z",
+        "time": 300,
+        "request": {
+          "method": "POST",
+          "url": "https://api.apidash.dev/case/lower",
+          "headers": [],
+          "queryString": [],
+          "postData": {
+            "mimeType": "application/json",
+            "text": "{ \"text\": \"I LOVE Flutter\" }"
+          },
+          "bodySize": 50
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "headers": [],
+          "bodySize": 0
+        }
+      }
+    ]
+  }
+}''';
+
+        final result = harParserIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$2.method, HTTPVerb.post);
+        expect(result[0].$2.url, 'https://api.apidash.dev/case/lower');
+        expect(result[0].$2.bodyContentType, ContentType.json);
+        expect(result[0].$2.body, '{ "text": "I LOVE Flutter" }');
+      });
+
+      test('should parse POST request with multipart/form-data (text params)',
+          () {
+        const json = r'''
+{
+  "log": {
+    "version": "1.2",
+    "creator": {"name": "Test", "version": "1.0"},
+    "entries": [
+      {
+        "startedDateTime": "2025-03-25T12:04:00.000Z",
+        "time": 350,
+        "request": {
+          "method": "POST",
+          "url": "https://api.apidash.dev/io/form",
+          "headers": [
+            {"name": "User-Agent", "value": "Test Agent"}
+          ],
+          "queryString": [],
+          "postData": {
+            "mimeType": "multipart/form-data",
+            "params": [
+              {"name": "text", "value": "API", "contentType": "text/plain"},
+              {"name": "sep", "value": "|", "contentType": "text/plain"},
+              {"name": "times", "value": "3", "contentType": "text/plain"}
+            ]
+          },
+          "bodySize": 100
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "headers": [],
+          "bodySize": 0
+        }
+      }
+    ]
+  }
+}''';
+
+        final result = harParserIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$2.method, HTTPVerb.post);
+        expect(result[0].$2.url, 'https://api.apidash.dev/io/form');
+        expect(result[0].$2.bodyContentType, ContentType.formdata);
+        expect(result[0].$2.headers, [
+          const NameValueModel(name: 'User-Agent', value: 'Test Agent'),
+        ]);
+        expect(result[0].$2.isHeaderEnabledList, [true]);
+        expect(result[0].$2.formData, [
+          const FormDataModel(
+              name: 'text', value: 'API', type: FormDataType.text),
+          const FormDataModel(
+              name: 'sep', value: '|', type: FormDataType.text),
+          const FormDataModel(
+              name: 'times', value: '3', type: FormDataType.text),
+        ]);
+      });
+
+      test('should parse POST request with multipart/form-data (file upload)',
+          () {
+        const json = r'''
+{
+  "log": {
+    "version": "1.2",
+    "creator": {"name": "Test", "version": "1.0"},
+    "entries": [
+      {
+        "startedDateTime": "2025-03-25T12:05:00.000Z",
+        "time": 400,
+        "request": {
+          "method": "POST",
+          "url": "https://api.apidash.dev/io/img",
+          "headers": [],
+          "queryString": [],
+          "postData": {
+            "mimeType": "multipart/form-data",
+            "params": [
+              {"name": "token", "value": "xyz", "contentType": "text/plain"},
+              {"name": "imfile", "fileName": "hire AI.jpeg", "contentType": "image/jpeg"}
+            ]
+          },
+          "bodySize": 150
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "headers": [],
+          "bodySize": 0
+        }
+      }
+    ]
+  }
+}''';
+
+        final result = harParserIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$2.method, HTTPVerb.post);
+        expect(result[0].$2.bodyContentType, ContentType.formdata);
+        expect(result[0].$2.formData?.length, 2);
+        expect(
+          result[0].$2.formData?[0],
+          const FormDataModel(
+              name: 'token', value: 'xyz', type: FormDataType.text),
+        );
+        expect(
+          result[0].$2.formData?[1],
+          const FormDataModel(
+              name: 'imfile',
+              value: 'hire AI.jpeg',
+              type: FormDataType.file),
+        );
+      });
+
+      test(
+          'should parse POST request with application/x-www-form-urlencoded body',
+          () {
+        const json = r'''
+{
+  "log": {
+    "version": "1.2",
+    "creator": {"name": "Test", "version": "1.0"},
+    "entries": [
+      {
+        "startedDateTime": "2025-03-25T12:06:00.000Z",
+        "time": 200,
+        "request": {
+          "method": "POST",
+          "url": "https://api.apidash.dev/form",
+          "headers": [],
+          "queryString": [],
+          "postData": {
+            "mimeType": "application/x-www-form-urlencoded",
+            "text": "username=john&password=secret123"
+          },
+          "bodySize": 40
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "headers": [],
+          "bodySize": 0
+        }
+      }
+    ]
+  }
+}''';
+
+        final result = harParserIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$2.method, HTTPVerb.post);
+        expect(result[0].$2.bodyContentType, ContentType.formdata);
+        expect(result[0].$2.formData?.length, 2);
+        expect(
+          result[0].$2.formData?[0],
+          const FormDataModel(
+              name: 'username', value: 'john', type: FormDataType.text),
+        );
+        expect(
+          result[0].$2.formData?[1],
+          const FormDataModel(
+              name: 'password', value: 'secret123', type: FormDataType.text),
+        );
+      });
+
+      test('should parse multiple entries', () {
+        const json = r'''
+{
+  "log": {
+    "version": "1.2",
+    "creator": {"name": "Test", "version": "1.0"},
+    "entries": [
+      {
+        "startedDateTime": "2025-03-25T12:00:00.000Z",
+        "time": 100,
+        "request": {
+          "method": "GET",
+          "url": "https://api.apidash.dev",
+          "headers": [],
+          "queryString": [],
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "headers": [],
+          "bodySize": 0
+        }
+      },
+      {
+        "startedDateTime": "2025-03-25T12:01:00.000Z",
+        "time": 150,
+        "request": {
+          "method": "POST",
+          "url": "https://api.apidash.dev/case/lower",
+          "headers": [],
+          "queryString": [],
+          "postData": {
+            "mimeType": "application/json",
+            "text": "{\"text\": \"hello\"}"
+          },
+          "bodySize": 20
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "headers": [],
+          "bodySize": 0
+        }
+      },
+      {
+        "startedDateTime": "2025-03-25T12:02:00.000Z",
+        "time": 200,
+        "request": {
+          "method": "DELETE",
+          "url": "https://api.apidash.dev/users/1",
+          "headers": [],
+          "queryString": [],
+          "bodySize": 0
+        },
+        "response": {
+          "status": 204,
+          "statusText": "No Content",
+          "headers": [],
+          "bodySize": 0
+        }
+      }
+    ]
+  }
+}''';
+
+        final result = harParserIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 3);
+        expect(result[0].$2.method, HTTPVerb.get);
+        expect(result[0].$2.url, 'https://api.apidash.dev');
+        expect(result[1].$2.method, HTTPVerb.post);
+        expect(result[1].$2.url, 'https://api.apidash.dev/case/lower');
+        expect(result[1].$2.bodyContentType, ContentType.json);
+        expect(result[2].$2.method, HTTPVerb.delete);
+        expect(result[2].$2.url, 'https://api.apidash.dev/users/1');
+      });
+
+      test('should return null for invalid JSON', () {
+        const content = 'this is not valid json';
+        final result = harParserIO.getHttpRequestModelList(content);
+        expect(result, isNull);
+      });
+
+      test('should return null for empty string', () {
+        const content = '';
+        final result = harParserIO.getHttpRequestModelList(content);
+        expect(result, isNull);
+      });
+
+      test('should handle disabled headers and query params', () {
+        const json = r'''
+{
+  "log": {
+    "version": "1.2",
+    "creator": {"name": "Test", "version": "1.0"},
+    "entries": [
+      {
+        "startedDateTime": "2025-03-25T12:00:00.000Z",
+        "time": 100,
+        "request": {
+          "method": "GET",
+          "url": "https://api.apidash.dev?a=1&b=2",
+          "headers": [
+            {"name": "Accept", "value": "application/json", "disabled": false},
+            {"name": "X-Debug", "value": "true", "disabled": true}
+          ],
+          "queryString": [
+            {"name": "a", "value": "1", "disabled": false},
+            {"name": "b", "value": "2", "disabled": true}
+          ],
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "headers": [],
+          "bodySize": 0
+        }
+      }
+    ]
+  }
+}''';
+
+        final result = harParserIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$2.headers?.length, 2);
+        expect(result[0].$2.isHeaderEnabledList, [true, false]);
+        expect(result[0].$2.params?.length, 2);
+        expect(result[0].$2.isParamEnabledList, [true, false]);
+      });
+
+      test('should default to GET for unknown HTTP method', () {
+        const json = r'''
+{
+  "log": {
+    "version": "1.2",
+    "creator": {"name": "Test", "version": "1.0"},
+    "entries": [
+      {
+        "startedDateTime": "2025-03-25T12:00:00.000Z",
+        "time": 100,
+        "request": {
+          "method": "FOOBAR",
+          "url": "https://api.apidash.dev",
+          "headers": [],
+          "queryString": [],
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "headers": [],
+          "bodySize": 0
+        }
+      }
+    ]
+  }
+}''';
+
+        final result = harParserIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result![0].$2.method, HTTPVerb.get);
+      });
+
+      test('should strip URL parameters from request URL', () {
+        const json = r'''
+{
+  "log": {
+    "version": "1.2",
+    "creator": {"name": "Test", "version": "1.0"},
+    "entries": [
+      {
+        "startedDateTime": "2025-03-25T12:00:00.000Z",
+        "time": 100,
+        "request": {
+          "method": "GET",
+          "url": "https://api.example.com/search?q=test&page=1",
+          "headers": [],
+          "queryString": [
+            {"name": "q", "value": "test"},
+            {"name": "page", "value": "1"}
+          ],
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "headers": [],
+          "bodySize": 0
+        }
+      }
+    ]
+  }
+}''';
+
+        final result = harParserIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result![0].$2.url, 'https://api.example.com/search');
+      });
+
+      test('should return empty list for HAR with no entries', () {
+        const json = r'''
+{
+  "log": {
+    "version": "1.2",
+    "creator": {"name": "Test", "version": "1.0"},
+    "entries": []
+  }
+}''';
+
+        final result = harParserIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result, isEmpty);
+      });
+
+      test('should handle PUT method', () {
+        const json = r'''
+{
+  "log": {
+    "version": "1.2",
+    "creator": {"name": "Test", "version": "1.0"},
+    "entries": [
+      {
+        "startedDateTime": "2025-03-25T12:00:00.000Z",
+        "time": 100,
+        "request": {
+          "method": "PUT",
+          "url": "https://api.apidash.dev/users/1",
+          "headers": [],
+          "queryString": [],
+          "postData": {
+            "mimeType": "application/json",
+            "text": "{\"name\": \"updated\"}"
+          },
+          "bodySize": 30
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "headers": [],
+          "bodySize": 0
+        }
+      }
+    ]
+  }
+}''';
+
+        final result = harParserIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result![0].$2.method, HTTPVerb.put);
+        expect(result[0].$2.body, '{"name": "updated"}');
+        expect(result[0].$2.bodyContentType, ContentType.json);
+      });
+
+      test(
+          'should parse full API Dash HAR collection with all 6 request types',
+          () {
+        const json = r'''
+{
+  "log": {
+    "version": "1.2",
+    "creator": {"name": "Client Name", "version": "v8.x.x"},
+    "entries": [
+      {
+        "startedDateTime": "2025-03-25T12:00:00.000Z",
+        "time": 100,
+        "request": {
+          "method": "GET",
+          "url": "https://api.apidash.dev",
+          "headers": [],
+          "queryString": [],
+          "bodySize": 0
+        },
+        "response": {"status": 200, "statusText": "OK", "headers": [], "bodySize": 0}
+      },
+      {
+        "startedDateTime": "2025-03-25T12:01:00.000Z",
+        "time": 150,
+        "request": {
+          "method": "GET",
+          "url": "https://api.apidash.dev/country/data?code=US",
+          "headers": [],
+          "queryString": [{"name": "code", "value": "US"}],
+          "bodySize": 0
+        },
+        "response": {"status": 200, "statusText": "OK", "headers": [], "bodySize": 0}
+      },
+      {
+        "startedDateTime": "2025-03-25T12:02:00.000Z",
+        "time": 200,
+        "request": {
+          "method": "GET",
+          "url": "https://api.apidash.dev/humanize/social?num=8700000&digits=3&system=SS&add_space=true&trailing_zeros=true",
+          "headers": [],
+          "queryString": [
+            {"name": "num", "value": "8700000"},
+            {"name": "digits", "value": "3"},
+            {"name": "system", "value": "SS"},
+            {"name": "add_space", "value": "true"},
+            {"name": "trailing_zeros", "value": "true"}
+          ],
+          "bodySize": 0
+        },
+        "response": {"status": 200, "statusText": "OK", "headers": [], "bodySize": 0}
+      },
+      {
+        "startedDateTime": "2025-03-25T12:03:00.000Z",
+        "time": 300,
+        "request": {
+          "method": "POST",
+          "url": "https://api.apidash.dev/case/lower",
+          "headers": [],
+          "queryString": [],
+          "postData": {"mimeType": "application/json", "text": "{ \"text\": \"I LOVE Flutter\" }"},
+          "bodySize": 50
+        },
+        "response": {"status": 200, "statusText": "OK", "headers": [], "bodySize": 0}
+      },
+      {
+        "startedDateTime": "2025-03-25T12:04:00.000Z",
+        "time": 350,
+        "request": {
+          "method": "POST",
+          "url": "https://api.apidash.dev/io/form",
+          "headers": [{"name": "User-Agent", "value": "Test Agent"}],
+          "queryString": [],
+          "postData": {
+            "mimeType": "multipart/form-data",
+            "params": [
+              {"name": "text", "value": "API", "contentType": "text/plain"},
+              {"name": "sep", "value": "|", "contentType": "text/plain"},
+              {"name": "times", "value": "3", "contentType": "text/plain"}
+            ]
+          },
+          "bodySize": 100
+        },
+        "response": {"status": 200, "statusText": "OK", "headers": [], "bodySize": 0}
+      },
+      {
+        "startedDateTime": "2025-03-25T12:05:00.000Z",
+        "time": 400,
+        "request": {
+          "method": "POST",
+          "url": "https://api.apidash.dev/io/img",
+          "headers": [],
+          "queryString": [],
+          "postData": {
+            "mimeType": "multipart/form-data",
+            "params": [
+              {"name": "token", "value": "xyz", "contentType": "text/plain"},
+              {"name": "imfile", "fileName": "hire AI.jpeg", "contentType": "image/jpeg"}
+            ]
+          },
+          "bodySize": 150
+        },
+        "response": {"status": 200, "statusText": "OK", "headers": [], "bodySize": 0}
+      }
+    ]
+  }
+}''';
+
+        final result = harParserIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 6);
+
+        // Simple GET
+        expect(result[0].$2.method, HTTPVerb.get);
+        expect(result[0].$2.url, 'https://api.apidash.dev');
+
+        // GET with query param
+        expect(result[1].$2.method, HTTPVerb.get);
+        expect(result[1].$2.url, 'https://api.apidash.dev/country/data');
+        expect(result[1].$2.params?.length, 1);
+
+        // GET with multiple query params
+        expect(result[2].$2.params?.length, 5);
+
+        // POST with JSON body
+        expect(result[3].$2.method, HTTPVerb.post);
+        expect(result[3].$2.bodyContentType, ContentType.json);
+        expect(result[3].$2.body, '{ "text": "I LOVE Flutter" }');
+
+        // POST with multipart form data
+        expect(result[4].$2.method, HTTPVerb.post);
+        expect(result[4].$2.bodyContentType, ContentType.formdata);
+        expect(result[4].$2.formData?.length, 3);
+
+        // POST with file upload
+        expect(result[5].$2.method, HTTPVerb.post);
+        expect(result[5].$2.bodyContentType, ContentType.formdata);
+        expect(result[5].$2.formData?.length, 2);
+        expect(result[5].$2.formData?[1].type, FormDataType.file);
+        expect(result[5].$2.formData?[1].value, 'hire AI.jpeg');
+      });
+    });
+
+    group('parseFormData', () {
+      test('should parse simple form data string', () {
+        final harIO = HarParserIO();
+        final result = harIO.parseFormData('key1=value1&key2=value2');
+
+        expect(result, {'key1': 'value1', 'key2': 'value2'});
+      });
+
+      test('should return empty map for null input', () {
+        final harIO = HarParserIO();
+        final result = harIO.parseFormData(null);
+
+        expect(result, isEmpty);
+      });
+
+      test('should return empty map for empty string', () {
+        final harIO = HarParserIO();
+        final result = harIO.parseFormData('');
+
+        expect(result, isEmpty);
+      });
+
+      test('should handle URL-encoded values', () {
+        final harIO = HarParserIO();
+        final result =
+            harIO.parseFormData('name=John%20Doe&city=New%20York');
+
+        expect(result, {'name': 'John Doe', 'city': 'New York'});
+      });
+
+      test('should skip malformed pairs without equals sign', () {
+        final harIO = HarParserIO();
+        final result = harIO.parseFormData('valid=pair&invalid&also=good');
+
+        expect(result, {'valid': 'pair', 'also': 'good'});
+      });
+
+      test('should handle single key-value pair', () {
+        final harIO = HarParserIO();
+        final result = harIO.parseFormData('key=value');
+
+        expect(result, {'key': 'value'});
+      });
+    });
+  });
+}

--- a/packages/apidash_core/test/parsers/insomnia_io_test.dart
+++ b/packages/apidash_core/test/parsers/insomnia_io_test.dart
@@ -1,0 +1,764 @@
+import 'package:test/test.dart';
+import 'package:apidash_core/apidash_core.dart';
+import 'package:insomnia_collection/insomnia_collection.dart';
+
+void main() {
+  group('InsomniaIO Tests', () {
+    late InsomniaIO insomniaIO;
+
+    setUp(() {
+      insomniaIO = InsomniaIO();
+    });
+
+    group('getHttpRequestModelList', () {
+      test('should parse simple GET request', () {
+        const json = r'''
+{
+  "_type": "export",
+  "__export_format": 4,
+  "__export_date": "2025-01-05T13:05:11.752Z",
+  "__export_source": "insomnia.desktop.app:v10.3.0",
+  "resources": [
+    {
+      "_id": "req_1",
+      "parentId": "fld_1",
+      "url": "https://api.apidash.dev/country/codes",
+      "name": "test-get",
+      "method": "GET",
+      "body": {},
+      "parameters": [],
+      "headers": [],
+      "_type": "request"
+    }
+  ]
+}''';
+
+        final result = insomniaIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$1, 'test-get');
+        expect(result[0].$2.method, HTTPVerb.get);
+        expect(result[0].$2.url, 'https://api.apidash.dev/country/codes');
+        expect(result[0].$2.headers, isEmpty);
+        expect(result[0].$2.params, isEmpty);
+        expect(result[0].$2.body, isNull);
+        expect(result[0].$2.formData, isNull);
+      });
+
+      test('should parse GET request with query parameters', () {
+        const json = r'''
+{
+  "_type": "export",
+  "__export_format": 4,
+  "__export_date": "2025-01-05T13:05:11.752Z",
+  "__export_source": "insomnia.desktop.app:v10.3.0",
+  "resources": [
+    {
+      "_id": "req_1",
+      "parentId": "fld_1",
+      "url": "https://food-service-backend.onrender.com/api/users/",
+      "name": "get-with-params",
+      "method": "GET",
+      "body": {},
+      "parameters": [
+        {
+          "id": "pair_1",
+          "name": "user_id",
+          "value": "34",
+          "description": "",
+          "disabled": false
+        }
+      ],
+      "headers": [
+        {"name": "User-Agent", "value": "insomnia/10.3.0"}
+      ],
+      "_type": "request"
+    }
+  ]
+}''';
+
+        final result = insomniaIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$1, 'get-with-params');
+        expect(result[0].$2.method, HTTPVerb.get);
+        expect(result[0].$2.url,
+            'https://food-service-backend.onrender.com/api/users/');
+        expect(result[0].$2.params,
+            [const NameValueModel(name: 'user_id', value: '34')]);
+        expect(result[0].$2.isParamEnabledList, [true]);
+        expect(result[0].$2.headers, [
+          const NameValueModel(
+              name: 'User-Agent', value: 'insomnia/10.3.0'),
+        ]);
+        expect(result[0].$2.isHeaderEnabledList, [true]);
+      });
+
+      test('should parse POST request with JSON body', () {
+        const json = r'''
+{
+  "_type": "export",
+  "__export_format": 4,
+  "__export_date": "2025-01-05T13:05:11.752Z",
+  "__export_source": "insomnia.desktop.app:v10.3.0",
+  "resources": [
+    {
+      "_id": "req_1",
+      "parentId": "fld_1",
+      "url": "https://api.apidash.dev/case/lower",
+      "name": "test-post",
+      "method": "POST",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n  \"text\": \"Grass is green\"\n}"
+      },
+      "parameters": [],
+      "headers": [
+        {"name": "Content-Type", "value": "application/json"}
+      ],
+      "_type": "request"
+    }
+  ]
+}''';
+
+        final result = insomniaIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$1, 'test-post');
+        expect(result[0].$2.method, HTTPVerb.post);
+        expect(result[0].$2.url, 'https://api.apidash.dev/case/lower');
+        expect(result[0].$2.bodyContentType, ContentType.json);
+        expect(result[0].$2.body, '{\n  "text": "Grass is green"\n}');
+        expect(result[0].$2.headers, [
+          const NameValueModel(
+              name: 'Content-Type', value: 'application/json'),
+        ]);
+      });
+
+      test('should parse PUT request with JSON body', () {
+        const json = r'''
+{
+  "_type": "export",
+  "__export_format": 4,
+  "__export_date": "2025-01-05T13:05:11.752Z",
+  "__export_source": "insomnia.desktop.app:v10.3.0",
+  "resources": [
+    {
+      "_id": "req_1",
+      "parentId": "fld_1",
+      "url": "https://reqres.in/api/users/2",
+      "name": "test-put",
+      "method": "PUT",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n    \"name\": \"morpheus\",\n    \"job\": \"zion resident\"\n}"
+      },
+      "parameters": [],
+      "headers": [
+        {"name": "Content-Type", "value": "application/json"}
+      ],
+      "_type": "request"
+    }
+  ]
+}''';
+
+        final result = insomniaIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$1, 'test-put');
+        expect(result[0].$2.method, HTTPVerb.put);
+        expect(result[0].$2.url, 'https://reqres.in/api/users/2');
+        expect(result[0].$2.bodyContentType, ContentType.json);
+        expect(result[0].$2.body,
+            '{\n    "name": "morpheus",\n    "job": "zion resident"\n}');
+      });
+
+      test('should only extract request type resources, ignoring others', () {
+        const json = r'''
+{
+  "_type": "export",
+  "__export_format": 4,
+  "__export_date": "2025-01-05T13:05:11.752Z",
+  "__export_source": "insomnia.desktop.app:v10.3.0",
+  "resources": [
+    {
+      "_id": "req_1",
+      "parentId": "fld_1",
+      "url": "https://api.apidash.dev/country/codes",
+      "name": "test-get",
+      "method": "GET",
+      "body": {},
+      "parameters": [],
+      "headers": [],
+      "_type": "request"
+    },
+    {
+      "_id": "fld_1",
+      "parentId": "wrk_1",
+      "name": "Test Folder",
+      "description": "A test folder",
+      "_type": "request_group"
+    },
+    {
+      "_id": "wrk_1",
+      "name": "Test Workspace",
+      "scope": "collection",
+      "_type": "workspace"
+    },
+    {
+      "_id": "env_1",
+      "parentId": "wrk_1",
+      "name": "Base Environment",
+      "environmentType": "kv",
+      "_type": "environment"
+    },
+    {
+      "_id": "jar_1",
+      "parentId": "wrk_1",
+      "name": "Default Jar",
+      "cookies": [],
+      "_type": "cookie_jar"
+    }
+  ]
+}''';
+
+        final result = insomniaIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$1, 'test-get');
+        expect(result[0].$2.method, HTTPVerb.get);
+      });
+
+      test('should parse multiple request resources', () {
+        const json = r'''
+{
+  "_type": "export",
+  "__export_format": 4,
+  "__export_date": "2025-01-05T13:05:11.752Z",
+  "__export_source": "insomnia.desktop.app:v10.3.0",
+  "resources": [
+    {
+      "_id": "req_1",
+      "parentId": "fld_1",
+      "url": "https://api.apidash.dev/country/codes",
+      "name": "test-get",
+      "method": "GET",
+      "body": {},
+      "parameters": [],
+      "headers": [],
+      "_type": "request"
+    },
+    {
+      "_id": "req_2",
+      "parentId": "fld_1",
+      "url": "https://api.apidash.dev/case/lower",
+      "name": "test-post",
+      "method": "POST",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\"text\": \"Grass is green\"}"
+      },
+      "parameters": [],
+      "headers": [
+        {"name": "Content-Type", "value": "application/json"}
+      ],
+      "_type": "request"
+    },
+    {
+      "_id": "req_3",
+      "parentId": "fld_1",
+      "url": "https://reqres.in/api/users/2",
+      "name": "test-put",
+      "method": "PUT",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\"name\": \"morpheus\"}"
+      },
+      "parameters": [],
+      "headers": [
+        {"name": "Content-Type", "value": "application/json"}
+      ],
+      "_type": "request"
+    }
+  ]
+}''';
+
+        final result = insomniaIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 3);
+        expect(result[0].$1, 'test-get');
+        expect(result[0].$2.method, HTTPVerb.get);
+        expect(result[1].$1, 'test-post');
+        expect(result[1].$2.method, HTTPVerb.post);
+        expect(result[2].$1, 'test-put');
+        expect(result[2].$2.method, HTTPVerb.put);
+      });
+
+      test('should return null for invalid JSON', () {
+        const content = 'this is not valid json';
+        final result = insomniaIO.getHttpRequestModelList(content);
+        expect(result, isNull);
+      });
+
+      test('should return null for empty string', () {
+        const content = '';
+        final result = insomniaIO.getHttpRequestModelList(content);
+        expect(result, isNull);
+      });
+
+      test('should return empty list when no request resources exist', () {
+        const json = r'''
+{
+  "_type": "export",
+  "__export_format": 4,
+  "__export_date": "2025-01-05T13:05:11.752Z",
+  "__export_source": "insomnia.desktop.app:v10.3.0",
+  "resources": [
+    {
+      "_id": "wrk_1",
+      "name": "Test Workspace",
+      "scope": "collection",
+      "_type": "workspace"
+    },
+    {
+      "_id": "env_1",
+      "parentId": "wrk_1",
+      "name": "Base Environment",
+      "environmentType": "kv",
+      "_type": "environment"
+    }
+  ]
+}''';
+
+        final result = insomniaIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result, isEmpty);
+      });
+
+      test('should default to GET for unknown HTTP method', () {
+        const json = r'''
+{
+  "_type": "export",
+  "__export_format": 4,
+  "resources": [
+    {
+      "_id": "req_1",
+      "parentId": "fld_1",
+      "url": "https://api.apidash.dev",
+      "name": "unknown-method",
+      "method": "FOOBAR",
+      "body": {},
+      "parameters": [],
+      "headers": [],
+      "_type": "request"
+    }
+  ]
+}''';
+
+        final result = insomniaIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result![0].$2.method, HTTPVerb.get);
+      });
+
+      test('should default to GET for null method', () {
+        const json = r'''
+{
+  "_type": "export",
+  "__export_format": 4,
+  "resources": [
+    {
+      "_id": "req_1",
+      "parentId": "fld_1",
+      "url": "https://api.apidash.dev",
+      "name": "no-method",
+      "body": {},
+      "parameters": [],
+      "headers": [],
+      "_type": "request"
+    }
+  ]
+}''';
+
+        final result = insomniaIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result![0].$2.method, HTTPVerb.get);
+      });
+
+      test('should handle disabled headers and query params', () {
+        const json = r'''
+{
+  "_type": "export",
+  "__export_format": 4,
+  "resources": [
+    {
+      "_id": "req_1",
+      "parentId": "fld_1",
+      "url": "https://api.apidash.dev",
+      "name": "disabled-test",
+      "method": "GET",
+      "body": {},
+      "parameters": [
+        {"name": "active", "value": "1", "disabled": false},
+        {"name": "inactive", "value": "0", "disabled": true}
+      ],
+      "headers": [
+        {"name": "Accept", "value": "application/json", "disabled": false},
+        {"name": "X-Debug", "value": "true", "disabled": true}
+      ],
+      "_type": "request"
+    }
+  ]
+}''';
+
+        final result = insomniaIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$2.headers?.length, 2);
+        expect(result[0].$2.isHeaderEnabledList, [true, false]);
+        expect(result[0].$2.params?.length, 2);
+        expect(result[0].$2.isParamEnabledList, [true, false]);
+      });
+
+      test('should handle request with no body mimeType', () {
+        const json = r'''
+{
+  "_type": "export",
+  "__export_format": 4,
+  "resources": [
+    {
+      "_id": "req_1",
+      "parentId": "fld_1",
+      "url": "https://api.apidash.dev",
+      "name": "no-body",
+      "method": "GET",
+      "body": {},
+      "parameters": [],
+      "headers": [],
+      "_type": "request"
+    }
+  ]
+}''';
+
+        final result = insomniaIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result![0].$2.body, isNull);
+        expect(result[0].$2.formData, isNull);
+      });
+
+      test('should parse formdata body with text and file fields', () {
+        const json = r'''
+{
+  "_type": "export",
+  "__export_format": 4,
+  "resources": [
+    {
+      "_id": "req_1",
+      "parentId": "fld_1",
+      "url": "https://api.apidash.dev/upload",
+      "name": "form-upload",
+      "method": "POST",
+      "body": {
+        "mimeType": "multipart/form-data",
+        "params": [
+          {"name": "token", "value": "xyz", "type": "text"},
+          {"name": "avatar", "type": "file", "fileName": "/path/to/file.png"}
+        ]
+      },
+      "parameters": [],
+      "headers": [],
+      "_type": "request"
+    }
+  ]
+}''';
+
+        final result = insomniaIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$2.method, HTTPVerb.post);
+        expect(result[0].$2.bodyContentType, ContentType.formdata);
+        expect(result[0].$2.formData?.length, 2);
+        expect(
+          result[0].$2.formData?[0],
+          const FormDataModel(
+              name: 'token', value: 'xyz', type: FormDataType.text),
+        );
+        expect(
+          result[0].$2.formData?[1],
+          const FormDataModel(
+              name: 'avatar',
+              value: '/path/to/file.png',
+              type: FormDataType.file),
+        );
+        expect(result[0].$2.body, isNull);
+      });
+
+      test('should strip URL parameters from URL', () {
+        const json = r'''
+{
+  "_type": "export",
+  "__export_format": 4,
+  "resources": [
+    {
+      "_id": "req_1",
+      "parentId": "fld_1",
+      "url": "https://api.example.com/search?q=test&page=1",
+      "name": "url-with-params",
+      "method": "GET",
+      "body": {},
+      "parameters": [
+        {"name": "q", "value": "test"},
+        {"name": "page", "value": "1"}
+      ],
+      "headers": [],
+      "_type": "request"
+    }
+  ]
+}''';
+
+        final result = insomniaIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result![0].$2.url, 'https://api.example.com/search');
+      });
+
+      test('should parse DELETE method', () {
+        const json = r'''
+{
+  "_type": "export",
+  "__export_format": 4,
+  "resources": [
+    {
+      "_id": "req_1",
+      "parentId": "fld_1",
+      "url": "https://api.apidash.dev/users/1",
+      "name": "delete-user",
+      "method": "DELETE",
+      "body": {},
+      "parameters": [],
+      "headers": [],
+      "_type": "request"
+    }
+  ]
+}''';
+
+        final result = insomniaIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result![0].$2.method, HTTPVerb.delete);
+      });
+
+      test('should parse PATCH method', () {
+        const json = r'''
+{
+  "_type": "export",
+  "__export_format": 4,
+  "resources": [
+    {
+      "_id": "req_1",
+      "parentId": "fld_1",
+      "url": "https://api.apidash.dev/users/1",
+      "name": "patch-user",
+      "method": "PATCH",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\"status\": \"active\"}"
+      },
+      "parameters": [],
+      "headers": [],
+      "_type": "request"
+    }
+  ]
+}''';
+
+        final result = insomniaIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result![0].$2.method, HTTPVerb.patch);
+        expect(result[0].$2.body, '{"status": "active"}');
+        expect(result[0].$2.bodyContentType, ContentType.json);
+      });
+
+      test('should parse full API Dash Insomnia collection', () {
+        const json = r'''
+{
+  "_type": "export",
+  "__export_format": 4,
+  "__export_date": "2025-01-05T13:05:11.752Z",
+  "__export_source": "insomnia.desktop.app:v10.3.0",
+  "resources": [
+    {
+      "_id": "req_1",
+      "parentId": "fld_1",
+      "url": "https://food-service-backend.onrender.com/api/users/",
+      "name": "get-with-params",
+      "method": "GET",
+      "body": {},
+      "parameters": [
+        {"id": "pair_1", "name": "user_id", "value": "34", "description": "", "disabled": false}
+      ],
+      "headers": [
+        {"name": "User-Agent", "value": "insomnia/10.3.0"}
+      ],
+      "_type": "request"
+    },
+    {
+      "_id": "fld_1",
+      "parentId": "wrk_1",
+      "name": "APIDash-APItests",
+      "description": "These are test endpoints for API Dash",
+      "_type": "request_group"
+    },
+    {
+      "_id": "wrk_1",
+      "name": "APIDash-APItests",
+      "scope": "collection",
+      "_type": "workspace"
+    },
+    {
+      "_id": "req_2",
+      "parentId": "fld_1",
+      "url": "https://api.apidash.dev/country/codes",
+      "name": "test-get",
+      "method": "GET",
+      "body": {},
+      "parameters": [],
+      "headers": [],
+      "_type": "request"
+    },
+    {
+      "_id": "req_3",
+      "parentId": "fld_1",
+      "url": "https://api.apidash.dev/case/lower",
+      "name": "test-post",
+      "method": "POST",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n  \"text\": \"Grass is green\"\n}"
+      },
+      "parameters": [],
+      "headers": [
+        {"name": "Content-Type", "value": "application/json"}
+      ],
+      "_type": "request"
+    },
+    {
+      "_id": "req_4",
+      "parentId": "fld_1",
+      "url": "https://reqres.in/api/users/2",
+      "name": "test-put",
+      "method": "PUT",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n    \"name\": \"morpheus\",\n    \"job\": \"zion resident\"\n}"
+      },
+      "parameters": [],
+      "headers": [
+        {"name": "Content-Type", "value": "application/json"}
+      ],
+      "_type": "request"
+    },
+    {
+      "_id": "env_1",
+      "parentId": "wrk_1",
+      "name": "Base Environment",
+      "environmentType": "kv",
+      "_type": "environment"
+    },
+    {
+      "_id": "jar_1",
+      "parentId": "wrk_1",
+      "name": "Default Jar",
+      "cookies": [],
+      "_type": "cookie_jar"
+    }
+  ]
+}''';
+
+        final result = insomniaIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 4);
+
+        // GET with params
+        expect(result[0].$1, 'get-with-params');
+        expect(result[0].$2.method, HTTPVerb.get);
+        expect(result[0].$2.params?.length, 1);
+        expect(result[0].$2.params?[0],
+            const NameValueModel(name: 'user_id', value: '34'));
+
+        // Simple GET
+        expect(result[1].$1, 'test-get');
+        expect(result[1].$2.method, HTTPVerb.get);
+
+        // POST with JSON
+        expect(result[2].$1, 'test-post');
+        expect(result[2].$2.method, HTTPVerb.post);
+        expect(result[2].$2.bodyContentType, ContentType.json);
+
+        // PUT with JSON
+        expect(result[3].$1, 'test-put');
+        expect(result[3].$2.method, HTTPVerb.put);
+        expect(result[3].$2.bodyContentType, ContentType.json);
+      });
+    });
+
+    group('insomniaResourceToEnvironmentModel', () {
+      test('should convert environment resource to EnvironmentModel', () {
+        const json = r'''
+{
+  "_type": "export",
+  "__export_format": 4,
+  "resources": [
+    {
+      "_id": "env_1",
+      "parentId": "wrk_1",
+      "name": "Test Environment",
+      "environmentType": "kv",
+      "kvPairData": [
+        {"id": "kv_1", "name": "API_KEY", "value": "abc123", "type": "text", "enabled": true},
+        {"id": "kv_2", "name": "SECRET", "value": "s3cret", "type": "secret", "enabled": true},
+        {"id": "kv_3", "name": "DISABLED_VAR", "value": "test", "type": "text", "enabled": false}
+      ],
+      "_type": "environment"
+    }
+  ]
+}''';
+
+        // Parse to get the environment resource directly
+        final ic = insomniaCollectionFromJsonStr(json);
+        final resource = ic.resources!
+            .firstWhere((r) => r.type == 'environment');
+
+        final result = insomniaIO.insomniaResourceToEnvironmentModel(resource);
+
+        expect(result.id, 'env_1');
+        expect(result.name, 'Test Environment');
+        expect(result.values.length, 3);
+        expect(result.values[0].key, 'API_KEY');
+        expect(result.values[0].value, 'abc123');
+        expect(result.values[0].type, EnvironmentVariableType.variable);
+        expect(result.values[0].enabled, true);
+        expect(result.values[1].key, 'SECRET');
+        expect(result.values[1].value, 's3cret');
+        expect(result.values[1].type, EnvironmentVariableType.secret);
+        expect(result.values[1].enabled, true);
+        expect(result.values[2].key, 'DISABLED_VAR');
+        expect(result.values[2].value, 'test');
+        expect(result.values[2].type, EnvironmentVariableType.variable);
+        expect(result.values[2].enabled, false);
+      });
+    });
+  });
+}

--- a/packages/apidash_core/test/parsers/postman_io_test.dart
+++ b/packages/apidash_core/test/parsers/postman_io_test.dart
@@ -1,0 +1,902 @@
+import 'package:test/test.dart';
+import 'package:apidash_core/apidash_core.dart';
+
+void main() {
+  group('PostmanIO Tests', () {
+    late PostmanIO postmanIO;
+
+    setUp(() {
+      postmanIO = PostmanIO();
+    });
+
+    group('getHttpRequestModelList', () {
+      test('should parse simple GET request', () {
+        const json = r'''
+{
+  "info": {
+    "name": "Test",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Simple GET",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "https://api.apidash.dev",
+          "protocol": "https",
+          "host": ["api", "apidash", "dev"]
+        }
+      },
+      "response": []
+    }
+  ]
+}''';
+
+        final result = postmanIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$1, 'Simple GET');
+        expect(result[0].$2.method, HTTPVerb.get);
+        expect(result[0].$2.url, 'https://api.apidash.dev');
+        expect(result[0].$2.headers, isEmpty);
+        expect(result[0].$2.params, isEmpty);
+        expect(result[0].$2.body, isNull);
+        expect(result[0].$2.formData, isNull);
+      });
+
+      test('should parse GET request with query parameters', () {
+        const json = r'''
+{
+  "info": {
+    "name": "Test",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Country Data",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "https://api.apidash.dev/country/data?code=US",
+          "protocol": "https",
+          "host": ["api", "apidash", "dev"],
+          "path": ["country", "data"],
+          "query": [
+            {"key": "code", "value": "US"}
+          ]
+        }
+      },
+      "response": []
+    }
+  ]
+}''';
+
+        final result = postmanIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$1, 'Country Data');
+        expect(result[0].$2.method, HTTPVerb.get);
+        expect(result[0].$2.url, 'https://api.apidash.dev/country/data');
+        expect(result[0].$2.params,
+            [const NameValueModel(name: 'code', value: 'US')]);
+        expect(result[0].$2.isParamEnabledList, [true]);
+      });
+
+      test('should parse GET request with multiple query parameters', () {
+        const json = r'''
+{
+  "info": {
+    "name": "Test",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Humanize Rank",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "https://api.apidash.dev/humanize/social?num=8700000&digits=3&system=SS&add_space=true&trailing_zeros=true",
+          "protocol": "https",
+          "host": ["api", "apidash", "dev"],
+          "path": ["humanize", "social"],
+          "query": [
+            {"key": "num", "value": "8700000"},
+            {"key": "digits", "value": "3"},
+            {"key": "system", "value": "SS"},
+            {"key": "add_space", "value": "true"},
+            {"key": "trailing_zeros", "value": "true"}
+          ]
+        }
+      },
+      "response": []
+    }
+  ]
+}''';
+
+        final result = postmanIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$2.method, HTTPVerb.get);
+        expect(
+            result[0].$2.url, 'https://api.apidash.dev/humanize/social');
+        expect(result[0].$2.params?.length, 5);
+        expect(result[0].$2.params?[0],
+            const NameValueModel(name: 'num', value: '8700000'));
+        expect(result[0].$2.params?[4],
+            const NameValueModel(name: 'trailing_zeros', value: 'true'));
+        expect(result[0].$2.isParamEnabledList,
+            [true, true, true, true, true]);
+      });
+
+      test('should parse POST request with raw JSON body', () {
+        const json = r'''
+{
+  "info": {
+    "name": "Test",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Case Lower",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"text\": \"I LOVE Flutter\"}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "https://api.apidash.dev/case/lower",
+          "protocol": "https",
+          "host": ["api", "apidash", "dev"],
+          "path": ["case", "lower"]
+        }
+      },
+      "response": []
+    }
+  ]
+}''';
+
+        final result = postmanIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$2.method, HTTPVerb.post);
+        expect(result[0].$2.url, 'https://api.apidash.dev/case/lower');
+        expect(result[0].$2.body, '{"text": "I LOVE Flutter"}');
+        expect(result[0].$2.bodyContentType, ContentType.json);
+        expect(result[0].$2.formData, isNull);
+      });
+
+      test('should parse POST request with formdata', () {
+        const json = r'''
+{
+  "info": {
+    "name": "Test",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Form Example",
+      "request": {
+        "method": "POST",
+        "header": [
+          {"key": "User-Agent", "value": "Test Agent", "type": "text"}
+        ],
+        "body": {
+          "mode": "formdata",
+          "formdata": [
+            {"key": "text", "value": "API", "type": "text"},
+            {"key": "sep", "value": "|", "type": "text"},
+            {"key": "times", "value": "3", "type": "text"}
+          ]
+        },
+        "url": {
+          "raw": "https://api.apidash.dev/io/form",
+          "protocol": "https",
+          "host": ["api", "apidash", "dev"],
+          "path": ["io", "form"]
+        }
+      },
+      "response": []
+    }
+  ]
+}''';
+
+        final result = postmanIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$2.method, HTTPVerb.post);
+        expect(result[0].$2.url, 'https://api.apidash.dev/io/form');
+        expect(result[0].$2.bodyContentType, ContentType.formdata);
+        expect(result[0].$2.headers, [
+          const NameValueModel(name: 'User-Agent', value: 'Test Agent'),
+        ]);
+        expect(result[0].$2.isHeaderEnabledList, [true]);
+        expect(result[0].$2.formData, [
+          const FormDataModel(
+              name: 'text', value: 'API', type: FormDataType.text),
+          const FormDataModel(
+              name: 'sep', value: '|', type: FormDataType.text),
+          const FormDataModel(
+              name: 'times', value: '3', type: FormDataType.text),
+        ]);
+        expect(result[0].$2.body, isNull);
+      });
+
+      test('should parse POST request with formdata including file', () {
+        const json = r'''
+{
+  "info": {
+    "name": "Test",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Form with File",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "formdata",
+          "formdata": [
+            {"key": "token", "value": "xyz", "type": "text"},
+            {"key": "imfile", "type": "file", "src": "/path/to/image.jpeg"}
+          ]
+        },
+        "url": {
+          "raw": "https://api.apidash.dev/io/img",
+          "protocol": "https",
+          "host": ["api", "apidash", "dev"],
+          "path": ["io", "img"]
+        }
+      },
+      "response": []
+    }
+  ]
+}''';
+
+        final result = postmanIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$2.method, HTTPVerb.post);
+        expect(result[0].$2.bodyContentType, ContentType.formdata);
+        expect(result[0].$2.formData?.length, 2);
+        expect(
+          result[0].$2.formData?[0],
+          const FormDataModel(
+              name: 'token', value: 'xyz', type: FormDataType.text),
+        );
+        expect(
+          result[0].$2.formData?[1],
+          const FormDataModel(
+              name: 'imfile',
+              value: '/path/to/image.jpeg',
+              type: FormDataType.file),
+        );
+      });
+
+      test('should parse nested folder structure (full collection)', () {
+        const json = r'''
+{
+  "info": {
+    "name": "API Dash",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "GET Requests",
+      "item": [
+        {
+          "name": "Simple GET",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "https://api.apidash.dev",
+              "protocol": "https",
+              "host": ["api", "apidash", "dev"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Country Data",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "https://api.apidash.dev/country/data?code=US",
+              "protocol": "https",
+              "host": ["api", "apidash", "dev"],
+              "path": ["country", "data"],
+              "query": [{"key": "code", "value": "US"}]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "POST Requests",
+      "item": [
+        {
+          "name": "Case Lower",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"text\": \"I LOVE Flutter\"}",
+              "options": {"raw": {"language": "json"}}
+            },
+            "url": {
+              "raw": "https://api.apidash.dev/case/lower",
+              "protocol": "https",
+              "host": ["api", "apidash", "dev"],
+              "path": ["case", "lower"]
+            }
+          },
+          "response": []
+        }
+      ]
+    }
+  ]
+}''';
+
+        final result = postmanIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 3);
+        expect(result[0].$1, 'Simple GET');
+        expect(result[0].$2.method, HTTPVerb.get);
+        expect(result[1].$1, 'Country Data');
+        expect(result[1].$2.method, HTTPVerb.get);
+        expect(result[1].$2.params,
+            [const NameValueModel(name: 'code', value: 'US')]);
+        expect(result[2].$1, 'Case Lower');
+        expect(result[2].$2.method, HTTPVerb.post);
+        expect(result[2].$2.bodyContentType, ContentType.json);
+      });
+
+      test('should return null for invalid JSON', () {
+        const content = 'this is not valid json';
+        final result = postmanIO.getHttpRequestModelList(content);
+        expect(result, isNull);
+      });
+
+      test('should return null for empty string', () {
+        const content = '';
+        final result = postmanIO.getHttpRequestModelList(content);
+        expect(result, isNull);
+      });
+
+      test('should handle disabled headers and query params', () {
+        const json = r'''
+{
+  "info": {
+    "name": "Test",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Request with disabled",
+      "request": {
+        "method": "GET",
+        "header": [
+          {"key": "Accept", "value": "application/json", "disabled": false},
+          {"key": "X-Debug", "value": "true", "disabled": true}
+        ],
+        "url": {
+          "raw": "https://api.apidash.dev?active=1&inactive=0",
+          "query": [
+            {"key": "active", "value": "1", "disabled": false},
+            {"key": "inactive", "value": "0", "disabled": true}
+          ]
+        }
+      },
+      "response": []
+    }
+  ]
+}''';
+
+        final result = postmanIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$2.headers?.length, 2);
+        expect(result[0].$2.isHeaderEnabledList, [true, false]);
+        expect(result[0].$2.params?.length, 2);
+        expect(result[0].$2.isParamEnabledList, [true, false]);
+      });
+
+      test('should default to GET for unknown HTTP method', () {
+        const json = r'''
+{
+  "info": {
+    "name": "Test",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Unknown Method",
+      "request": {
+        "method": "FOOBAR",
+        "header": [],
+        "url": {
+          "raw": "https://api.apidash.dev"
+        }
+      },
+      "response": []
+    }
+  ]
+}''';
+
+        final result = postmanIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$2.method, HTTPVerb.get);
+      });
+
+      test('should default to GET for null HTTP method', () {
+        const json = r'''
+{
+  "info": {
+    "name": "Test",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "No Method",
+      "request": {
+        "header": [],
+        "url": {
+          "raw": "https://api.apidash.dev"
+        }
+      },
+      "response": []
+    }
+  ]
+}''';
+
+        final result = postmanIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$2.method, HTTPVerb.get);
+      });
+
+      test('should handle raw body with unknown language option', () {
+        const json = r'''
+{
+  "info": {
+    "name": "Test",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Unknown Lang",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "some raw content",
+          "options": {
+            "raw": {
+              "language": "unknownlang"
+            }
+          }
+        },
+        "url": {
+          "raw": "https://api.apidash.dev/endpoint"
+        }
+      },
+      "response": []
+    }
+  ]
+}''';
+
+        final result = postmanIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$2.body, 'some raw content');
+        expect(result[0].$2.bodyContentType, ContentType.json);
+      });
+
+      test('should return empty list for collection with no items', () {
+        const json = r'''
+{
+  "info": {
+    "name": "Empty",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": []
+}''';
+
+        final result = postmanIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result, isEmpty);
+      });
+
+      test('should handle formdata with unknown type defaulting to text', () {
+        const json = r'''
+{
+  "info": {
+    "name": "Test",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Unknown FormData Type",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "formdata",
+          "formdata": [
+            {"key": "field1", "value": "val1", "type": "unknowntype"}
+          ]
+        },
+        "url": {
+          "raw": "https://api.apidash.dev/upload"
+        }
+      },
+      "response": []
+    }
+  ]
+}''';
+
+        final result = postmanIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result[0].$2.formData?[0].type, FormDataType.text);
+      });
+
+      test('should strip URL parameters from raw URL', () {
+        const json = r'''
+{
+  "info": {
+    "name": "Test",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "URL with params",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "https://api.example.com/search?q=test&page=1",
+          "query": [
+            {"key": "q", "value": "test"},
+            {"key": "page", "value": "1"}
+          ]
+        }
+      },
+      "response": []
+    }
+  ]
+}''';
+
+        final result = postmanIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result![0].$2.url, 'https://api.example.com/search');
+      });
+
+      test('should parse full API Dash collection', () {
+        const json = r'''
+{
+  "info": {
+    "_postman_id": "a31e8a59-aa12-48c5-96a3-133822d7247e",
+    "name": "API Dash",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "26763819"
+  },
+  "item": [
+    {
+      "name": "GET Requests",
+      "item": [
+        {
+          "name": "Simple GET",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "https://api.apidash.dev",
+              "protocol": "https",
+              "host": ["api", "apidash", "dev"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Country Data",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "https://api.apidash.dev/country/data?code=US",
+              "protocol": "https",
+              "host": ["api", "apidash", "dev"],
+              "path": ["country", "data"],
+              "query": [{"key": "code", "value": "US"}]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Humanize Rank",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "https://api.apidash.dev/humanize/social?num=8700000&digits=3&system=SS&add_space=true&trailing_zeros=true",
+              "protocol": "https",
+              "host": ["api", "apidash", "dev"],
+              "path": ["humanize", "social"],
+              "query": [
+                {"key": "num", "value": "8700000"},
+                {"key": "digits", "value": "3"},
+                {"key": "system", "value": "SS"},
+                {"key": "add_space", "value": "true"},
+                {"key": "trailing_zeros", "value": "true"}
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "POST Requests",
+      "item": [
+        {
+          "name": "Case Lower",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n\"text\": \"I LOVE Flutter\"\n}",
+              "options": {"raw": {"language": "json"}}
+            },
+            "url": {
+              "raw": "https://api.apidash.dev/case/lower",
+              "protocol": "https",
+              "host": ["api", "apidash", "dev"],
+              "path": ["case", "lower"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Form Example",
+          "request": {
+            "method": "POST",
+            "header": [
+              {"key": "User-Agent", "value": "Test Agent", "type": "text"}
+            ],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {"key": "text", "value": "API", "type": "text"},
+                {"key": "sep", "value": "|", "type": "text"},
+                {"key": "times", "value": "3", "type": "text"}
+              ]
+            },
+            "url": {
+              "raw": "https://api.apidash.dev/io/form",
+              "protocol": "https",
+              "host": ["api", "apidash", "dev"],
+              "path": ["io", "form"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Form with File",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {"key": "token", "value": "xyz", "type": "text"},
+                {"key": "imfile", "type": "file", "src": "/Users/ashitaprasad/Downloads/hire AI.jpeg"}
+              ]
+            },
+            "url": {
+              "raw": "https://api.apidash.dev/io/img",
+              "protocol": "https",
+              "host": ["api", "apidash", "dev"],
+              "path": ["io", "img"]
+            }
+          },
+          "response": []
+        }
+      ]
+    }
+  ]
+}''';
+
+        final result = postmanIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result!.length, 6);
+
+        // Simple GET
+        expect(result[0].$1, 'Simple GET');
+        expect(result[0].$2.method, HTTPVerb.get);
+        expect(result[0].$2.url, 'https://api.apidash.dev');
+
+        // Country Data
+        expect(result[1].$1, 'Country Data');
+        expect(result[1].$2.method, HTTPVerb.get);
+        expect(result[1].$2.url, 'https://api.apidash.dev/country/data');
+        expect(result[1].$2.params?.length, 1);
+
+        // Humanize Rank
+        expect(result[2].$1, 'Humanize Rank');
+        expect(result[2].$2.params?.length, 5);
+
+        // Case Lower
+        expect(result[3].$1, 'Case Lower');
+        expect(result[3].$2.method, HTTPVerb.post);
+        expect(result[3].$2.bodyContentType, ContentType.json);
+
+        // Form Example
+        expect(result[4].$1, 'Form Example');
+        expect(result[4].$2.method, HTTPVerb.post);
+        expect(result[4].$2.bodyContentType, ContentType.formdata);
+        expect(result[4].$2.formData?.length, 3);
+
+        // Form with File
+        expect(result[5].$1, 'Form with File');
+        expect(result[5].$2.method, HTTPVerb.post);
+        expect(result[5].$2.bodyContentType, ContentType.formdata);
+        expect(result[5].$2.formData?.length, 2);
+        expect(result[5].$2.formData?[1].type, FormDataType.file);
+      });
+    });
+
+    group('postmanRequestToHttpRequestModel', () {
+      test('should handle request with empty URL', () {
+        const json = r'''
+{
+  "info": {
+    "name": "Test",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Empty URL",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": ""
+        }
+      },
+      "response": []
+    }
+  ]
+}''';
+
+        final result = postmanIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result![0].$2.url, '');
+      });
+
+      test('should handle DELETE method', () {
+        const json = r'''
+{
+  "info": {
+    "name": "Test",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Delete Request",
+      "request": {
+        "method": "DELETE",
+        "header": [],
+        "url": {
+          "raw": "https://api.apidash.dev/users/1"
+        }
+      },
+      "response": []
+    }
+  ]
+}''';
+
+        final result = postmanIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result![0].$2.method, HTTPVerb.delete);
+      });
+
+      test('should handle PUT method', () {
+        const json = r'''
+{
+  "info": {
+    "name": "Test",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Put Request",
+      "request": {
+        "method": "PUT",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"name\": \"updated\"}",
+          "options": {"raw": {"language": "json"}}
+        },
+        "url": {
+          "raw": "https://api.apidash.dev/users/1"
+        }
+      },
+      "response": []
+    }
+  ]
+}''';
+
+        final result = postmanIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result![0].$2.method, HTTPVerb.put);
+        expect(result[0].$2.body, '{"name": "updated"}');
+      });
+
+      test('should handle PATCH method', () {
+        const json = r'''
+{
+  "info": {
+    "name": "Test",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Patch Request",
+      "request": {
+        "method": "PATCH",
+        "header": [],
+        "url": {
+          "raw": "https://api.apidash.dev/users/1"
+        }
+      },
+      "response": []
+    }
+  ]
+}''';
+
+        final result = postmanIO.getHttpRequestModelList(json);
+
+        expect(result, isNotNull);
+        expect(result![0].$2.method, HTTPVerb.patch);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Fixes : #1170
**Summary**:

Adds comprehensive unit tests for the four import/export IO parsers in [apidash_core](vscode-file://vscode-app/c:/Users/hp/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) that previously had zero or minimal test coverage

What's tested:
1. **HTTP methods**: GET, POST, PUT, PATCH, DELETE
2. **Request components**: headers, query parameters, raw JSON body, form-data (text & file), x-www-form-urlencoded
3. **Enabled/disabled states** for headers and query params
4. **Structural parsing**: nested Postman folders, multiple HAR entries, Insomnia resource type filtering
5. **Insomnia environment** model conversion
6. **HAR parseFormData** utility (6 sub-tests)
7. URL parameter stripping from raw URLs
8. **Error handling**: invalid JSON, empty strings, unknown/null HTTP methods, unknown body types
9. Full collection round-trip parsing using API Dash's own exported collection fixtures
