### PR TITLE
docs: update inline rename behavior in collections guide

### DIFF
--- a/doc/user_guide/collections_guide.md
+++ b/doc/user_guide/collections_guide.md
@@ -12,7 +12,7 @@ API Dash organizes your API requests in a single, ordered collection. You can ad
 
 Give your requests meaningful names to find them quickly:
 
-- **Desktop:** Double-click a request in the sidebar to edit its name inline. Press **Enter** to save or **Escape** to cancel.
+- **Desktop:** Right-click a request in the sidebar and select **Rename** from the context menu, or click the **⋮** menu icon on the selected card and choose **Rename**. Edit the name inline, then press **Enter** to save or click outside to confirm.
 - **Mobile:** Long-press a request to see the full name tooltip, or use the context menu to rename.
 
 > **Tip:** Hovering on Desktop or long-pressing on Mobile displays a tooltip with the full request name for requests with long names.


### PR DESCRIPTION
## PR Description

Updated `collections_guide.md` to reflect the current behavior for renaming a request in the sidebar.

The documentation previously mentioned double-click to rename inline, but this behavior is currently disabled due to UX concerns. The guide now reflects the correct right-click → Rename flow.

## Related Issues

* N/A (docs update based on discussion)

### Checklist

* [x] I have gone through the contributing guide
* [x] I have updated my branch and synced it with project `main` branch before making this PR *(skip if you didn't sync; don’t falsely check it)*
* [ ] I am using the latest Flutter stable branch (run `flutter upgrade` and verify) *(not applicable for docs-only change)*
* [ ] I have run the tests (`flutter test`) and all tests are passing *(not applicable for docs-only change)*

## Added/updated tests?

* [ ] Yes
* [x] No, and this is why: This PR only updates documentation and does not modify application logic.

## OS on which you have developed and tested the feature?

* [x] Windows  *(or whichever you're actually using)*
* [ ] macOS
* [ ] Linux