### PR TITLE
Populating form-data from the OpenApi schema for multipart/form-data and x-www-form-urlencoded conten-type

### DIFF
--- a/lib/dashbot/services/openapi_import_service.dart
+++ b/lib/dashbot/services/openapi_import_service.dart
@@ -230,18 +230,25 @@ class OpenApiImportService {
           headers['Content-Type'] = content.containsKey('multipart/form-data')
               ? 'multipart/form-data'
               : 'application/x-www-form-urlencoded';
-          // Populate fields from schema properties if available
-          // final key = content.containsKey('multipart/form-data')
-          //     ? 'multipart/form-data'
-          //     : 'application/x-www-form-urlencoded';
-          // TODO: Extract form field names from schema if available
-          // if (props != null && props.isNotEmpty) {
-          //   for (final entry in props.entries) {
-          //     final n = entry.key;
-          //     // Using empty placeholder values
-          //     formData.add({'name': n, 'value': '', 'type': 'text'});
-          //   }
-          // }
+          final key = content.containsKey('multipart/form-data')
+              ? 'multipart/form-data'
+              : 'application/x-www-form-urlencoded';
+          final media=content[key];
+          final schema=media?.schema;
+          final schemaJson=schema?.toJson();
+          if(schemaJson!.isNotEmpty){
+            if (schemaJson?['type'] == 'object') {
+            final props =schemaJson['properties'] as Map<String, dynamic>?;
+            props?.forEach((propName, propSchema) {
+                final format = propSchema['format'];
+                final type = format == 'binary' ? 'file' : 'text';
+                formData.add({
+                    'name': propName,
+                    'value': '',
+                    'type': type,});
+              });
+            }
+          }
         }
       }
     }

--- a/test/dashbot/services/openapi_import_service_test.dart
+++ b/test/dashbot/services/openapi_import_service_test.dart
@@ -293,4 +293,66 @@ void main() {
       expect(picker['explanation'], contains('No operations'));
     });
   });
+
+  test('payloadForOperation extracts direct form schema properties', () {
+  const formSpecJson = '''
+{
+  "openapi": "3.0.0",
+  "info": {"title": "Form API", "version": "1.0.0"},
+  "servers": [{"url": "https://api.test.dev"}],
+  "paths": {
+    "/upload": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": {"type": "string"},
+                  "avatar": {"type": "string", "format": "binary"}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {"description": "ok"}
+        }
+      }
+    }
+  }
+}
+''';
+
+  final spec = OpenApiImportService.tryParseSpec(formSpecJson)!;
+  final op = spec.paths!['/upload']!.post!;
+
+  final payload = OpenApiImportService.payloadForOperation(
+    baseUrl: spec.servers!.first.url!,
+    path: '/upload',
+    method: 'post',
+    op: op,
+  );
+
+  expect(payload['form'], true);
+
+  final formData = payload['formData'] as List;
+
+  expect(formData.length, 2);
+
+  expect(
+    formData.any((f) =>
+        f['name'] == 'username' &&
+        f['type'] == 'text'),
+    true,
+  );
+
+  expect(
+    formData.any((f) =>
+        f['name'] == 'avatar' &&
+        f['type'] == 'file'),
+    true,
+  );
+});
 }


### PR DESCRIPTION
## PR Description
The pr implements extraction of field names from ``OpenApi`` schema when content-type is :
- ``multipart/form-data``
- ``application/x-www-form-urlencoded``

Previously, when importing such OpenAPI specifications via DashBot: 
- isform was correctly set true
- ``Content-header``header was set true
- However the field names are not reflected in the formData it remains empty

Changes were made in  ``_payloadForOperation`` : 
- media.schema is converted to Json 
-  properties are extracted from json result
- each property is added to ``formData``

This implementation supports : 
- ``type:object``
- Direct properties
- Binary file detection via ``format: binary``

It intentionally does not handle 
- Nested object schemas
- allOf, oneOf, anyOf
- $ref
- Arrays
- Recursive schema resolution
These can be addressed in future enhancements if required.

**Example**

 ***Input*** 

```
openapi: 3.0.0
info:
  title: Test API
  version: 1.0.0
servers:
  - url: http://localhost:3000
paths:
  /upload:
    post:
      requestBody:
        required: true
        content:
          multipart/form-data:
            schema:
              type: object
              properties:
                username:
                  type: string
                avatar:
                  type: string
                  format: binary
      responses:
        '200':
          description: OK
```

***Result***
- form=true
- Content-Type=multipart/form-data
- formData auto-populate with:
     - username -> text
     - avatar -> file

<img width="340" height="291" alt="apiDash1 ss" src="https://github.com/user-attachments/assets/e2c7a920-a023-437e-8d77-bd1ac86229a7" />

<img width="332" height="315" alt="apiDash2 ss" src="https://github.com/user-attachments/assets/3c3857b1-00dc-44fc-bf89-a410646c9c3f" />

## Related Issues

- Closes #1252 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_

## OS on which you have developed and tested the feature?

- [ ] Windows
- [x] macOS
- [ ] Linux