### PR TITLE
feat(request-body): add JSON env authoring adapter UX

### DIFF
--- a/lib/screens/common_widgets/common_widgets.dart
+++ b/lib/screens/common_widgets/common_widgets.dart
@@ -13,6 +13,7 @@ export 'envfield_cell.dart';
 export 'envfield_header.dart';
 export 'envfield_url.dart';
 export 'environment_dropdown.dart';
+export 'json_env_highlight.dart';
 export 'envvar_indicator.dart';
 export 'envvar_popover.dart';
 export 'envvar_span.dart';

--- a/lib/screens/common_widgets/json_env_highlight.dart
+++ b/lib/screens/common_widgets/json_env_highlight.dart
@@ -1,0 +1,129 @@
+import 'package:apidash/consts.dart';
+import 'package:extended_text_field/extended_text_field.dart';
+import 'package:flutter/material.dart';
+
+import 'envvar_span.dart';
+
+class JsonEnvHighlight extends SpecialTextSpanBuilder {
+  JsonEnvHighlight({
+    this.keyHighlightStyle,
+    this.stringHighlightStyle,
+    this.numberHighlightStyle,
+    this.boolHighlightStyle,
+    this.nullHighlightStyle,
+    this.specialCharHighlightStyle,
+    this.commonTextStyle,
+    required this.isFormatting,
+  });
+
+  final TextStyle? keyHighlightStyle;
+  final TextStyle? stringHighlightStyle;
+  final TextStyle? numberHighlightStyle;
+  final TextStyle? boolHighlightStyle;
+  final TextStyle? nullHighlightStyle;
+  final TextStyle? specialCharHighlightStyle;
+  final TextStyle? commonTextStyle;
+  final bool isFormatting;
+
+  @override
+  TextSpan build(
+    String data, {
+    TextStyle? textStyle,
+    SpecialTextGestureTapCallback? onTap,
+  }) {
+    final spans = <InlineSpan>[];
+    int offset = 0;
+
+    data.splitMapJoin(
+      RegExp(
+        r'\".*?\"\s*:|\".*?\"|\s*\b(\d+(\.\d+)?)\b|\b(true|false|null)\b|[{}\[\],]',
+      ),
+      onMatch: (m) {
+        final word = m.group(0)!;
+        if (isFormatting) {
+          final style = _styleForToken(word);
+          spans.addAll(_buildWithEnv(word, style, offset));
+        } else {
+          spans.addAll(_buildWithEnv(word, commonTextStyle, offset));
+        }
+        offset += word.length;
+        return '';
+      },
+      onNonMatch: (n) {
+        spans.addAll(_buildWithEnv(n, commonTextStyle, offset));
+        offset += n.length;
+        return '';
+      },
+    );
+
+    return TextSpan(children: spans);
+  }
+
+  TextStyle? _styleForToken(String token) {
+    if (RegExp(r'\".*?\"\s*:').hasMatch(token)) {
+      return keyHighlightStyle;
+    }
+    if (RegExp(r'\".*?\"').hasMatch(token)) {
+      return stringHighlightStyle;
+    }
+    if (RegExp(r'\s*\b(\d+(\.\d+)?)\b').hasMatch(token)) {
+      return numberHighlightStyle;
+    }
+    if (RegExp(r'\b(true|false)\b').hasMatch(token)) {
+      return boolHighlightStyle;
+    }
+    if (RegExp(r'\bnull\b').hasMatch(token)) {
+      return nullHighlightStyle;
+    }
+    if (RegExp(r'[{}\[\],:]').hasMatch(token)) {
+      return specialCharHighlightStyle;
+    }
+    return commonTextStyle;
+  }
+
+  List<InlineSpan> _buildWithEnv(String text, TextStyle? style, int baseOffset) {
+    if (text.isEmpty) {
+      return const [];
+    }
+
+    final spans = <InlineSpan>[];
+    int last = 0;
+    for (final match in kEnvVarRegEx.allMatches(text)) {
+      if (match.start > last) {
+        spans.add(TextSpan(text: text.substring(last, match.start), style: style));
+      }
+
+      final token = match.group(0)!;
+      final key = token.substring(2, token.length - 2);
+      spans.add(
+        ExtendedWidgetSpan(
+          actualText: token,
+          start: baseOffset + match.start,
+          alignment: PlaceholderAlignment.middle,
+          child: EnvVarSpan(variableKey: key),
+        ),
+      );
+      last = match.end;
+    }
+
+    if (last < text.length) {
+      spans.add(TextSpan(text: text.substring(last), style: style));
+    }
+
+    if (spans.isEmpty) {
+      spans.add(TextSpan(text: text, style: style));
+    }
+
+    return spans;
+  }
+
+  @override
+  SpecialText? createSpecialText(
+    String flag, {
+    TextStyle? textStyle,
+    SpecialTextGestureTapCallback? onTap,
+    required int index,
+  }) {
+    return null;
+  }
+}

