### PR TITLE
prevent file upload crash on macOS/iOS by adding uniformTypeIdentifiers

### DIFF
--- a/lib/dashbot/widgets/dashbot_action_buttons/dashbot_upload_requests_button.dart
+++ b/lib/dashbot/widgets/dashbot_action_buttons/dashbot_upload_requests_button.dart
@@ -28,12 +28,12 @@ class DashbotUploadRequestButton extends ConsumerWidget
               .map((e) => e.trim())
               .toList();
           if (exts.isNotEmpty) {
-            types.add(XTypeGroup(label: 'Allowed', mimeTypes: exts));
+            types.add(XTypeGroup(label: 'Allowed', mimeTypes: exts,uniformTypeIdentifiers: const ['public.json','public.yaml','public.data'],));
           }
         }
         final file = await openFile(
             acceptedTypeGroups:
-                types.isEmpty ? [const XTypeGroup(label: 'Any')] : types);
+                types.isEmpty ? [const XTypeGroup(label: 'Any',uniformTypeIdentifiers: ['public.data'],)] : types);
         if (file == null) return;
         final bytes = await file.readAsBytes();
         final att = ref.read(attachmentsProvider.notifier).add(


### PR DESCRIPTION
## PR Description

This pr fixes upload crash of file when using `` DashBot `` -> `` Import OpenApi ``-> ``Upload file `` on macOS and IOS 
The crash was caused by the XTypeGroup passed to the file picker not defining uniformTypeIdentifiers

**Fix**
Added ``uniformTypeIdentifiers`` to the ``XTypeGroup`` used when selecting OpenAPI files.
This ensures the file picker works correctly on:
- macOS
- iOS
while maintaining the same file filtering behavior.

**Result**
The file picker now opens normally and allows selecting OpenAPI specification files without crashing.

https://github.com/user-attachments/assets/532c0f0b-0175-4e7b-b68f-a7d39c81cd71


## Related Issues

- Closes #1255 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_

## OS on which you have developed and tested the feature?

- [ ] Windows
- [x] macOS
- [ ] Linux
