### PR TITLE
Fix crash in collection filter when AI Requests have null httpRequestModel

### DIFF
--- a/lib/screens/home_page/collection_pane.dart
+++ b/lib/screens/home_page/collection_pane.dart
@@ -146,10 +146,7 @@ class _RequestListState extends ConsumerState<RequestList> {
               controller: controller,
               children: requestSequence.map((id) {
                 var item = requestItems[id]!;
-                if (item.httpRequestModel!.url.toLowerCase().contains(
-                      filterQuery,
-                    ) ||
-                    item.name.toLowerCase().contains(filterQuery)) {
+                if (_matchesFilter(item, filterQuery)) {
                   return Padding(
                     padding: kP1,
                     child: RequestItem(id: id, requestModel: item),
@@ -161,6 +158,14 @@ class _RequestListState extends ConsumerState<RequestList> {
     );
   }
 }
+
+bool _matchesFilter(RequestModel item, String query) {
+  final matchName = item.name.toLowerCase().contains(query);
+  final matchUrl =
+      item.httpRequestModel?.url?.toLowerCase().contains(query) == true;
+  return matchName || matchUrl;
+}
+
 
 class RequestItem extends ConsumerWidget {
   const RequestItem({super.key, required this.id, required this.requestModel});


### PR DESCRIPTION
Fixes #1113

This PR fixes a crash occurring when using the collection filter if AI Requests exist.

Root cause:
The filtering logic forcefully accessed `httpRequestModel!.url`. AI Requests intentionally do not contain an HTTP request model, causing a null dereference at runtime.

Solution:
• Replaced unsafe null assertion with null-aware access (`?.`)
• Separated name and URL filtering logic
• Ensured AI requests are filtered by name only
• Preserved existing behavior for HTTP requests

Result:
Filtering now works safely for mixed collections of HTTP and AI requests without crashing.