### PR TITLE
Fix Dashbot AI integration bug with Ollama provider #1296

### DIFF
--- a/lib/screens/common_widgets/ai/ai_model_selector_dialog.dart
+++ b/lib/screens/common_widgets/ai/ai_model_selector_dialog.dart
@@ -68,8 +68,16 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
                           onChanged: (x) {
                             setState(() {
                               selectedProvider = x;
-                              newAIRequestModel = mappedData[selectedProvider]
+                              final defaultModel = mappedData[selectedProvider]
                                   ?.toAiRequestModel();
+                              if (newAIRequestModel != null) {
+                                newAIRequestModel = newAIRequestModel!.copyWith(
+                                  modelApiProvider: selectedProvider,
+                                  model: defaultModel?.model,
+                                );
+                              } else {
+                                newAIRequestModel = defaultModel;
+                              }
                             });
                           },
                           value: selectedProvider,
@@ -121,8 +129,16 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
                             onTap: () {
                               setState(() {
                                 selectedProvider = x.providerId;
-                                newAIRequestModel = mappedData[selectedProvider]
+                                final defaultModel = mappedData[selectedProvider]
                                     ?.toAiRequestModel();
+                                if (newAIRequestModel != null) {
+                                  newAIRequestModel = newAIRequestModel!.copyWith(
+                                    modelApiProvider: selectedProvider,
+                                    model: defaultModel?.model,
+                                  );
+                                } else {
+                                  newAIRequestModel = defaultModel;
+                                }
                               });
                             },
                           ),
