### PR TITLE
Fix response body segmented tab wrapping on cold start

### DIFF
--- a/lib/widgets/response_body_success.dart
+++ b/lib/widgets/response_body_success.dart
@@ -68,31 +68,52 @@ class _ResponseBodySuccessState extends State<ResponseBodySuccess> {
                 children: [
                   (widget.options == kRawBodyViewOptions)
                       ? const SizedBox()
-                      : SegmentedButton<ResponseBodyView>(
-                          style: SegmentedButton.styleFrom(
-                            padding: const EdgeInsets.symmetric(horizontal: 8),
-                          ),
-                          selectedIcon: Icon(currentSeg.icon),
-                          segments: widget.options
-                              .map<ButtonSegment<ResponseBodyView>>(
-                                (e) => ButtonSegment<ResponseBodyView>(
-                                  value: e,
-                                  label: Text(e.label),
-                                  icon: constraints.maxWidth >
-                                          kMinWindowSize.width
-                                      ? Icon(e.icon)
-                                      : null,
+                      : Flexible(
+                          child: LayoutBuilder(
+                            builder: (context, segmentConstraints) {
+                              final showSegmentIcons =
+                                  segmentConstraints.maxWidth.isFinite &&
+                                  segmentConstraints.maxWidth >
+                                      widget.options.length * 96;
+                              return Align(
+                                alignment: Alignment.centerLeft,
+                                child: SegmentedButton<ResponseBodyView>(
+                                  showSelectedIcon: false,
+                                  style: SegmentedButton.styleFrom(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 8,
+                                    ),
+                                  ),
+                                  segments: widget.options
+                                      .map<ButtonSegment<ResponseBodyView>>(
+                                        (e) => ButtonSegment<ResponseBodyView>(
+                                          value: e,
+                                          label: Text(
+                                            e.label,
+                                            maxLines: 1,
+                                            overflow: TextOverflow.ellipsis,
+                                          ),
+                                          icon: showSegmentIcons
+                                              ? Icon(e.icon)
+                                              : null,
+                                        ),
+                                      )
+                                      .toList(),
+                                  selected: {currentSeg},
+                                  onSelectionChanged: (newSelection) {
+                                    setState(() {
+                                      segmentIdx =
+                                          widget.options.indexOf(
+                                            newSelection.first,
+                                          );
+                                    });
+                                  },
                                 ),
-                              )
-                              .toList(),
-                          selected: {currentSeg},
-                          onSelectionChanged: (newSelection) {
-                            setState(() {
-                              segmentIdx =
-                                  widget.options.indexOf(newSelection.first);
-                            });
-                          },
+                              );
+                            },
+                          ),
                         ),
+                  if (widget.options != kRawBodyViewOptions) kHSpacer8,
                   const Spacer(),
                   ((widget.options == kPreviewRawBodyViewOptions) ||
                           kCodeRawBodyViewOptions.contains(currentSeg))


### PR DESCRIPTION
## PR Description

Fixes the response body segmented tab layout so the `Answer` label does not wrap incorrectly on cold start.

The issue happened because icon visibility for the `SegmentedButton` was being decided using the full response pane width, even though the segmented control shares the same row with action buttons like Copy and Download/Share. This could make the control render icon + label when the control itself did not actually have enough space, causing the `Answer` text to appear shifted/wrapped on startup.

This PR updates the layout to measure the segmented control using its own available width and uses that width to decide whether segment icons should be shown. It also disables the selected-state icon and keeps labels constrained to a single line with ellipsis as a fallback.

## Before
<img width="1919" height="1079" alt="Screenshot 2026-03-06 142024" src="https://github.com/user-attachments/assets/23d42dcd-58c0-468b-b553-37886966f92c" />

## After

https://github.com/user-attachments/assets/5c0bf992-abe5-4a2a-8113-d0f6775967ec



## Related Issues

- Closes #1283

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [x] No, and this is why: this is a focused UI layout fix for segmented tab rendering, and no widget test was added in this change.

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux