### PR TITLE
FIxed API keys disappearing

### DIFF
--- a/lib/models/settings_model.dart
+++ b/lib/models/settings_model.dart
@@ -20,6 +20,7 @@ class SettingsModel {
     this.isSSLDisabled = false,
     this.isDashBotEnabled = true,
     this.defaultAIModel,
+    this.aiKeys = const {},
   });
 
   final bool isDark;
@@ -36,6 +37,7 @@ class SettingsModel {
   final bool isSSLDisabled;
   final bool isDashBotEnabled;
   final Map<String, Object?>? defaultAIModel;
+  final Map<String, String> aiKeys;
 
   SettingsModel copyWith({
     bool? isDark,
@@ -52,6 +54,7 @@ class SettingsModel {
     bool? isSSLDisabled,
     bool? isDashBotEnabled,
     Map<String, Object?>? defaultAIModel,
+    Map<String, String>? aiKeys,
   }) {
     return SettingsModel(
       isDark: isDark ?? this.isDark,
@@ -70,6 +73,7 @@ class SettingsModel {
       isSSLDisabled: isSSLDisabled ?? this.isSSLDisabled,
       isDashBotEnabled: isDashBotEnabled ?? this.isDashBotEnabled,
       defaultAIModel: defaultAIModel ?? this.defaultAIModel,
+      aiKeys: aiKeys ?? this.aiKeys,
     );
   }
 
@@ -91,6 +95,7 @@ class SettingsModel {
       isSSLDisabled: isSSLDisabled,
       isDashBotEnabled: isDashBotEnabled,
       defaultAIModel: defaultAIModel,
+      aiKeys: aiKeys,
     );
   }
 
@@ -149,6 +154,9 @@ class SettingsModel {
     final defaultAIModel = data["defaultAIModel"] == null
         ? null
         : Map<String, Object?>.from(data["defaultAIModel"]);
+    final aiKeys = data["aiKeys"] == null
+        ? <String, String>{}
+        : Map<String, String>.from(data["aiKeys"]);
     const sm = SettingsModel();
 
     return sm.copyWith(
@@ -167,6 +175,7 @@ class SettingsModel {
       isSSLDisabled: isSSLDisabled,
       isDashBotEnabled: isDashBotEnabled,
       defaultAIModel: defaultAIModel,
+      aiKeys: aiKeys,
     );
   }
 
@@ -188,6 +197,7 @@ class SettingsModel {
       "isSSLDisabled": isSSLDisabled,
       "isDashBotEnabled": isDashBotEnabled,
       "defaultAIModel": defaultAIModel,
+      "aiKeys": aiKeys,
     };
   }
 
@@ -214,7 +224,8 @@ class SettingsModel {
         other.workspaceFolderPath == workspaceFolderPath &&
         other.isSSLDisabled == isSSLDisabled &&
         other.isDashBotEnabled == isDashBotEnabled &&
-        mapEquals(other.defaultAIModel, defaultAIModel);
+        mapEquals(other.defaultAIModel, defaultAIModel) &&
+        mapEquals(other.aiKeys, aiKeys);
   }
 
   @override
@@ -235,6 +246,7 @@ class SettingsModel {
       isSSLDisabled,
       isDashBotEnabled,
       defaultAIModel,
+      aiKeys,
     );
   }
 }

--- a/lib/providers/settings_providers.dart
+++ b/lib/providers/settings_providers.dart
@@ -35,6 +35,7 @@ class ThemeStateNotifier extends StateNotifier<SettingsModel> {
     bool? isSSLDisabled,
     bool? isDashBotEnabled,
     Map<String, Object?>? defaultAIModel,
+    Map<String, String>? aiKeys,
   }) async {
     state = state.copyWith(
       isDark: isDark,
@@ -51,6 +52,7 @@ class ThemeStateNotifier extends StateNotifier<SettingsModel> {
       isSSLDisabled: isSSLDisabled,
       isDashBotEnabled: isDashBotEnabled,
       defaultAIModel: defaultAIModel,
+      aiKeys: aiKeys,
     );
     await setSettingsToSharedPrefs(state);
   }

--- a/lib/screens/common_widgets/ai/ai_model_selector_dialog.dart
+++ b/lib/screens/common_widgets/ai/ai_model_selector_dialog.dart
@@ -1,4 +1,4 @@
-// import 'package:apidash/providers/providers.dart';
+import 'package:apidash/providers/providers.dart';
 import 'package:apidash/widgets/widgets.dart';
 import 'package:apidash/consts.dart';
 import 'package:apidash_core/apidash_core.dart';
@@ -19,6 +19,7 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
   late final Future<AvailableModels> aM;
   ModelAPIProvider? selectedProvider;
   AIRequestModel? newAIRequestModel;
+  Map<String, String> _localAIKeys = {};
 
   @override
   void initState() {
@@ -28,6 +29,14 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
       newAIRequestModel = widget.aiRequestModel?.copyWith();
     }
     aM = ModelManager.fetchAvailableModels();
+
+    final settings = ref.read(settingsProvider);
+    _localAIKeys = Map<String, String>.from(settings.aiKeys);
+    if (newAIRequestModel?.apiKey != null &&
+        newAIRequestModel!.apiKey!.isNotEmpty &&
+        selectedProvider != null) {
+      _localAIKeys[selectedProvider!.name] = newAIRequestModel!.apiKey!;
+    }
   }
 
   @override
