### PR TITLE
test+docs: add form env substitution regression coverage

### DIFF
--- a/doc/user_guide/env_user_guide.md
+++ b/doc/user_guide/env_user_guide.md
@@ -51,10 +51,13 @@ When constructing a request, insert the variable into a field by typing the vari
 - URL field.
 - Params (key & value).
 - Header (key & value).
+- Request body (Text).
+- Request body (JSON).
+- Form body fields (key & value) for Form URL-Encoded and Multipart Form Data.
 
 > Note: The Header key field supports variable substitution but does not offer highlighting or suggestions.
 
-4. **Checing scope and value**
+4. **Checking scope and value**
 
 ![Image](./images/env/active_variable.png)
 

--- a/test/utils/envvar_utils_test.dart
+++ b/test/utils/envvar_utils_test.dart
@@ -280,6 +280,61 @@ void main() {
               httpRequestModel, envMap, activeEnvironmentId),
           expected);
     });
+
+    test(
+        "Testing substituteHttpRequestModel with environment variables in form data names and values",
+        () {
+      const httpRequestModel = HttpRequestModel(
+        url: "{{url}}/submit",
+        bodyContentType: ContentType.formdata,
+        formData: [
+          FormDataModel(
+            name: "{{header_name}}",
+            value: "{{token}}",
+            type: FormDataType.text,
+          ),
+          FormDataModel(
+            name: "file_{{num}}",
+            value: "/tmp/upload.txt",
+            type: FormDataType.file,
+          ),
+        ],
+      );
+
+      Map<String?, List<EnvironmentVariableModel>> envMap = {
+        kGlobalEnvironmentId: globalVars,
+        "activeEnvId": activeEnvVars,
+        "activeEnvId2": [
+          const EnvironmentVariableModel(
+            key: "header_name",
+            value: "X-Token",
+          ),
+        ],
+      };
+
+      const activeEnvironmentId = "activeEnvId2";
+      const expected = HttpRequestModel(
+        url: "api.foss42.com/submit",
+        bodyContentType: ContentType.formdata,
+        formData: [
+          FormDataModel(
+            name: "X-Token",
+            value: "token",
+            type: FormDataType.text,
+          ),
+          FormDataModel(
+            name: "file_5670000",
+            value: "/tmp/upload.txt",
+            type: FormDataType.file,
+          ),
+        ],
+      );
+
+      expect(
+          substituteHttpRequestModel(
+              httpRequestModel, envMap, activeEnvironmentId),
+          expected);
+    });
   });
 
   group("Testing getEnvironmentTriggerSuggestions function", () {


### PR DESCRIPTION
## PR Description

Completes the **environment variable authoring UX** for request bodies by adding **Form body regression coverage** and updating docs.  

**Key changes:**
- Added regression tests for form-body env substitution in `test/utils/envvar_utils_test.dart`.
- Updated environment variable support documentation for request bodies (Text, JSON, and Form key/value fields) in `doc/user_guide/env_user_guide.md`.

**Validation:**
- Focused tests passed: `flutter test test/utils/envvar_utils_test.dart`.
- Scope clean: only these two files committed; untracked `run-local.ps1` not included.

---

## Related Issues

- Completes parent task #590 (sub-issue coverage for Form body)

---

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

### Added/updated tests?
- [x] Yes, regression coverage for Form body env substitution

### OS on which you have developed and tested the feature
- [x] Windows 
---