@@ -181,7 +197,6 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
         Text(kLabelEndpoint),
         kVSpacer8,
         BoundedTextField(
-          key: ValueKey(aiModelProvider.providerName ?? ""),
           onChanged: (x) {
             setState(() {
               newAIRequestModel = newAIRequestModel?.copyWith(url: x);

--- a/packages/genai/lib/interface/model_providers/ollama.dart
+++ b/packages/genai/lib/interface/model_providers/ollama.dart
@@ -1,3 +1,4 @@
+import 'package:better_networking/better_networking.dart';
 import '../../models/models.dart';
 import '../consts.dart';
 import 'openai.dart';
@@ -11,4 +12,53 @@ class OllamaModel extends OpenAIModel {
     url: kOllamaUrl,
     modelConfigs: [kDefaultModelConfigTemperature, kDefaultModelConfigTopP],
   );
+
+  @override
+  HttpRequestModel? createRequest(AIRequestModel? aiRequestModel) {
+    if (aiRequestModel == null) return null;
+
+    if (aiRequestModel.url.endsWith('/api/generate')) {
+      return HttpRequestModel(
+        method: HTTPVerb.post,
+        url: aiRequestModel.url,
+        authModel: aiRequestModel.apiKey == null
+            ? null
+            : AuthModel(
+                type: APIAuthType.bearer,
+                bearer: AuthBearerModel(token: aiRequestModel.apiKey!),
+              ),
+        body: kJsonEncoder.convert({
+          "model": aiRequestModel.model ?? "",
+          "prompt": aiRequestModel.userPrompt.isNotEmpty ? aiRequestModel.userPrompt : "Generate",
+          if (aiRequestModel.systemPrompt.isNotEmpty) "system": aiRequestModel.systemPrompt,
+          ...aiRequestModel.getModelConfigMap(),
+          if (aiRequestModel.stream != null) "stream": aiRequestModel.stream,
+        }),
+      );
+    }
+
+    return super.createRequest(aiRequestModel);
+  }
+
+  @override
+  String? outputFormatter(Map x) {
+    if (x.containsKey("response")) {
+      return x["response"];
+    }
+    if (x.containsKey("message") && x["message"] is Map) {
+      return x["message"]["content"];
+    }
+    return super.outputFormatter(x);
+  }
+
+  @override
+  String? streamOutputFormatter(Map x) {
+    if (x.containsKey("response")) {
+      return x["response"];
+    }
+    if (x.containsKey("message") && x["message"] is Map) {
+      return x["message"]["content"];
+    }
+    return super.streamOutputFormatter(x);
+  }
 }

--- a/packages/genai/lib/interface/model_providers/openai.dart
+++ b/packages/genai/lib/interface/model_providers/openai.dart
@@ -26,7 +26,7 @@ class OpenAIModel extends ModelProvider {
               bearer: AuthBearerModel(token: aiRequestModel.apiKey!),
             ),
       body: kJsonEncoder.convert({
-        "model": aiRequestModel.model,
+        "model": aiRequestModel.model ?? "",
         "messages": [
           {"role": "system", "content": aiRequestModel.systemPrompt},
           if (aiRequestModel.userPrompt.isNotEmpty) ...{

--- a/packages/genai/lib/utils/ai_request_utils.dart
+++ b/packages/genai/lib/utils/ai_request_utils.dart
@@ -6,7 +6,15 @@ import 'package:nanoid/nanoid.dart';
 import '../models/models.dart';
 
 Future<String?> executeGenAIRequest(AIRequestModel? aiRequestModel) async {
-  final httpRequestModel = aiRequestModel?.httpRequestModel;
+  if (aiRequestModel == null) return null;
+  if (aiRequestModel.model == null || aiRequestModel.model!.trim().isEmpty) {
+    throw Exception("AI request failed: Model not selected.");
+  }
+  if (aiRequestModel.url.trim().isEmpty) {
+    throw Exception("AI request failed: URL is required.");
+  }
+
+  final httpRequestModel = aiRequestModel.httpRequestModel;
   if (httpRequestModel == null) {
     debugPrint("executeGenAIRequest -> httpRequestModel is null");
     return null;
@@ -19,17 +27,41 @@ Future<String?> executeGenAIRequest(AIRequestModel? aiRequestModel) async {
   if (response == null) return null;
   if (response.statusCode == 200) {
     final data = jsonDecode(response.body);
-    return aiRequestModel?.getFormattedOutput(data);
+    return aiRequestModel.getFormattedOutput(data);
   } else {
-    debugPrint('LLM_EXCEPTION: ${response.statusCode}\n${response.body}');
-    return null;
+    String errorMsg = "${response.statusCode} - ${response.body}";
+    try {
+      final decoded = jsonDecode(response.body);
+      if (decoded["error"] != null) {
+        if (decoded["error"] is Map && decoded["error"]["message"] != null) {
+          errorMsg = decoded["error"]["message"].toString();
+        } else {
+          errorMsg = decoded["error"].toString();
+        }
+      }
+    } catch (_) {}
+
+    String providerName = aiRequestModel.modelApiProvider?.name ?? 'Unknown';
+    if (providerName.isNotEmpty && providerName != 'Unknown') {
+      providerName = "${providerName[0].toUpperCase()}${providerName.substring(1)}";
+    }
+
+    throw Exception("AI Request Failed\nProvider: $providerName\nError: $errorMsg");
   }
 }
 
 Future<Stream<String?>> streamGenAIRequest(
   AIRequestModel? aiRequestModel,
 ) async {
-  final httpRequestModel = aiRequestModel?.httpRequestModel;
+  if (aiRequestModel == null) return const Stream.empty();
+  if (aiRequestModel.model == null || aiRequestModel.model!.trim().isEmpty) {
+    throw Exception("AI request failed: Model not selected.");
+  }
+  if (aiRequestModel.url.trim().isEmpty) {
+    throw Exception("AI request failed: URL is required.");
+  }
+
+  final httpRequestModel = aiRequestModel.httpRequestModel;
   final streamController = StreamController<String?>();
   if (httpRequestModel == null) {
     debugPrint("streamGenAIRequest -> httpRequestModel is null");

--- a/packages/genai/test/interface/model_providers/ollama_test.dart
+++ b/packages/genai/test/interface/model_providers/ollama_test.dart
@@ -1,0 +1,92 @@
+import 'dart:convert';
+import 'package:better_networking/better_networking.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genai/interface/consts.dart';
+import 'package:genai/interface/model_providers/ollama.dart';
+import 'package:genai/models/models.dart';
+
+void main() {
+  group('OllamaModel Request Generation', () {
+    test('creates raw prompt request for /api/generate', () {
+      final aiRequestModel = AIRequestModel(
+        modelApiProvider: ModelAPIProvider.ollama,
+        url: 'http://localhost:11434/api/generate',
+        model: 'llama2',
+        systemPrompt: 'You are a helpful assistant.',
+        userPrompt: 'Tell me a joke.',
+        stream: false,
+      );
+
+      final httpRequest = OllamaModel.instance.createRequest(aiRequestModel);
+
+      expect(httpRequest, isNotNull);
+      expect(httpRequest!.method, HTTPVerb.post);
+      expect(httpRequest.url, 'http://localhost:11434/api/generate');
+
+      final body = jsonDecode(httpRequest.body!) as Map<String, dynamic>;
+      expect(body['model'], 'llama2');
+      expect(body['prompt'], 'Tell me a joke.');
+      expect(body['system'], 'You are a helpful assistant.');
+      expect(body['stream'], false);
+    });
+
+    test('creates open ai compatible messages array for /api/chat', () {
+      final aiRequestModel = AIRequestModel(
+        modelApiProvider: ModelAPIProvider.ollama,
+        url: 'http://localhost:11434/api/chat',
+        model: 'mistral',
+        systemPrompt: 'System',
+        userPrompt: 'User Message',
+        stream: true,
+      );
+
+      final httpRequest = OllamaModel.instance.createRequest(aiRequestModel);
+
+      expect(httpRequest, isNotNull);
+      expect(httpRequest!.method, HTTPVerb.post);
+
+      final body = jsonDecode(httpRequest.body!) as Map<String, dynamic>;
+      expect(body['model'], 'mistral');
+      expect(body['messages'], isList);
+      final messages = body['messages'] as List;
+      expect(messages.length, 2);
+      expect(messages[0]['role'], 'system');
+      expect(messages[0]['content'], 'System');
+      expect(messages[1]['role'], 'user');
+      expect(messages[1]['content'], 'User Message');
+      expect(body['stream'], true);
+    });
+
+    test('adds Empty model string if model is null', () {
+      final aiRequestModel = AIRequestModel(
+        modelApiProvider: ModelAPIProvider.ollama,
+        url: 'http://localhost:11434/api/chat',
+        model: null,
+      );
+
+      final httpRequest = OllamaModel.instance.createRequest(aiRequestModel);
+      final body = jsonDecode(httpRequest!.body!) as Map<String, dynamic>;
+      expect(body['model'], '');
+    });
+  });
+
+  group('OllamaModel Response Formatters', () {
+    test('outputFormatter parses /api/chat payload', () {
+      final payload = {"model":"llama3","created_at":"2023-08-04T19:22:45.499127Z","message":{"role":"assistant","content":"Sure!"},"done":true};
+      final result = OllamaModel.instance.outputFormatter(payload);
+      expect(result, "Sure!");
+    });
+
+    test('outputFormatter parses /api/generate payload', () {
+      final payload = {"model":"llama3","created_at":"2023-08-04T19:22:45.499127Z","response":"Ok!","done":true};
+      final result = OllamaModel.instance.outputFormatter(payload);
+      expect(result, "Ok!");
+    });
+    
+    test('outputFormatter passes OpenAI format correctly', () {
+      final payload = {"choices": [{"message": {"content": "Hello OpenAI!"}}]};
+      final result = OllamaModel.instance.outputFormatter(payload);
+      expect(result, "Hello OpenAI!");
+    });
+  });
+}


### PR DESCRIPTION
Fix Dashbot AI Model Selector state reset and improve Ollama compatibility #1296 
Problem

Selecting a new AI model in the AIModelSelectorDialog caused previously entered configuration values (such as Custom URL and API Key) to be cleared. This resulted in malformed requests to local providers like Ollama, leading to errors such as:

400 {"error":{"message":"model is required"}}
Root Cause

The dialog recreated a new AIRequestModel instance on every model change instead of updating the existing state. This discarded previously entered configuration fields.

Fix

- Introduced copyWith() updates when switching models to preserve existing configuration

- Removed ValueKey usage in BoundedTextField which triggered widget rebuilds that reset text controllers
 
- Added strict validation in ai_request_utils.dart to ensure model and url are present before executing requests
 
- Improved Ollama request handling by dynamically formatting payloads for /api/chat and /api/generate
 
- Enhanced error propagation to surface server-side API errors directly in the UI

Result

- Custom configuration is preserved when switching AI models

- Ollama integrations work correctly across supported endpoints
 
- Users now receive meaningful error messages instead of generic failures