@@ -70,6 +79,15 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
                               selectedProvider = x;
                               newAIRequestModel = mappedData[selectedProvider]
                                   ?.toAiRequestModel();
+                              if (newAIRequestModel != null &&
+                                  selectedProvider != null) {
+                                final storedKey =
+                                    _localAIKeys[selectedProvider!.name];
+                                if (storedKey != null) {
+                                  newAIRequestModel = newAIRequestModel!
+                                      .copyWith(apiKey: storedKey);
+                                }
+                              }
                             });
                           },
                           value: selectedProvider,
@@ -123,6 +141,15 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
                                 selectedProvider = x.providerId;
                                 newAIRequestModel = mappedData[selectedProvider]
                                     ?.toAiRequestModel();
+                                if (newAIRequestModel != null &&
+                                    selectedProvider != null) {
+                                  final storedKey =
+                                      _localAIKeys[selectedProvider!.name];
+                                  if (storedKey != null) {
+                                    newAIRequestModel = newAIRequestModel!
+                                        .copyWith(apiKey: storedKey);
+                                  }
+                                }
                               });
                             },
                           ),
@@ -165,16 +192,12 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
           kVSpacer8,
           BoundedTextField(
             onChanged: (x) {
-              // ref.read(aiApiCredentialProvider.notifier).state = {
-              //   ...ref.read(aiApiCredentialProvider),
-              //   aiModelProvider.providerId!: x
-              // };
               setState(() {
+                _localAIKeys[aiModelProvider.providerId!.name] = x;
                 newAIRequestModel = newAIRequestModel?.copyWith(apiKey: x);
               });
             },
-            value: newAIRequestModel?.apiKey ?? "",
-            // value: currentCredential,
+            value: _localAIKeys[aiModelProvider.providerId!.name] ?? "",
           ),
           kVSpacer10,
         ],
@@ -243,6 +266,7 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
           alignment: Alignment.centerRight,
           child: ElevatedButton(
             onPressed: () {
+              ref.read(settingsProvider.notifier).update(aiKeys: _localAIKeys);
               Navigator.of(context).pop(newAIRequestModel);
             },
             child: Text(kLabelSave),

--- a/lib/widgets/field_text_bounded.dart
+++ b/lib/widgets/field_text_bounded.dart
@@ -31,8 +31,7 @@ class _BoundedTextFieldState extends State<BoundedTextField> {
 
   @override
   void didUpdateWidget(covariant BoundedTextField oldWidget) {
-    //Assisting in Resetting on Change
-    if (widget.value == '') {
+    if (widget.value != oldWidget.value && widget.value != controller.text) {
       controller.text = widget.value;
     }
     super.didUpdateWidget(oldWidget);

--- a/test/models/settings_model_test.dart
+++ b/test/models/settings_model_test.dart
@@ -20,6 +20,7 @@ void main() {
     isSSLDisabled: true,
     isDashBotEnabled: true,
     defaultAIModel: {"model": "llama"},
+    aiKeys: {"openai": "test-key"},
   );
 
   test('Testing toJson()', () {
@@ -39,7 +40,8 @@ void main() {
       "workspaceFolderPath": null,
       "isSSLDisabled": true,
       "isDashBotEnabled": true,
-      "defaultAIModel": {"model": "llama"}
+      "defaultAIModel": {"model": "llama"},
+      "aiKeys": {"openai": "test-key"}
     };
     expect(sm.toJson(), expectedResult);
   });
@@ -61,7 +63,8 @@ void main() {
       "workspaceFolderPath": null,
       "isSSLDisabled": true,
       "isDashBotEnabled": true,
-      "defaultAIModel": {"model": "llama"}
+      "defaultAIModel": {"model": "llama"},
+      "aiKeys": {"openai": "test-key"}
     };
     expect(SettingsModel.fromJson(input), sm);
   });
@@ -81,6 +84,7 @@ void main() {
       isSSLDisabled: false,
       isDashBotEnabled: false,
       defaultAIModel: {"model": "llama"},
+      aiKeys: {"openai": "test-key"},
     );
     expect(
         sm.copyWith(
@@ -111,6 +115,9 @@ void main() {
   "isDashBotEnabled": true,
   "defaultAIModel": {
     "model": "llama"
+  },
+  "aiKeys": {
+    "openai": "test-key"
   }
 }''';
     expect(sm.toString(), expectedResult);


### PR DESCRIPTION
## PR Description

Fix API key persistence when switching between AI providers in the model selector dialog.

**Problem:** API keys disappeared when switching between providers because `toAiRequestModel()` creates a fresh model with empty `apiKey`, and there was no per-provider key storage.

**Solution:**
- Added `aiKeys: Map<String, String>` field to `SettingsModel` for per-provider key storage
- Fixed `BoundedTextField.didUpdateWidget` to properly sync controller when parent value changes (root cause fix)
- Dialog now loads stored keys on open, restores them when switching providers, and persists all keys on save

## Related Issues

- Closes #1182

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [x] Yes

## OS on which you have developed and tested the feature?

- [ ] Windows
- [x] macOS
- [ ] Linux
