### PR TITLE
Fix: Search bar crashing for AI requests in collection pane

### DIFF
--- a/lib/screens/home_page/collection_pane.dart
+++ b/lib/screens/home_page/collection_pane.dart
@@ -156,9 +156,10 @@ class _RequestListState extends ConsumerState<RequestList> {
               controller: controller,
               children: requestSequence.map((id) {
                 var item = requestItems[id]!;
-                if (item.httpRequestModel!.url
-                        .toLowerCase()
-                        .contains(filterQuery) ||
+                if ((item.httpRequestModel?.url
+                            .toLowerCase()
+                            .contains(filterQuery) ??
+                        false) ||
                     item.name.toLowerCase().contains(filterQuery)) {
                   return Padding(
                     padding: kP1,

--- a/test/screens/home_page/collection_pane_test.dart
+++ b/test/screens/home_page/collection_pane_test.dart
@@ -1,0 +1,91 @@
+import 'package:apidash/models/models.dart';
+import 'package:apidash/providers/providers.dart';
+import 'package:apidash/screens/home_page/collection_pane.dart';
+import 'package:apidash/services/hive_services.dart';
+import 'package:apidash_core/apidash_core.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../providers/helpers.dart';
+
+const _restRequest = RequestModel(
+  id: 'rest_id_1',
+  name: 'My REST Request',
+  apiType: APIType.rest,
+  httpRequestModel: HttpRequestModel(
+    method: HTTPVerb.get,
+    url: 'https://api.github.com',
+  ),
+);
+
+const _aiRequest = RequestModel(
+  id: 'ai_id_1',
+  name: 'My AI Request',
+  apiType: APIType.ai,
+  httpRequestModel: null,
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await testSetUpTempDirForHive();
+  });
+
+  Widget buildWithOverrides({
+    required Map<String, RequestModel> collection,
+    required List<String> sequence,
+    String filterQuery = '',
+  }) {
+    return ProviderScope(
+      overrides: [
+        collectionStateNotifierProvider.overrideWith(
+          (ref) =>
+              CollectionStateNotifier(ref, hiveHandler)..state = collection,
+        ),
+        requestSequenceProvider.overrideWith((ref) => sequence),
+        collectionSearchQueryProvider.overrideWith((ref) => filterQuery),
+      ],
+      child: const MaterialApp(home: Scaffold(body: RequestList())),
+    );
+  }
+
+  testWidgets('does not crash when searching with AI request in collection',
+      (tester) async {
+    await tester.pumpWidget(buildWithOverrides(
+      collection: {
+        'rest_id_1': _restRequest,
+        'ai_id_1': _aiRequest,
+      },
+      sequence: ['rest_id_1', 'ai_id_1'],
+      filterQuery: 'test',
+    ));
+    await tester.pump();
+
+    expect(find.byType(RequestItem), findsNothing);
+  });
+
+  testWidgets('filters AI requests by name when httpRequestModel is null',
+      (tester) async {
+    await tester.pumpWidget(buildWithOverrides(
+      collection: {'ai_id_1': _aiRequest},
+      sequence: ['ai_id_1'],
+      filterQuery: 'ai request',
+    ));
+    await tester.pump();
+
+    expect(find.byType(RequestItem), findsOneWidget);
+  });
+
+  testWidgets('filters HTTP requests by URL', (tester) async {
+    await tester.pumpWidget(buildWithOverrides(
+      collection: {'rest_id_1': _restRequest},
+      sequence: ['rest_id_1'],
+      filterQuery: 'github',
+    ));
+    await tester.pump();
+
+    expect(find.byType(RequestItem), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## PR Description

This PR resolves a critical app crash in the Collection Pane's search feature when the collection contains **AI Requests**.

### The Problem
The logic for the search filter was employing a null check operator `!` on `httpRequestModel`, assuming that all elements in the collection are standard HTTP requests. Since AI requests' `httpRequestModel` is `null`, attempting to type anything in the search box with an AI request in the collection caused a `Null check operator used on a null value` app crash.

### The Fix
The filtering logic in [RequestList] (lib/screens/home_page/collection_pane.dart) has been modified to use null-aware access `?.` on `httpRequestModel`, providing a default value of `false` `?? false` in case `httpRequestModel` is `null`. This allows AI requests to be searched by **Name**, but prevents the app from crashing when the search tries to look for **URL** on AI requests.

## Related Issues

- Closes #1276

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project [main] branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
- [x] Yes

## OS on which you have developed and tested the feature?
- [x] Windows
- [ ] macOS
- [ ] Linux
