### PR TITLE
fix 1183: add validation for API Key and Endpoint URL in AI Model Selector

### DIFF
--- a/lib/screens/common_widgets/ai/ai_model_selector_dialog.dart
+++ b/lib/screens/common_widgets/ai/ai_model_selector_dialog.dart
@@ -18,6 +18,8 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
   late final Future<AvailableModels> aM;
   ModelAPIProvider? selectedProvider;
   AIRequestModel? newAIRequestModel;
+  bool apiKeyError = false;
+  bool endpointError = false;
 
   @override
   void initState() {
@@ -69,6 +71,8 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
                               selectedProvider = x;
                               newAIRequestModel = mappedData[selectedProvider]
                                   ?.toAiRequestModel();
+                              apiKeyError = false;
+                              endpointError = false;
                             });
                           },
                           value: selectedProvider,
@@ -121,6 +125,8 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
                                 selectedProvider = x.providerId;
                                 newAIRequestModel = mappedData[selectedProvider]
                                     ?.toAiRequestModel();
+                                apiKeyError = false;
+                                endpointError = false;
                               });
                             },
                           ),
@@ -169,9 +175,11 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
               // };
               setState(() {
                 newAIRequestModel = newAIRequestModel?.copyWith(apiKey: x);
+                apiKeyError = false;
               });
             },
             value: newAIRequestModel?.apiKey ?? "",
+            errorText: apiKeyError ? "API Key is required" : null,
             // value: currentCredential,
           ),
           kVSpacer10,
@@ -183,9 +191,11 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
           onChanged: (x) {
             setState(() {
               newAIRequestModel = newAIRequestModel?.copyWith(url: x);
+              endpointError = false;
             });
           },
           value: newAIRequestModel?.url ?? "",
+          errorText: endpointError ? "Endpoint URL is required" : null,
         ),
         kVSpacer20,
         Row(
@@ -240,6 +250,27 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
           alignment: Alignment.centerRight,
           child: ElevatedButton(
             onPressed: () {
+              // Validate Endpoint URL (always required)
+              final endpoint = (newAIRequestModel?.url ?? '').trim();
+              if (endpoint.isEmpty) {
+                setState(() {
+                  endpointError = true;
+                });
+                return;
+              }
+
+              // Validate API Key (required for non-Ollama providers)
+              if (aiModelProvider.providerId != ModelAPIProvider.ollama) {
+                final apiKey = (newAIRequestModel?.apiKey ?? '').trim();
+                if (apiKey.isEmpty) {
+                  setState(() {
+                    apiKeyError = true;
+                  });
+                  return;
+                }
+              }
+
+              // All validations passed, save and close
               Navigator.of(context).pop(newAIRequestModel);
             },
             child: Text('Save'),

--- a/lib/widgets/field_text_bounded.dart
+++ b/lib/widgets/field_text_bounded.dart
@@ -6,10 +6,12 @@ class BoundedTextField extends StatefulWidget {
     super.key,
     required this.value,
     required this.onChanged,
+    this.errorText,
   });
 
   final String value;
   final void Function(String value) onChanged;
+  final String? errorText;
 
   @override
   State<BoundedTextField> createState() => _BoundedTextFieldState();
@@ -35,27 +37,46 @@ class _BoundedTextFieldState extends State<BoundedTextField> {
   @override
   Widget build(BuildContext context) {
     // final double width = context.isCompactWindow ? 150 : 220;
-    return Container(
-      height: 40,
-      decoration: BoxDecoration(
-        border: Border.all(
-          color: Theme.of(context).colorScheme.surfaceContainerHighest,
-        ),
-        borderRadius: kBorderRadius8,
-      ),
-      width: double.infinity,
-      child: Container(
-        transform: Matrix4.translationValues(0, -5, 0),
-        child: TextField(
-          controller: controller,
-          // obscureText: true,
-          decoration: InputDecoration(
-            border: InputBorder.none,
-            contentPadding: EdgeInsets.only(left: 10),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          height: 40,
+          decoration: BoxDecoration(
+            border: Border.all(
+              color: widget.errorText != null
+                  ? Theme.of(context).colorScheme.error
+                  : Theme.of(context).colorScheme.surfaceContainerHighest,
+            ),
+            borderRadius: kBorderRadius8,
           ),
-          onChanged: widget.onChanged,
+          width: double.infinity,
+          child: Container(
+            transform: Matrix4.translationValues(0, -5, 0),
+            child: TextField(
+              controller: controller,
+              // obscureText: true,
+              decoration: InputDecoration(
+                border: InputBorder.none,
+                contentPadding: EdgeInsets.only(left: 10),
+              ),
+              onChanged: widget.onChanged,
+            ),
+          ),
         ),
-      ),
+        if (widget.errorText != null)
+          Padding(
+            padding: const EdgeInsets.only(left: 4, top: 4),
+            child: Text(
+              widget.errorText!,
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.error,
+                fontSize: 12,
+              ),
+            ),
+          ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Fixes Issue #1183

Adds proper validation to the AI Model Selector Dialog to prevent saving invalid configurations.

## Changes Made

### BoundedTextField Widget
- Added `errorText` parameter for validation messages
- Error text displays below the field in red
- Border color changes to red when there's an error

### AI Model Selector Dialog
- Added validation for API Key field (required for non-Ollama providers)
- Added validation for Endpoint URL field (always required)
- Validation occurs on Save button click
- Dialog won't close if validation fails
- Errors clear automatically when user types
- Errors reset when provider is changed

## Validation Rules

- **Endpoint URL**: Always required for all providers
- **API Key**: Required for all providers except Ollama

## Testing

- Verified validation with OpenAI provider
-  Verified Ollama provider allows empty API Key
-  Verified Endpoint URL is always required
-  Confirmed errors clear when typing
-  Confirmed errors reset on provider change
- Verified `flutter analyze` passes with no new issues

## Screenshots

_Add screenshots showing error states if possible_