--- a/lib/widgets/editor_json.dart
+++ b/lib/widgets/editor_json.dart
@@ -2,8 +2,10 @@ import 'dart:math' as math;
 import 'package:apidash_design_system/apidash_design_system.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:multi_trigger_autocomplete_plus/multi_trigger_autocomplete_plus.dart';
 import 'package:json_field_editor/json_field_editor.dart';
 import 'package:apidash/consts.dart';
+import 'package:apidash/screens/common_widgets/common_widgets.dart';
 
 class JsonTextFieldEditor extends StatefulWidget {
   const JsonTextFieldEditor({
@@ -85,6 +87,45 @@ class _JsonTextFieldEditorState extends State<JsonTextFieldEditor> {
 
   @override
   Widget build(BuildContext context) {
+    final codeStyle = kCodeStyle.copyWith(
+      fontSize: Theme.of(context).textTheme.bodyMedium?.fontSize,
+    );
+
+    final keyStyle = kCodeStyle.copyWith(
+      color:
+          widget.isDark ? kDarkCodeTheme['attr']?.color : kLightCodeTheme['attr']?.color,
+      fontWeight: FontWeight.bold,
+    );
+
+    final stringStyle = kCodeStyle.copyWith(
+      color: widget.isDark
+          ? kDarkCodeTheme['string']?.color
+          : kLightCodeTheme['string']?.color,
+    );
+
+    final numberStyle = kCodeStyle.copyWith(
+      color: widget.isDark
+          ? kDarkCodeTheme['number']?.color
+          : kLightCodeTheme['number']?.color,
+    );
+
+    final boolStyle = kCodeStyle.copyWith(
+      color: widget.isDark
+          ? kDarkCodeTheme['literal']?.color
+          : kLightCodeTheme['literal']?.color,
+    );
+
+    final nullStyle = kCodeStyle.copyWith(
+      color: widget.isDark
+          ? kDarkCodeTheme['variable']?.color
+          : kLightCodeTheme['variable']?.color,
+    );
+
+    final specialCharStyle = kCodeStyle.copyWith(
+      color:
+          widget.isDark ? kDarkCodeTheme['root']?.color : kLightCodeTheme['root']?.color,
+    );
+
     return Stack(
       children: [
         CallbackShortcuts(
@@ -93,89 +134,87 @@ class _JsonTextFieldEditorState extends State<JsonTextFieldEditor> {
               insertTab();
             },
           },
-          child: JsonField(
-            key: ValueKey("${widget.fieldKey}-fld"),
-            fieldKey: widget.fieldKey,
-            commonTextStyle: kCodeStyle.copyWith(
-              color: widget.isDark
-                  ? kDarkCodeTheme['root']?.color
-                  : kLightCodeTheme['root']?.color,
-            ),
-            specialCharHighlightStyle: kCodeStyle.copyWith(
-              color: widget.isDark
-                  ? kDarkCodeTheme['root']?.color
-                  : kLightCodeTheme['root']?.color,
-            ),
-            stringHighlightStyle: kCodeStyle.copyWith(
-              color: widget.isDark
-                  ? kDarkCodeTheme['string']?.color
-                  : kLightCodeTheme['string']?.color,
-            ),
-            numberHighlightStyle: kCodeStyle.copyWith(
-              color: widget.isDark
-                  ? kDarkCodeTheme['number']?.color
-                  : kLightCodeTheme['number']?.color,
-            ),
-            boolHighlightStyle: kCodeStyle.copyWith(
-              color: widget.isDark
-                  ? kDarkCodeTheme['literal']?.color
-                  : kLightCodeTheme['literal']?.color,
-            ),
-            nullHighlightStyle: kCodeStyle.copyWith(
-              color: widget.isDark
-                  ? kDarkCodeTheme['variable']?.color
-                  : kLightCodeTheme['variable']?.color,
-            ),
-            keyHighlightStyle: kCodeStyle.copyWith(
-              color: widget.isDark
-                  ? kDarkCodeTheme['attr']?.color
-                  : kLightCodeTheme['attr']?.color,
-              fontWeight: FontWeight.bold,
-            ),
-            // errorContainerDecoration: BoxDecoration(
-            //   color: Theme.of(context).colorScheme.error.withOpacity(
-            //         kForegroundOpacity,
-            //       ),
-            //   borderRadius: kBorderRadius8,
-            // ),
-            // TODO: Show error message in Global Status bar
-            // showErrorMessage: true,
-            isFormatting: true,
-            controller: controller,
+          child: MultiTriggerAutocomplete(
+            key: Key('${widget.fieldKey}-json-mta'),
+            textEditingController: controller,
             focusNode: editorFocusNode,
-            keyboardType: TextInputType.multiline,
-            expands: true,
-            maxLines: null,
-            readOnly: widget.readOnly,
-            style: kCodeStyle.copyWith(
-              fontSize: Theme.of(context).textTheme.bodyMedium?.fontSize,
-            ),
-            textAlignVertical: TextAlignVertical.top,
-            onChanged: widget.onChanged,
-            onTapOutside: (PointerDownEvent event) {
-              editorFocusNode.unfocus();
+            optionsWidthFactor: 1,
+            autocompleteTriggers: [
+              AutocompleteTrigger(
+                trigger: '{{',
+                triggerEnd: '}}',
+                triggerOnlyAfterSpace: false,
+                optionsViewBuilder: (context, autocompleteQuery, ctrl) {
+                  return EnvironmentTriggerOptions(
+                    query: autocompleteQuery.query,
+                    onSuggestionTap: (suggestion) {
+                      final autocomplete = MultiTriggerAutocomplete.of(context);
+                      autocomplete.acceptAutocompleteOption(
+                        suggestion.variable.key,
+                      );
+                      widget.onChanged?.call(ctrl.text);
+                    },
+                  );
+                },
+              ),
+            ],
+            fieldViewBuilder: (context, textEditingController, focusNode) {
+              return JsonField(
+                key: ValueKey("${widget.fieldKey}-fld"),
+                fieldKey: widget.fieldKey,
+                commonTextStyle: codeStyle,
+                specialCharHighlightStyle: specialCharStyle,
+                stringHighlightStyle: stringStyle,
+                numberHighlightStyle: numberStyle,
+                boolHighlightStyle: boolStyle,
+                nullHighlightStyle: nullStyle,
+                keyHighlightStyle: keyStyle,
+                jsonSpecialTextSpanBuilder: JsonEnvHighlight(
+                  isFormatting: true,
+                  commonTextStyle: codeStyle,
+                  specialCharHighlightStyle: specialCharStyle,
+                  stringHighlightStyle: stringStyle,
+                  numberHighlightStyle: numberStyle,
+                  boolHighlightStyle: boolStyle,
+                  nullHighlightStyle: nullStyle,
+                  keyHighlightStyle: keyStyle,
+                ),
+                isFormatting: true,
+                controller: controller,
+                focusNode: focusNode,
+                keyboardType: TextInputType.multiline,
+                expands: true,
+                maxLines: null,
+                readOnly: widget.readOnly,
+                style: codeStyle,
+                textAlignVertical: TextAlignVertical.top,
+                onChanged: widget.onChanged,
+                onTapOutside: (PointerDownEvent event) {
+                  editorFocusNode.unfocus();
+                },
+                decoration: InputDecoration(
+                  hintText: widget.hintText ?? kHintContent,
+                  hintStyle: TextStyle(
+                    color: Theme.of(context).colorScheme.outlineVariant,
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: kBorderRadius8,
+                    borderSide: BorderSide(
+                      color: Theme.of(context).colorScheme.outlineVariant,
+                    ),
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: kBorderRadius8,
+                    borderSide: BorderSide(
+                      color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                    ),
+                  ),
+                  filled: true,
+                  hoverColor: kColorTransparent,
+                  fillColor: Theme.of(context).colorScheme.surfaceContainerLowest,
+                ),
+              );
             },
-            decoration: InputDecoration(
-              hintText: widget.hintText ?? kHintContent,
-              hintStyle: TextStyle(
-                color: Theme.of(context).colorScheme.outlineVariant,
-              ),
-              focusedBorder: OutlineInputBorder(
-                borderRadius: kBorderRadius8,
-                borderSide: BorderSide(
-                  color: Theme.of(context).colorScheme.outlineVariant,
-                ),
-              ),
-              enabledBorder: OutlineInputBorder(
-                borderRadius: kBorderRadius8,
-                borderSide: BorderSide(
-                  color: Theme.of(context).colorScheme.surfaceContainerHighest,
-                ),
-              ),
-              filled: true,
-              hoverColor: kColorTransparent,
-              fillColor: Theme.of(context).colorScheme.surfaceContainerLowest,
-            ),
           ),
         ),
         Align(

--- a/packages/json_field_editor/lib/src/json_field.dart
+++ b/packages/json_field_editor/lib/src/json_field.dart
@@ -84,6 +84,7 @@ class JsonField extends ExtendedTextField {
     this.showErrorMessage = false,
     this.isFormatting = true,
     this.doInitFormatting = false,
+    this.jsonSpecialTextSpanBuilder,
     this.onError,
   });
 
@@ -128,6 +129,12 @@ class JsonField extends ExtendedTextField {
 
   /// Callback for the error message.
   final Function(String?)? onError;
+
+  /// Optional special text span builder override.
+  ///
+  /// If null, JsonField uses the built-in JsonHighlight.
+  final SpecialTextSpanBuilder? jsonSpecialTextSpanBuilder;
+
   @override
   final JsonTextFieldController? controller;
 
@@ -236,16 +243,18 @@ class JsonFieldState extends State<JsonField> {
           showCursor: widget.showCursor,
           smartDashesType: widget.smartDashesType,
           smartQuotesType: widget.smartQuotesType,
-          specialTextSpanBuilder: JsonHighlight(
-            boolHighlightStyle: boolHighlightStyle,
-            keyHighlightStyle: keyHighlightStyle,
-            nullHighlightStyle: nullHighlightStyle,
-            numberHighlightStyle: numberHighlightStyle,
-            specialCharHighlightStyle: stringHighlightStyle,
-            stringHighlightStyle: stringHighlightStyle,
-            commonTextStyle: commonTextStyle,
-            isFormating: widget.isFormatting,
-          ),
+          specialTextSpanBuilder:
+              widget.jsonSpecialTextSpanBuilder ??
+              JsonHighlight(
+                boolHighlightStyle: boolHighlightStyle,
+                keyHighlightStyle: keyHighlightStyle,
+                nullHighlightStyle: nullHighlightStyle,
+                numberHighlightStyle: numberHighlightStyle,
+                specialCharHighlightStyle: stringHighlightStyle,
+                stringHighlightStyle: stringHighlightStyle,
+                commonTextStyle: commonTextStyle,
+                isFormating: widget.isFormatting,
+              ),
           style: widget.style,
           textAlign: widget.textAlign,
           textAlignVertical: widget.textAlignVertical,

--- a/test/screens/common_widgets/json_env_highlight_test.dart
+++ b/test/screens/common_widgets/json_env_highlight_test.dart
@@ -1,0 +1,40 @@
+import 'package:apidash/screens/common_widgets/common_widgets.dart';
+import 'package:extended_text_field/extended_text_field.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  List<ExtendedWidgetSpan> collectExtendedWidgetSpans(List<InlineSpan> spans) {
+    final result = <ExtendedWidgetSpan>[];
+    for (final span in spans) {
+      if (span is ExtendedWidgetSpan) {
+        result.add(span);
+      } else if (span is TextSpan && span.children != null) {
+        result.addAll(collectExtendedWidgetSpans(span.children!));
+      }
+    }
+    return result;
+  }
+
+  test('JsonEnvHighlight renders env tokens as EnvVarSpan widgets', () {
+    final highlight = JsonEnvHighlight(
+      isFormatting: true,
+      commonTextStyle: const TextStyle(),
+      keyHighlightStyle: const TextStyle(),
+      stringHighlightStyle: const TextStyle(),
+      numberHighlightStyle: const TextStyle(),
+      boolHighlightStyle: const TextStyle(),
+      nullHighlightStyle: const TextStyle(),
+      specialCharHighlightStyle: const TextStyle(),
+    );
+
+    final span = highlight.build('{"token":"{{API_KEY}}"}');
+    final children = span.children ?? const <InlineSpan>[];
+    final envSpans = collectExtendedWidgetSpans(children);
+
+    expect(envSpans, isNotEmpty);
+    final envSpan = envSpans.first;
+    expect(envSpan.actualText, '{{API_KEY}}');
+    expect(envSpan.child, isA<EnvVarSpan>());
+  });
+}

--- a/test/widgets/editor_json_env_adapter_test.dart
+++ b/test/widgets/editor_json_env_adapter_test.dart
@@ -1,0 +1,70 @@
+import 'package:apidash/consts.dart';
+import 'package:apidash/providers/providers.dart';
+import 'package:apidash/screens/common_widgets/common_widgets.dart';
+import 'package:apidash/widgets/editor_json.dart';
+import 'package:apidash_core/apidash_core.dart';
+import 'package:extended_text_field/extended_text_field.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_portal/flutter_portal.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:multi_trigger_autocomplete_plus/multi_trigger_autocomplete_plus.dart';
+
+import '../providers/helpers.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await testSetUpTempDirForHive();
+  });
+
+  const envMap = {
+    kGlobalEnvironmentId: [
+      EnvironmentVariableModel(key: 'API_KEY', value: 'xyz'),
+    ],
+    'active-env': [
+      EnvironmentVariableModel(key: 'TOKEN', value: 'abc'),
+    ],
+  };
+
+  testWidgets('JsonTextFieldEditor renders env tokens with JSON adapter',
+      (tester) async {
+    String lastValue = '';
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          availableEnvironmentVariablesStateProvider
+              .overrideWith((ref) => envMap),
+          activeEnvironmentIdStateProvider.overrideWith((ref) => 'active-env'),
+        ],
+        child: Portal(
+          child: MaterialApp(
+            home: Scaffold(
+              body: JsonTextFieldEditor(
+                fieldKey: 'json-editor-test',
+                initialValue: '{"auth":""}',
+                onChanged: (value) => lastValue = value,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(MultiTriggerAutocomplete), findsOneWidget);
+
+    final editableFinder = find.byType(EditableText);
+    expect(editableFinder, findsOneWidget);
+
+    await tester.tap(editableFinder);
+    await tester.pump();
+    tester.testTextInput.enterText('{"auth":"{{TOKEN}}"}');
+    await tester.pumpAndSettle();
+
+    expect(find.byType(EnvVarSpan), findsWidgets);
+    expect(find.byTooltip('Format JSON'), findsOneWidget);
+    expect(lastValue, contains('{{TOKEN}}'));
+  });
+}


### PR DESCRIPTION
## PR Description

Implements full environment variable authoring UX for **JSON request bodies** via an adapter layer.  

**Key changes:**
- JSON adapter layer in `lib/widgets/editor_json.dart` adding `{{...}}` autocomplete around `JsonField`.
- Preserves JSON formatting, linting, and highlighting.
- New env-aware JSON highlighter in `lib/screens/common_widgets/json_env_highlight.dart` with inline token rendering + hover popover (`EnvVarSpan`).
- JsonField extension point in `packages/json_field_editor/lib/src/json_field.dart` to accept adapter span builder.

**Validation:**
- Focused tests passing:  
  - `test/screens/common_widgets/json_env_highlight_test.dart`  
  - `test/widgets/editor_json_env_adapter_test.dart`  
- Unrelated files (`run-local.ps1`) not included.

---

## Related Issues

- Closes #590 (JSON sub-issue #592)

---

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

### Added/updated tests?
- [x] Yes, focused widget tests for JSON env-trigger suggestions, inline token rendering, and hover popovers

### OS on which you have developed and tested the feature
- [x] Windows 