### PR TITLE
Add paste-from-text to Import dialog

### DIFF
--- a/lib/importer/import_dialog.dart
+++ b/lib/importer/import_dialog.dart
@@ -5,14 +5,47 @@ import 'package:apidash/providers/providers.dart';
 import 'package:apidash/widgets/widgets.dart';
 import 'importer.dart';
 
+void _handleImportContent(
+  BuildContext context,
+  WidgetRef ref,
+  ScaffoldMessengerState sm,
+  String content,
+  [String? sourceLabel],
+) {
+  final importFormatType = ref.read(importFormatStateProvider);
+  sm.hideCurrentSnackBar();
+  kImporter.getHttpRequestModelList(importFormatType, content).then(
+    (importedRequestModels) {
+      if (importedRequestModels != null) {
+        if (importedRequestModels.isEmpty) {
+          sm.showSnackBar(getSnackBar("No requests imported", small: false));
+        } else {
+          for (var model in importedRequestModels.reversed) {
+            ref
+                .read(collectionStateNotifierProvider.notifier)
+                .addRequestModel(model.$2, name: model.$1);
+          }
+          sm.showSnackBar(getSnackBar(
+              "Successfully imported ${importedRequestModels.length} requests",
+              small: false));
+        }
+        if (!context.mounted) return;
+        Navigator.of(context).pop();
+      } else {
+        final err = sourceLabel != null
+            ? "Unable to parse $sourceLabel"
+            : "Unable to parse pasted content";
+        sm.showSnackBar(getSnackBar(err, small: false));
+      }
+    },
+  );
+}
+
 void importToCollectionPane(
   BuildContext context,
   WidgetRef ref,
   ScaffoldMessengerState sm,
 ) {
-  // TODO: The dialog must have a feature to paste contents in a text field
-  // Also, a mechanism can be added where on importing a file it shows the
-  // contents in the text field and then the user presses ok to add it to collection
   showImportDialog(
     context: context,
     importFormat: ref.watch(importFormatStateProvider),
@@ -22,44 +55,19 @@ void importToCollectionPane(
       }
     },
     onFileDropped: (file) {
-      final importFormatType = ref.read(importFormatStateProvider);
       sm.hideCurrentSnackBar();
       file.readAsString().then(
         (content) {
-          kImporter
-              .getHttpRequestModelList(importFormatType, content)
-              .then((importedRequestModels) {
-            if (importedRequestModels != null) {
-              if (importedRequestModels.isEmpty) {
-                sm.showSnackBar(
-                    getSnackBar("No requests imported", small: false));
-              } else {
-                for (var model in importedRequestModels.reversed) {
-                  ref
-                      .read(collectionStateNotifierProvider.notifier)
-                      .addRequestModel(
-                        model.$2,
-                        name: model.$1,
-                      );
-                }
-                sm.showSnackBar(getSnackBar(
-                    "Successfully imported ${importedRequestModels.length} requests",
-                    small: false));
-              }
-              // Solves - Do not use BuildContexts across async gaps
-              if (!context.mounted) return;
-              Navigator.of(context).pop();
-            } else {
-              var err = "Unable to parse ${file.name}";
-              sm.showSnackBar(getSnackBar(err, small: false));
-            }
-          });
+          _handleImportContent(context, ref, sm, content, file.name);
         },
         onError: (e) {
-          var err = "Unable to import ${file.name}";
-          sm.showSnackBar(getSnackBar(err, small: false));
+          sm.showSnackBar(
+              getSnackBar("Unable to import ${file.name}", small: false));
         },
       );
+    },
+    onPastedContentImport: (content) {
+      _handleImportContent(context, ref, sm, content);
     },
   );
 }

