### PR TITLE
docs: add note about missing script hint in user guide

### DIFF
--- a/doc/user_guide/scripting_user_guide.md
+++ b/doc/user_guide/scripting_user_guide.md
@@ -4,6 +4,13 @@ APIDash allows you to write JavaScript code that runs either **before** a reques
 
 The primary way to interact with APIDash data and functionality within these scripts is through the global `ad` object. This object provides structured access to request data, response data, environment variables, and logging utilities.
 
+> [!NOTE]
+> When you first open the **Pre-request** or **Post-response** script tabs, the editor might appear completely empty without any placeholder or hint text (this is a known UI limitation). To get started quickly, you can use the following example to verify it's working:
+> ```javascript
+> // Use JavaScript to modify this request dynamically
+> ad.console.log("Hello from APIDash Scripting!");
+> ```
+
 
 ## `ad.request` (Available in Pre-request Scripts Only)
 


### PR DESCRIPTION
## PR Description

Added a quick note in the scripting user guide. Currently, when a user opens the **Pre-request** or **Post-response** script tabs, the editor shows up completely empty without any hint text (due to a known limitation with the `CodeField` widget). 

This PR adds a helpful `> [!NOTE]` in the documentation along with a simple starter JavaScript snippet. This will help users understand that the editor is working fine and gives them code to copy-paste so they can get started quickly.

## Related Issues

- Closes # (Add the issue number here if there is one, otherwise you can just write N/A)

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [x] No, and this is why: This is just a simple documentation update in a Markdown (`.md`) file, so no code changes or tests are needed.

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux