### PR TITLE
Add selective delete option to History section

### DIFF
--- a/lib/providers/history_providers.dart
+++ b/lib/providers/history_providers.dart
@@ -3,6 +3,10 @@ import 'package:apidash/models/models.dart';
 import '../services/services.dart' show hiveHandler, HiveHandler;
 import '../utils/history_utils.dart';
 
+final isHistorySelectionModeProvider = StateProvider<bool>((ref) => false);
+
+final selectedHistoryItemIdsProvider = StateProvider<Set<String>>((ref) => {});
+
 final selectedHistoryIdStateProvider = StateProvider<String?>((ref) => null);
 
 final selectedRequestGroupIdStateProvider = StateProvider<String?>((ref) {
@@ -110,5 +114,36 @@ class HistoryMetaStateNotifier
     ref.read(selectedHistoryIdStateProvider.notifier).state = null;
     ref.read(selectedHistoryRequestModelProvider.notifier).state = null;
     loadHistoryMetas();
+  }
+
+  Future<void> deleteHistoryRequests(Set<String> ids) async {
+    if (ids.isEmpty || state == null) return;
+
+    // Remove from Hive
+    for (var id in ids) {
+      await hiveHandler.deleteHistoryRequest(id);
+      hiveHandler.deleteHistoryMeta(id);
+    }
+
+    // Update history ids list in Hive
+    final existingKeys = state!.keys.toList();
+    final updatedKeys = existingKeys.where((id) => !ids.contains(id)).toList();
+    hiveHandler.setHistoryIds(updatedKeys);
+
+    // Update State
+    final newState = Map<String, HistoryMetaModel>.from(state!);
+    newState.removeWhere((key, value) => ids.contains(key));
+    state = newState;
+
+    // Clear selection if current item got deleted
+    final currentSelectedId = ref.read(selectedHistoryIdStateProvider);
+    if (currentSelectedId != null && ids.contains(currentSelectedId)) {
+      ref.read(selectedHistoryIdStateProvider.notifier).state = null;
+      ref.read(selectedHistoryRequestModelProvider.notifier).state = null;
+    }
+
+    // Reset selection mode
+    ref.read(isHistorySelectionModeProvider.notifier).state = false;
+    ref.read(selectedHistoryItemIdsProvider.notifier).state = {};
   }
 }

--- a/lib/screens/history/history_sidebar.dart
+++ b/lib/screens/history/history_sidebar.dart
@@ -103,6 +103,8 @@ class _HistoryExpansionTileState extends ConsumerState<HistoryExpansionTile>
     final animation = Tween(begin: 0.0, end: 0.25).animate(animationController);
     final colorScheme = Theme.of(context).colorScheme;
     final selectedGroupId = ref.watch(selectedRequestGroupIdStateProvider);
+    final isSelectionMode = ref.watch(isHistorySelectionModeProvider);
+    final selectedIds = ref.watch(selectedHistoryItemIdsProvider);
     return ExpansionTile(
       dense: true,
       title: Row(
@@ -138,6 +140,9 @@ class _HistoryExpansionTileState extends ConsumerState<HistoryExpansionTile>
       initiallyExpanded: widget.initiallyExpanded,
       childrenPadding: kPv8 + kPe4,
       children: widget.requestGroups.values.map((item) {
+        final groupIds = item.map((e) => e.historyId).toSet();
+        final isItemChecked =
+            groupIds.isNotEmpty && selectedIds.containsAll(groupIds);
         return Padding(
           padding: kPv2 + kPh4,
           child: SidebarHistoryCard(
@@ -147,11 +152,24 @@ class _HistoryExpansionTileState extends ConsumerState<HistoryExpansionTile>
             method: item.first.method,
             isSelected: selectedGroupId == getHistoryRequestKey(item.first),
             requestGroupSize: item.length,
+            isSelectionMode: isSelectionMode,
+            isItemChecked: isItemChecked,
             onTap: () {
-              ref
-                  .read(historyMetaStateNotifier.notifier)
-                  .loadHistoryRequest(item.first.historyId);
-              kHisScaffoldKey.currentState?.closeDrawer();
+              if (isSelectionMode) {
+                final newSelectedIds = Set<String>.from(selectedIds);
+                if (isItemChecked) {
+                  newSelectedIds.removeAll(groupIds);
+                } else {
+                  newSelectedIds.addAll(groupIds);
+                }
+                ref.read(selectedHistoryItemIdsProvider.notifier).state =
+                    newSelectedIds;
+              } else {
+                ref
+                    .read(historyMetaStateNotifier.notifier)
+                    .loadHistoryRequest(item.first.historyId);
+                kHisScaffoldKey.currentState?.closeDrawer();
+              }
             },
           ),
         );

--- a/lib/screens/history/history_widgets/his_sidebar_header.dart
+++ b/lib/screens/history/history_widgets/his_sidebar_header.dart
@@ -12,63 +12,133 @@ class HistorySidebarHeader extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final mobileScaffoldKey = ref.read(mobileScaffoldKeyStateProvider);
     final sm = ScaffoldMessenger.of(context);
+    final isSelectionMode = ref.watch(isHistorySelectionModeProvider);
+    final selectedIds = ref.watch(selectedHistoryItemIdsProvider);
+
     return Padding(
       padding: kPe4,
       child: Row(
         children: [
           kHSpacer10,
           Text(
-            "History",
+            isSelectionMode ? "${selectedIds.length} selected" : "History",
             style: Theme.of(context).textTheme.titleMedium,
           ),
           const Spacer(),
-          ADIconButton(
-            icon: Icons.delete_forever,
-            iconSize: kButtonIconSizeLarge,
-            tooltip: "Clear History",
-            color: Theme.of(context).brightness == Brightness.dark
-                ? kColorDarkDanger
-                : kColorLightDanger,
-            onPressed: () {
-              showOkCancelDialog(
-                context,
-                dialogTitle: kTitleClearHistory,
-                content: kMsgClearHistory,
-                onClickOk: () async {
-                  sm.hideCurrentSnackBar();
-                  try {
-                    await ref
-                        .read(historyMetaStateNotifier.notifier)
-                        .clearAllHistory();
-                    sm.showSnackBar(getSnackBar(
-                      kMsgClearHistorySuccess,
-                    ));
-                  } catch (e) {
-                    debugPrint("Clear History Stack: $e");
-                    sm.showSnackBar(getSnackBar(
-                      kMsgClearHistoryError,
-                      color: kColorRed,
-                    ));
-                  }
-                },
-              );
-            },
-          ),
-          ADIconButton(
-            icon: Icons.manage_history_rounded,
-            iconSize: kButtonIconSizeLarge,
-            tooltip: "Manage History",
-            onPressed: () {
-              showHistoryRetentionDialog(
+          if (isSelectionMode) ...[
+            ADIconButton(
+              icon: Icons.done_all,
+              iconSize: kButtonIconSizeLarge,
+              tooltip: "Select All",
+              onPressed: () {
+                final historyMetas = ref.read(historyMetaStateNotifier);
+                if (historyMetas != null) {
+                  ref.read(selectedHistoryItemIdsProvider.notifier).state =
+                      historyMetas.keys.toSet();
+                }
+              },
+            ),
+            ADIconButton(
+              icon: Icons.delete_outline,
+              iconSize: kButtonIconSizeLarge,
+              tooltip: "Delete Selected",
+              color: Theme.of(context).brightness == Brightness.dark
+                  ? kColorDarkDanger
+                  : kColorLightDanger,
+              onPressed: selectedIds.isEmpty
+                  ? null
+                  : () {
+                showOkCancelDialog(
                   context,
-                  ref.read(settingsProvider.select(
-                          (value) => value.historyRetentionPeriod)), (value) {
-                ref.read(settingsProvider.notifier).update(
-                  historyRetentionPeriod: value,
+                  dialogTitle: "Delete Selected History",
+                  content:
+                  "Are you sure you want to delete the selected history items? This action cannot be undone.",
+                  onClickOk: () async {
+                    sm.hideCurrentSnackBar();
+                    try {
+                      await ref
+                          .read(historyMetaStateNotifier.notifier)
+                          .deleteHistoryRequests(selectedIds);
+                      sm.showSnackBar(getSnackBar(
+                        "Selected history deleted successfully",
+                      ));
+                    } catch (e) {
+                      debugPrint("Delete Selected History Stack: $e");
+                      sm.showSnackBar(getSnackBar(
+                        "Error deleting selected history",
+                        color: kColorRed,
+                      ));
+                    }
+                  },
                 );
-              });
-            },
-          ),
+              },
+            ),
+            ADIconButton(
+              icon: Icons.close,
+              iconSize: kButtonIconSizeLarge,
+              tooltip: "Cancel Selection",
+              onPressed: () {
+                ref.read(isHistorySelectionModeProvider.notifier).state = false;
+                ref.read(selectedHistoryItemIdsProvider.notifier).state = {};
+              },
+            ),
+          ] else ...[
+            ADIconButton(
+              icon: Icons.checklist,
+              iconSize: kButtonIconSizeLarge,
+              tooltip: "Select",
+              onPressed: () {
+                ref.read(isHistorySelectionModeProvider.notifier).state = true;
+              },
+            ),
+            ADIconButton(
+              icon: Icons.delete_forever,
+              iconSize: kButtonIconSizeLarge,
+              tooltip: "Clear History",
+              color: Theme.of(context).brightness == Brightness.dark
+                  ? kColorDarkDanger
+                  : kColorLightDanger,
+              onPressed: () {
+                showOkCancelDialog(
+                  context,
+                  dialogTitle: kTitleClearHistory,
+                  content: kMsgClearHistory,
+                  onClickOk: () async {
+                    sm.hideCurrentSnackBar();
+                    try {
+                      await ref
+                          .read(historyMetaStateNotifier.notifier)
+                          .clearAllHistory();
+                      sm.showSnackBar(getSnackBar(
+                        kMsgClearHistorySuccess,
+                      ));
+                    } catch (e) {
+                      debugPrint("Clear History Stack: $e");
+                      sm.showSnackBar(getSnackBar(
+                        kMsgClearHistoryError,
+                        color: kColorRed,
+                      ));
+                    }
+                  },
+                );
+              },
+            ),
+            ADIconButton(
+              icon: Icons.manage_history_rounded,
+              iconSize: kButtonIconSizeLarge,
+              tooltip: "Manage History",
+              onPressed: () {
+                showHistoryRetentionDialog(
+                    context,
+                    ref.read(settingsProvider.select(
+                            (value) => value.historyRetentionPeriod)), (value) {
+                  ref.read(settingsProvider.notifier).update(
+                    historyRetentionPeriod: value,
+                  );
+                });
+              },
+            ),
+          ],
           context.width <= kMinWindowSize.width
               ? IconButton(
             style: IconButton.styleFrom(

--- a/lib/widgets/card_sidebar_history.dart
+++ b/lib/widgets/card_sidebar_history.dart
@@ -14,6 +14,8 @@ class SidebarHistoryCard extends StatelessWidget {
     required this.method,
     this.isSelected = false,
     this.requestGroupSize = 1,
+    this.isSelectionMode = false,
+    this.isItemChecked = false,
     this.onTap,
   });
 
@@ -23,6 +25,8 @@ class SidebarHistoryCard extends StatelessWidget {
   final HTTPVerb method;
   final bool isSelected;
   final int requestGroupSize;
+  final bool isSelectionMode;
+  final bool isItemChecked;
   final Function()? onTap;
 
   @override
@@ -63,6 +67,19 @@ class SidebarHistoryCard extends StatelessWidget {
               height: 20,
               child: Row(
                 children: [
+                  if (isSelectionMode) ...[
+                    SizedBox(
+                      height: 20,
+                      width: 20,
+                      child: Checkbox(
+                        value: isItemChecked,
+                        onChanged: (value) {
+                          onTap?.call();
+                        },
+                      ),
+                    ),
+                    kHSpacer4,
+                  ],
                   SidebarRequestCardTextBox(
                     apiType: apiType,
                     method: method,


### PR DESCRIPTION
## PR Description

This PR adds a selective delete feature to the History section while keeping the existing delete-all functionality intact.

## Changes Made

- Added multi-selection support for history items
- Implemented delete selected functionality
- Preserved existing delete-all option
- Updated UI and state management logic

## Issue

Closes #1135 

https://github.com/user-attachments/assets/90cbacb7-c0c1-4c91-ae6a-ad33e2f66786



### Checklist
- [ ] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [ ] I have updated my branch and synced it with project `main` branch before making this PR
- [ ] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [ ] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_

## OS on which you have developed and tested the feature?

- [ ] Windows
- [ ] macOS
- [ ] Linux
