### PR TITLE
fix: add validation for empty API key and endpoint URL in AI Model Selector

### DIFF
--- a/lib/screens/common_widgets/ai/ai_model_selector_dialog.dart
+++ b/lib/screens/common_widgets/ai/ai_model_selector_dialog.dart
@@ -18,6 +18,8 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
   late final Future<AvailableModels> aM;
   ModelAPIProvider? selectedProvider;
   AIRequestModel? newAIRequestModel;
+  String? _apiKeyError;
+  String? _endpointError;
 
   @override
   void initState() {
@@ -69,6 +71,8 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
                               selectedProvider = x;
                               newAIRequestModel = mappedData[selectedProvider]
                                   ?.toAiRequestModel();
+                              _apiKeyError = null;
+                              _endpointError = null;
                             });
                           },
                           value: selectedProvider,
@@ -121,6 +125,8 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
                                 selectedProvider = x.providerId;
                                 newAIRequestModel = mappedData[selectedProvider]
                                     ?.toAiRequestModel();
+                                _apiKeyError = null;
+                                _endpointError = null;
                               });
                             },
                           ),
@@ -163,17 +169,24 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
           kVSpacer8,
           BoundedTextField(
             onChanged: (x) {
-              // ref.read(aiApiCredentialProvider.notifier).state = {
-              //   ...ref.read(aiApiCredentialProvider),
-              //   aiModelProvider.providerId!: x
-              // };
               setState(() {
                 newAIRequestModel = newAIRequestModel?.copyWith(apiKey: x);
+                _apiKeyError = null;
               });
             },
             value: newAIRequestModel?.apiKey ?? "",
-            // value: currentCredential,
           ),
+          if (_apiKeyError != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Text(
+                _apiKeyError!,
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.error,
+                  fontSize: 12,
+                ),
+              ),
+            ),
           kVSpacer10,
         ],
         Text('Endpoint'),
@@ -183,10 +196,22 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
           onChanged: (x) {
             setState(() {
               newAIRequestModel = newAIRequestModel?.copyWith(url: x);
+              _endpointError = null;
             });
           },
           value: newAIRequestModel?.url ?? "",
         ),
+        if (_endpointError != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Text(
+              _endpointError!,
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.error,
+                fontSize: 12,
+              ),
+            ),
+          ),
         kVSpacer20,
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -240,6 +265,28 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
           alignment: Alignment.centerRight,
           child: ElevatedButton(
             onPressed: () {
+              final isOllama =
+                  aiModelProvider.providerId == ModelAPIProvider.ollama;
+              final apiKey = newAIRequestModel?.apiKey?.trim() ?? "";
+              final endpoint = newAIRequestModel?.url.trim() ?? "";
+
+              bool hasError = false;
+
+              if (!isOllama && apiKey.isEmpty) {
+                _apiKeyError = "API Key is required";
+                hasError = true;
+              }
+
+              if (endpoint.isEmpty) {
+                _endpointError = "Endpoint URL is required";
+                hasError = true;
+              }
+
+              if (hasError) {
+                setState(() {});
+                return;
+              }
+
               Navigator.of(context).pop(newAIRequestModel);
             },
             child: Text('Save'),


### PR DESCRIPTION
## Summary
- Adds validation to the **AI Model Selector dialog** to prevent saving invalid configurations
- Shows inline error message **"API Key is required"** when API Key is empty (for non-Ollama providers)
- Shows inline error message **"Endpoint URL is required"** when Endpoint URL is empty
- Dialog remains open until all required fields are valid
- Errors clear automatically when user types or switches providers

## Test plan
- [ ] Open AI Model Selector dialog
- [ ] Select any provider (e.g., OpenAI)
- [ ] Leave API Key empty, click Save → verify "API Key is required" error appears
- [ ] Leave Endpoint URL empty, click Save → verify "Endpoint URL is required" error appears
- [ ] Verify dialog does NOT close when validation fails
- [ ] Fill in valid values, click Save → verify dialog closes successfully
- [ ] Select Ollama provider → verify API Key validation is skipped
- [ ] Switch providers → verify error messages are cleared

Resolves #1183