--- a/lib/widgets/dialog_import.dart
+++ b/lib/widgets/dialog_import.dart
@@ -10,45 +10,124 @@ showImportDialog({
   required ImportFormat importFormat,
   Function(ImportFormat?)? onImportFormatChange,
   Function(XFile)? onFileDropped,
+  Function(String)? onPastedContentImport,
 }) {
   showDialog(
     context: context,
     builder: (context) {
-      var fmt = importFormat;
-      return StatefulBuilder(
-        builder: (context, StateSetter setState) {
-          return AlertDialog(
-            contentPadding: kP12,
-            content: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    const Text(kLabelImport),
-                    kHSpacer8,
-                    DropdownButtonImportFormat(
-                      importFormat: fmt,
-                      onChanged: (format) {
-                        if (format != null) {
-                          onImportFormatChange?.call(format);
-                          setState(() {
-                            fmt = format;
-                          });
-                        }
-                      },
-                    ),
-                  ],
-                ),
-                kVSpacer6,
-                DragAndDropArea(
-                  onFileDropped: onFileDropped,
-                ),
-              ],
-            ),
-          );
-        },
+      return AlertDialog(
+        contentPadding: kP12,
+        content: _ImportDialogContent(
+          importFormat: importFormat,
+          onImportFormatChange: onImportFormatChange,
+          onFileDropped: onFileDropped,
+          onPastedContentImport: onPastedContentImport,
+        ),
       );
     },
   );
+}
+
+class _ImportDialogContent extends StatefulWidget {
+  const _ImportDialogContent({
+    required this.importFormat,
+    this.onImportFormatChange,
+    this.onFileDropped,
+    this.onPastedContentImport,
+  });
+
+  final ImportFormat importFormat;
+  final Function(ImportFormat?)? onImportFormatChange;
+  final Function(XFile)? onFileDropped;
+  final Function(String)? onPastedContentImport;
+
+  @override
+  State<_ImportDialogContent> createState() => _ImportDialogContentState();
+}
+
+class _ImportDialogContentState extends State<_ImportDialogContent> {
+  late ImportFormat _fmt;
+  final TextEditingController _pasteController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _fmt = widget.importFormat;
+  }
+
+  @override
+  void didUpdateWidget(_ImportDialogContent oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.importFormat != widget.importFormat) {
+      _fmt = widget.importFormat;
+    }
+  }
+
+  @override
+  void dispose() {
+    _pasteController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Text(kLabelImport),
+              kHSpacer8,
+              DropdownButtonImportFormat(
+                importFormat: _fmt,
+                onChanged: (format) {
+                  if (format != null) {
+                    widget.onImportFormatChange?.call(format);
+                    setState(() {
+                      _fmt = format;
+                    });
+                  }
+                },
+              ),
+            ],
+          ),
+          kVSpacer6,
+          DragAndDropArea(
+            onFileDropped: widget.onFileDropped,
+          ),
+          if (widget.onPastedContentImport != null) ...[
+            kVSpacer10,
+            const Text('Or paste content below'),
+            kVSpacer6,
+            TextField(
+              controller: _pasteController,
+              maxLines: 6,
+              minLines: 2,
+              decoration: const InputDecoration(
+                hintText: 'Paste cURL, Postman, Insomnia, or HAR content…',
+                border: OutlineInputBorder(),
+                contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              ),
+            ),
+            kVSpacer6,
+            Align(
+              alignment: Alignment.centerRight,
+              child: ADFilledButton(
+                onPressed: () {
+                  final content = _pasteController.text.trim();
+                  if (content.isNotEmpty) {
+                    widget.onPastedContentImport!.call(content);
+                  }
+                },
+                child: const Text('Import from pasted text'),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
 }


### PR DESCRIPTION
Add the ability to import requests by pasting content into the Import dialog,
in addition to drag-and-drop.

- Add an optional "Or paste content below" section to the import dialog with a 
   multiline text field and "Import from pasted text" button.
- Reuse the same parsing and collection-import logic for both file drop and
  pasted content (shared _handleImportContent helper).
- Refactor dialog content into a StatefulWidget so the paste field has a
  proper controller and is disposed when the dialog closes.
