### PR TITLE
docs: include sample audio URLs in testing guide

### DIFF
--- a/doc/dev_guide/api_endpoints_for_testing.md
+++ b/doc/dev_guide/api_endpoints_for_testing.md
@@ -44,7 +44,6 @@ A List of API endpoints that can be used for testing API Dash
 
 - https://freesound.org/data/previews/337/337049_3232293-hq.mp3
 - https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3
-- https://www.w3schools.com/html/horse.mp3
 - https://interactive-examples.mdn.mozilla.net/media/cc0-audio/t-rex-roar.mp3
 
 ## SSE


### PR DESCRIPTION
## PR Description

Added several public audio sample URLs to the `API Endpoints List` in the developer guide. Previously, the Audio section under testing endpoints was empty. These links provide reliable sources (MP3, WAV) for developers to test the response previewer functionality for different audio MIME types.

## Related Issues

- Closes N/A

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
- [ ] Yes
- [x] No, and this is why: This is a documentation change only, adding testing URLs to the developer guide.

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux
