### PR TITLE
fix: spelling corrections in codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 In this release, we have added the following features:
 
 1. Create workspace (directory) to persist your entire data locally in the provided file-system location
-2. Environment varibles
+2. Environment variables
 3. GraphQL support
 4. Import requests from cURL & Postman Collection (v2.1)
 5. History of your requests & response

--- a/doc/dev_guide/openapi.md
+++ b/doc/dev_guide/openapi.md
@@ -93,7 +93,7 @@ void main(List<String> args) async {
 ### How to run
 
 - Create a new dart project, put the openapi spec file and this script there.
-- Add the depndency, `dart pub add openapi_spec: ^0.15.0`
+- Add the dependency, `dart pub add openapi_spec: ^0.15.0`
 - Run:
   - `dart run path/to/this/file`
 

--- a/doc/dev_guide/platform_specific_instructions.md
+++ b/doc/dev_guide/platform_specific_instructions.md
@@ -85,7 +85,7 @@ For more information on:
 - Gradle and Java version compatibility, you can refer to [Compatibility Matrix](https://docs.gradle.org/current/userguide/compatibility.html).
 - Gradle and Android Gradle Plugin compatibility, you can refer to [Update Gradle](https://developer.android.com/build/releases/gradle-plugin).
 
-Note : It is highly recommended that always ensure gradle and agp versions are compatible with your JDK version not the vice-versa and having atleast JDK 17 is recommmended.
+Note : It is highly recommended that always ensure gradle and agp versions are compatible with your JDK version not the vice-versa and having at least JDK 17 is recommended.
 
 ## Web  
 

--- a/doc/user_guide/env_user_guide.md
+++ b/doc/user_guide/env_user_guide.md
@@ -54,7 +54,7 @@ When constructing a request, insert the variable into a field by typing the vari
 
 > Note: The Header key field supports variable substitution but does not offer highlighting or suggestions.
 
-4. **Checing scope and value**
+4. **Checking scope and value**
 
 ![Image](./images/env/active_variable.png)
 

--- a/lib/codegen/dart/dio.dart
+++ b/lib/codegen/dart/dio.dart
@@ -74,7 +74,7 @@ class DartDioCodeGen {
         contentType == ContentType.formdata)) {
       final strContent = CodeExpression(Code('r\'\'\'$body\'\'\''));
       switch (contentType) {
-        // dio dosen't need pass `content-type` header when body is json or plain text
+        // dio doesn't need pass `content-type` header when body is json or plain text
         case ContentType.json:
           final convertImport = Directive.import('dart:convert', as: 'convert');
           sbf.writeln(convertImport.accept(emitter));

--- a/lib/codegen/php/curl.dart
+++ b/lib/codegen/php/curl.dart
@@ -145,7 +145,7 @@ echo $response . "\n";
         // renders the initial request init function call
         result += kStringRequestInit;
 
-        //renders the request temlate
+        //renders the request template
         var templateRequestOptsInit = jj.Template(kTemplateRequestOptsInit);
         result += templateRequestOptsInit
             .render({'method': requestModel.method.name});

--- a/lib/codegen/ruby/faraday.dart
+++ b/lib/codegen/ruby/faraday.dart
@@ -2,7 +2,7 @@ import 'package:apidash_core/apidash_core.dart';
 import 'package:jinja/jinja.dart' as jj;
 
 // Note that delete is a special case in Faraday as API Dash supports request
-// body inside delete reqest, but Faraday does not. Hence we need to manually
+// body inside delete request, but Faraday does not. Hence we need to manually
 // setup request body for delete request and add that to request.
 //
 // Refer https://lostisland.github.io/faraday/#/getting-started/quick-start?id=get-head-delete-trace

--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -489,7 +489,7 @@ const kHintText = "Enter text";
 const kHintJson = "Enter JSON";
 const kHintQuery = "Enter Query";
 // TODO: CodeField widget does not allow this hint. To be solved.
-const kHintScript = "// Use Javacript to modify this request dynamically";
+const kHintScript = "// Use Javascript to modify this request dynamically";
 // Response Pane
 const kLabelNotSent = "Not Sent";
 const kLabelResponse = "Response";

--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -503,7 +503,7 @@ class CollectionStateNotifier
         isStreamingResponse: isStreamingResponse,
       );
 
-      //AI-FORMATTING for Non Streaming Varaint
+      //AI-FORMATTING for Non Streaming Variant
       if (!streamingMode &&
           apiType == APIType.ai &&
           response.statusCode == 200) {

--- a/lib/templates/system_prompt_templates/apitool_bodygen_prompt.dart
+++ b/lib/templates/system_prompt_templates/apitool_bodygen_prompt.dart
@@ -11,7 +11,7 @@ Wherever you find this pattern replace it with the appropriate values)
 `TOOL_NAME`: The name of the API Tool, infer it from the function code
 `TOOL_DESCRIPTION`: The Description of the Tool, generate it based on the tool name
 `TOOL_PARAMS`: The example of parameters have been provided below, infer the parameters needed from the func body, it must be a dictionary
-`REQUIRED_PARAM_NAMES`: infer what parameters are required and add thier names in a list
+`REQUIRED_PARAM_NAMES`: infer what parameters are required and add their names in a list
 `INPUT_SCHEMA`: if this variable exists, then create a StructuredTool or DynamicStructuredTool schema of the input according to the language of the tool itself. 
 
 this is the general format of parameters:

--- a/packages/better_networking/CHANGELOG.md
+++ b/packages/better_networking/CHANGELOG.md
@@ -13,4 +13,4 @@
 
 ## 0.0.1
 
-- Intial release.
+- Initial release.

--- a/packages/better_networking/test/extensions/map_extensions_test.dart
+++ b/packages/better_networking/test/extensions/map_extensions_test.dart
@@ -66,7 +66,7 @@ void main() {
         expect(mapEx.getKeyContentType(), "content-type");
       });
 
-      test('Multiple occurence should return first', () {
+      test('Multiple occurrence should return first', () {
         Map mapEx = {1: "Test", "content-Type": "y", "content-type": "x"};
         expect(mapEx.getKeyContentType(), "content-Type");
       });
@@ -104,7 +104,7 @@ void main() {
       expect(mapEx.getValueContentType(), "x");
     });
 
-    test('Multiple occurence should return first', () {
+    test('Multiple occurrence should return first', () {
       Map mapEx = {1: "Test", "content-Type": "y", "content-type": "x"};
       expect(mapEx.getValueContentType(), "y");
     });

--- a/packages/json_explorer/README.md
+++ b/packages/json_explorer/README.md
@@ -172,7 +172,7 @@ JsonExplorer(
 )
 ```
 
-Or, folowing the same principle, change how the value looks for specific
+Or, following the same principle, change how the value looks for specific
 value types:
 
 ```dart

--- a/packages/json_explorer/lib/src/json_explorer_store.dart
+++ b/packages/json_explorer/lib/src/json_explorer_store.dart
@@ -6,7 +6,7 @@ import 'package:flutter/widgets.dart';
 /// A decoded json object can be converted to a [NodeViewModelState] by calling
 /// the [buildViewModelNodes] method.
 ///
-/// A node item can be eiter a class root, an array or a single
+/// A node item can be either a class root, an array or a single
 /// class/array field.
 ///
 ///
@@ -686,7 +686,7 @@ class JsonExplorerStore extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Finds all occurences of [searchTerm] in [victim] and retrieves all their
+  /// Finds all occurrences of [searchTerm] in [victim] and retrieves all their
   /// indexes.
   Iterable<int> _getSearchTermMatchesIndexes(String victim) {
     final pattern = RegExp(searchTerm, caseSensitive: false);

--- a/test/utils/envvar_utils_test.dart
+++ b/test/utils/envvar_utils_test.dart
@@ -157,7 +157,7 @@ void main() {
       expect(substituteVariables(input, combinedEnvVarsMap), expected);
     });
 
-    test("Testing substituteVariables with incorrect paranthesis", () {
+    test("Testing substituteVariables with incorrect parenthesis", () {
       String input = "{{url}}}/humanize/social?num={{num}}";
       String expected = "api.apidash.dev}/humanize/social?num=8940000";
       expect(substituteVariables(input, combinedEnvVarsMap), expected);

--- a/test/widgets/response_widgets_test.dart
+++ b/test/widgets/response_widgets_test.dart
@@ -222,7 +222,7 @@ void main() {
   });
 
   testWidgets(
-      'Testing Response Body, no mediaType; shoud be default plaintext preview',
+      'Testing Response Body, no mediaType; should be default plaintext preview',
       (tester) async {
     var responseModelNoHeaders = responseModel.copyWith(
       headers: null,


### PR DESCRIPTION
## Summary

Fixed 18 spelling mistakes across 16 files in the codebase including comments, documentation, test files, and source code.

## Changes Made

### Source Code
- `lib/consts.dart`: Javacript → Javascript
- `lib/providers/collection_providers.dart`: Varaint → Variant  
- `lib/codegen/dart/dio.dart`: dosen't → doesn't
- `lib/codegen/ruby/faraday.dart`: reqest → request
- `lib/codegen/php/curl.dart`: temlate → template
- `lib/templates/system_prompt_templates/apitool_bodygen_prompt.dart`: thier → their
- `packages/json_explorer/lib/src/json_explorer_store.dart`: eiter → either, occurences → occurrences

### Documentation
- `CHANGELOG.md`: varibles → variables
- `doc/user_guide/env_user_guide.md`: Checing → Checking
- `doc/dev_guide/openapi.md`: depndency → dependency
- `doc/dev_guide/platform_specific_instructions.md`: atleast → at least, recommmended → recommended
- `packages/json_explorer/README.md`: folowing → following
- `packages/better_networking/CHANGELOG.md`: Intial → Initial

### Tests
- `packages/better_networking/test/extensions/map_extensions_test.dart`: occurence → occurrence (2 instances)
- `test/widgets/response_widgets_test.dart`: shoud → should
- `test/utils/envvar_utils_test.dart`: paranthesis → parenthesis

## What Was Skipped

False positives were intentionally skipped:
- Technical terms (IST timezone, ROUGE metric, TE header)
- Variable names (ans, ser)
- GSoC applicant proposal documents
- Test data files with intentional misspellings

## Testing

All changes are string-based corrections with no runtime behavior impact.