### PR TITLE
fix: resolve analysis warnings across codebase

### DIFF
--- a/lib/dashbot/providers/chat_viewmodel.dart
+++ b/lib/dashbot/providers/chat_viewmodel.dart
@@ -570,12 +570,6 @@ class ChatViewmodel extends StateNotifier<ChatState> {
     }
   }
 
-  Map<String, dynamic>? _currentRequestContext() {
-    final originalRq = _currentSubstitutedHttpRequestModel;
-    if (originalRq == null) return null;
-    return originalRq.toJson();
-  }
-
   Future<void> handleOpenApiAttachment(ChatAttachment att) async {
     try {
       final content = utf8.decode(att.data);

--- a/lib/dashbot/services/curl_import_service.dart
+++ b/lib/dashbot/services/curl_import_service.dart
@@ -160,15 +160,4 @@ class CurlImportService {
     return value.toString();
   }
 
-  static bool _looksLikeJson(String s) {
-    final t = s.trim();
-    if (t.isEmpty) return false;
-    if (!(t.startsWith('{') || t.startsWith('['))) return false;
-    try {
-      jsonDecode(t);
-      return true;
-    } catch (_) {
-      return false;
-    }
-  }
 }

--- a/lib/screens/mobile/widgets/page_base.dart
+++ b/lib/screens/mobile/widgets/page_base.dart
@@ -2,7 +2,6 @@ import 'package:apidash_design_system/apidash_design_system.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:apidash/consts.dart';
-import 'package:apidash/providers/providers.dart';
 // import 'package:apidash/widgets/window_caption.dart';
 
 class PageBase extends ConsumerWidget {

--- a/packages/better_networking/lib/models/http_response_model.dart
+++ b/packages/better_networking/lib/models/http_response_model.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'dart:typed_data';
 import 'package:collection/collection.dart' show mergeMaps;
 import 'package:http/http.dart';
-import 'package:http_parser/http_parser.dart';
 import 'package:seed/seed.dart';
 import '../extensions/extensions.dart';
 import '../utils/utils.dart';

--- a/packages/curl_parser/lib/curl_parser.dart
+++ b/packages/curl_parser/lib/curl_parser.dart
@@ -1,3 +1,1 @@
-library curl_parser;
-
 export 'models/curl.dart';

--- a/packages/genai/test/genai_test.dart
+++ b/packages/genai/test/genai_test.dart
@@ -1,4 +1,1 @@
-import 'package:flutter_test/flutter_test.dart';
-import 'package:genai/genai.dart';
-
 void main() {}

--- a/packages/json_field_editor/lib/json_field_editor.dart
+++ b/packages/json_field_editor/lib/json_field_editor.dart
@@ -1,4 +1,2 @@
-library json_field_editor;
-
 export 'src/json_field.dart';
 export 'src/json_text_field_controller.dart';

--- a/packages/seed/lib/seed.dart
+++ b/packages/seed/lib/seed.dart
@@ -1,5 +1,3 @@
-library seed;
-
 export 'models/models.dart';
 export 'consts.dart';
 

--- a/test/dashbot/widgets/action_buttons/dashbot_import_now_button_test.dart
+++ b/test/dashbot/widgets/action_buttons/dashbot_import_now_button_test.dart
@@ -41,12 +41,11 @@ void main() {
 
       late TestChatViewmodel notifier;
       late RecordingDashbotWindowNotifier windowNotifier;
-      final binding = TestWidgetsFlutterBinding.ensureInitialized();
-      binding.window.physicalSizeTestValue = const Size(1600, 1200);
-      binding.window.devicePixelRatioTestValue = 1.0;
+      tester.view.physicalSize = const Size(1600, 1200);
+      tester.view.devicePixelRatio = 1.0;
       addTearDown(() {
-        binding.window.clearPhysicalSizeTestValue();
-        binding.window.clearDevicePixelRatioTestValue();
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
       });
       await tester.pumpWidget(
         ProviderScope(

--- a/test/dashbot/widgets/openapi_operation_picker_dialog_test.dart
+++ b/test/dashbot/widgets/openapi_operation_picker_dialog_test.dart
@@ -25,11 +25,11 @@ const _sampleSpecJson = '''
 ''';
 
 void main() {
-  OpenApi _parse(String json) => OpenApi.fromString(source: json, format: null);
+  OpenApi parse(String json) => OpenApi.fromString(source: json, format: null);
 
   testWidgets('returns empty selection when spec has no operations',
       (tester) async {
-    final spec = _parse(_emptySpecJson);
+    final spec = parse(_emptySpecJson);
 
     List<OpenApiOperationItem>? resolved;
 
@@ -56,7 +56,7 @@ void main() {
 
   testWidgets('allows toggling select-all and individual operations',
       (tester) async {
-    final spec = _parse(_sampleSpecJson);
+    final spec = parse(_sampleSpecJson);
 
     late Future<List<OpenApiOperationItem>?> dialogFuture;
 
@@ -140,7 +140,7 @@ void main() {
   });
 
   testWidgets('returns null when cancelled', (tester) async {
-    final spec = _parse(_sampleSpecJson);
+    final spec = parse(_sampleSpecJson);
 
     late Future<List<OpenApiOperationItem>?> dialogFuture;
 


### PR DESCRIPTION
## PR Description
Fixes 18 analysis warnings reported by `flutter analyze`, reducing total issues from **47 → 29**.

**Changes:**
- Removed unused import (`providers.dart` in `page_base.dart`)
- Removed unused private methods (`_currentRequestContext` in `chat_viewmodel.dart`, `_looksLikeJson` in `curl_import_service.dart`)
- Removed unused imports in `genai_test.dart`
- Removed unnecessary `http_parser` import in `http_response_model.dart` (already re-exported by `http`)
- Removed unnecessary `library` declarations in `curl_parser.dart`, `json_field_editor.dart`, `seed.dart`
- Migrated deprecated `binding.window` test API to modern `tester.view` API in `dashbot_import_now_button_test.dart`
- Fixed underscore-prefixed local variable `_parse` → `parse` in `openapi_operation_picker_dialog_test.dart`

The remaining 29 issues are intentional (monorepo path deps, experimental APIs with no stable alternative, template naming conventions) and not appropriate for a cleanup PR.

## Related Issues
- Closes #

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [ ] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
- [ ] Yes
- [x] No, and this is why: This PR only removes dead code and migrates deprecated test APIs. No new logic was introduced. Existing tests are preserved with updated API usage.

## OS on which you have developed and tested the feature?
- [x] Windows
- [ ] macOS
- [ ] Linux
