### PR TITLE
fix: replace GutterStyle width:0 hack with GutterStyle.none

### DIFF
--- a/lib/widgets/editor_code.dart
+++ b/lib/widgets/editor_code.dart
@@ -35,13 +35,7 @@ class CodeEditor extends StatelessWidget {
         smartDashesType: SmartDashesType.enabled,
         smartQuotesType: SmartQuotesType.enabled,
         background: Theme.of(context).colorScheme.surfaceContainerLowest,
-        gutterStyle: GutterStyle(
-          width: 0, // TODO: Fix numbers size
-          margin: 2,
-          textAlign: TextAlign.left,
-          showFoldingHandles: false,
-          showLineNumbers: false,
-        ),
+        gutterStyle: GutterStyle.none,
         cursorColor: Theme.of(context).colorScheme.primary,
         controller: controller,
         textStyle: kCodeStyle.copyWith(


### PR DESCRIPTION
## PR Description
Fixes the TODO on line 39 of `editor_code.dart` where `width: 0` was used 
as a workaround to hide the code editor gutter. Replaced with `GutterStyle.none` 
which is the correct API provided by the `flutter_code_editor` package for 
hiding the gutter entirely. This removes 6 lines of unnecessary configuration 
with no behavior change.

## Related Issues
- Fixes TODO comment in `lib/widgets/editor_code.dart` line 39

### Checklist
- [x] I have gone through the contributing guide
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
- [x] No, and this is why: This is a one-line cleanup replacing a workaround with 
the correct API. No new functionality was added and existing behavior is unchanged, 
so no new tests are required.

## OS on which you have developed and tested the feature?
- [x] Windows
```

---

For the **Related Issues** field since there's no issue number, write:
```
Fixes TODO comment in `lib/widgets/editor_code.dart` line 39