### PR TITLE
fix: Add inline validation for empty API Key and Endpoint URL in AI Model Selector dialog #1183

### DIFF
--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -583,6 +583,8 @@ const kLabelOnboardingDesc3 =
 
 // AI Model Selector Dialog
 const kLabelUpdateModels = "Update Models";
+const kValidationApiKeyRequired = "API Key is required";
+const kValidationEndpointRequired = "Endpoint URL is required";
 const kLabelSelectModelProvider = "Select Model Provider";
 const kLabelSelectAIProvider = "Please select an AI API Provider";
 const kLabelApiKeyCredential = "API Key / Credential";

--- a/lib/screens/common_widgets/ai/ai_model_selector_dialog.dart
+++ b/lib/screens/common_widgets/ai/ai_model_selector_dialog.dart
@@ -19,6 +19,8 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
   late final Future<AvailableModels> aM;
   ModelAPIProvider? selectedProvider;
   AIRequestModel? newAIRequestModel;
+  String? _apiKeyError;
+  String? _endpointError;
 
   @override
   void initState() {
@@ -171,11 +173,22 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
               // };
               setState(() {
                 newAIRequestModel = newAIRequestModel?.copyWith(apiKey: x);
+                if (x.isNotEmpty) _apiKeyError = null;
               });
             },
             value: newAIRequestModel?.apiKey ?? "",
             // value: currentCredential,
           ),
+          if (_apiKeyError != null) ...[
+            kVSpacer5,
+            Text(
+              _apiKeyError!,
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.error,
+                fontSize: 12,
+              ),
+            ),
+          ],
           kVSpacer10,
         ],
         Text(kLabelEndpoint),
@@ -185,10 +198,21 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
           onChanged: (x) {
             setState(() {
               newAIRequestModel = newAIRequestModel?.copyWith(url: x);
+              if (x.isNotEmpty) _endpointError = null;
             });
           },
           value: newAIRequestModel?.url ?? "",
         ),
+        if (_endpointError != null) ...[
+          kVSpacer5,
+          Text(
+            _endpointError!,
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.error,
+              fontSize: 12,
+            ),
+          ),
+        ],
         kVSpacer20,
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -243,6 +267,26 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
           alignment: Alignment.centerRight,
           child: ElevatedButton(
             onPressed: () {
+              final isOllama =
+                  newAIRequestModel?.modelApiProvider ==
+                  ModelAPIProvider.ollama;
+              final apiKey = newAIRequestModel?.apiKey ?? "";
+              final endpoint = newAIRequestModel?.url ?? "";
+              String? apiKeyErr;
+              String? endpointErr;
+              if (!isOllama && apiKey.trim().isEmpty) {
+                apiKeyErr = kValidationApiKeyRequired;
+              }
+              if (endpoint.trim().isEmpty) {
+                endpointErr = kValidationEndpointRequired;
+              }
+              if (apiKeyErr != null || endpointErr != null) {
+                setState(() {
+                  _apiKeyError = apiKeyErr;
+                  _endpointError = endpointErr;
+                });
+                return;
+              }
               Navigator.of(context).pop(newAIRequestModel);
             },
             child: Text(kLabelSave),


### PR DESCRIPTION
## PR Description

Adds inline field-level validation to the AI Model Selector dialog to prevent saving invalid configurations silently.

When the user clicks **Save**:
- If the provider is not Ollama and the **API Key** field is empty, an error message ("API Key is required") appears inline below the field.
- If the **Endpoint URL** field is empty, an error message ("Endpoint URL is required") appears inline below the field.
- The dialog does **not** close until both required fields are filled.
- Error messages clear automatically as the user types.


https://github.com/user-attachments/assets/7f101916-4731-4089-bf98-55599bdec782



## Related Issues

- Closes #1183

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [ ] No, and this is why: The validation logic is contained entirely in `_buildModelSelector` inside a `StatefulWidget` that depends on `FutureBuilder` and `ModelManager.fetchAvailableModels()`. Widget tests for this dialog would require mocking the network fetch; a follow-up test can be added separately.

## OS on which you have developed and tested the feature?

- [x] Windows