### PR TITLE
Show JSON editor error in global status bar

### DIFF
--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_body.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_body.dart
@@ -3,6 +3,7 @@ import 'package:apidash_design_system/apidash_design_system.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:apidash/providers/providers.dart';
+import 'package:apidash/terminal/terminal.dart';
 import 'package:apidash/widgets/widgets.dart';
 import 'package:apidash/consts.dart';
 import 'request_form_data.dart';
@@ -56,6 +57,17 @@ class EditRequestBody extends ConsumerWidget {
                         ref
                             .read(collectionStateNotifierProvider.notifier)
                             .update(body: value);
+                      },
+                      onError: (String? error) {
+                        if (error != null) {
+                          ref.read(terminalStateProvider.notifier).logSystem(
+                                category: 'validation',
+                                message: error,
+                                level: TerminalLevel.error,
+                              );
+                          ref.read(showTerminalBadgeProvider.notifier).state =
+                              true;
+                        }
                       },
                       hintText: kHintJson,
                     ),

--- a/lib/widgets/editor_json.dart
+++ b/lib/widgets/editor_json.dart
@@ -10,6 +10,7 @@ class JsonTextFieldEditor extends StatefulWidget {
     super.key,
     required this.fieldKey,
     this.onChanged,
+    this.onError,
     this.initialValue,
     this.hintText,
     this.readOnly = false,
@@ -18,6 +19,9 @@ class JsonTextFieldEditor extends StatefulWidget {
 
   final String fieldKey;
   final Function(String)? onChanged;
+  /// Called when JSON parse error changes. Error message or null when valid.
+  /// Use e.g. to show the error in the global status bar (Terminal).
+  final Function(String?)? onError;
   final String? initialValue;
   final String? hintText;
   final bool readOnly;
@@ -138,8 +142,7 @@ class _JsonTextFieldEditorState extends State<JsonTextFieldEditor> {
             //       ),
             //   borderRadius: kBorderRadius8,
             // ),
-            // TODO: Show error message in Global Status bar
-            // showErrorMessage: true,
+            onError: widget.onError,
             isFormatting: true,
             controller: controller,
             focusNode: editorFocusNode,


### PR DESCRIPTION
When the request body is JSON, invalid content is now reported in the global status bar (Terminal), consistent with other validation errors.

- Add optional onError callback to JsonTextFieldEditor and pass it through to the underlying JsonField.
- In the request body screen, onError logs the parse error to the Terminal with category 'validation' and shows the terminal badge so users can open the Terminal to see the exact error.