### PR TITLE
feat: add structured error handling with AgentResult type

### DIFF
--- a/lib/screens/common_widgets/agentic_ui_features/ai_ui_designer/generate_ui_dialog.dart
+++ b/lib/screens/common_widgets/agentic_ui_features/ai_ui_designer/generate_ui_dialog.dart
@@ -40,74 +40,64 @@ class _GenerateUIDialogState extends ConsumerState<GenerateUIDialog> {
   String generatedSDUI = '{}';
 
   Future<String?> generateSDUICode(String apiResponse) async {
-    try {
-      setState(() {
-        index = 1; //Induce Loading
-      });
-      final res = await generateSDUICodeFromResponse(
-        ref: ref,
-        apiResponse: apiResponse,
-      );
-      if (res == null) {
+    setState(() {
+      index = 1; //Induce Loading
+    });
+    final result = await generateSDUICodeFromResponse(
+      ref: ref,
+      apiResponse: apiResponse,
+    );
+    return result.when(
+      success: (code) => code,
+      failure: (exception) {
         setState(() {
           index = 0;
         });
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(
-              kMsgPreviewGenerationFailed,
+              exception.message,
               style: TextStyle(color: Colors.white),
             ),
             backgroundColor: Colors.redAccent,
           ),
         );
         return null;
-      }
-      return res;
-    } catch (e) {
-      String errMsg = kMsgUnexpectedError;
-      if (e.toString().contains('NO_DEFAULT_LLM')) {
-        errMsg = kMsgSelectDefaultAIModel;
-      }
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(errMsg, style: TextStyle(color: Colors.white)),
-          backgroundColor: Colors.redAccent,
-        ),
-      );
-      Navigator.pop(context);
-      return null;
-    }
+      },
+    );
   }
 
   Future<void> modifySDUICode(String modificationRequest) async {
     setState(() {
       index = 1; //Induce Loading
     });
-    final res = await modifySDUICodeUsingPrompt(
+    final result = await modifySDUICodeUsingPrompt(
       generatedSDUI: generatedSDUI,
       ref: ref,
       modificationRequest: modificationRequest,
     );
-    if (res == null) {
-      setState(() {
-        index = 2;
-      });
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            kMsgModificationRequestFailed,
-            style: TextStyle(color: Colors.white),
+    result.when(
+      success: (code) {
+        setState(() {
+          generatedSDUI = code;
+          index = 2;
+        });
+      },
+      failure: (exception) {
+        setState(() {
+          index = 2;
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              exception.message,
+              style: TextStyle(color: Colors.white),
+            ),
+            backgroundColor: Colors.redAccent,
           ),
-          backgroundColor: Colors.redAccent,
-        ),
-      );
-      return;
-    }
-    setState(() {
-      generatedSDUI = res;
-      index = 2;
-    });
+        );
+      },
+    );
   }
 
   @override

--- a/lib/screens/common_widgets/agentic_ui_features/ai_ui_designer/sdui_preview.dart
+++ b/lib/screens/common_widgets/agentic_ui_features/ai_ui_designer/sdui_preview.dart
@@ -29,34 +29,45 @@ class _SDUIPreviewPageState extends ConsumerState<SDUIPreviewPage> {
     setState(() {
       exportingCode = true;
     });
-    final ans = await APIDashAgentCaller.instance.call(
+    final result = await APIDashAgentCaller.instance.call(
       StacToFlutterBot(),
       ref: ref,
       input: AgentInputs(variables: {'VAR_CODE': widget.sduiCode}),
     );
-    final exportedCode = ans?['CODE'];
-
-    if (exportedCode == null) {
-      setState(() {
-        exportingCode = false;
-      });
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            kMsgExportFailed,
-            style: TextStyle(color: Colors.white),
+    result.when(
+      success: (ans) {
+        final exportedCode = ans?['CODE'];
+        if (exportedCode == null) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                kMsgExportFailed,
+                style: TextStyle(color: Colors.white),
+              ),
+              backgroundColor: Colors.redAccent,
+            ),
+          );
+          debugPrint("exportCode: Failed; ABORTING");
+        } else {
+          Clipboard.setData(ClipboardData(text: exportedCode));
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text(kMsgCopiedToClipboard)));
+        }
+      },
+      failure: (exception) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              exception.message,
+              style: TextStyle(color: Colors.white),
+            ),
+            backgroundColor: Colors.redAccent,
           ),
-          backgroundColor: Colors.redAccent,
-        ),
-      );
-      debugPrint("exportCode: Failed; ABORTING");
-      return;
-    }
-
-    Clipboard.setData(ClipboardData(text: ans['CODE']));
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text(kMsgCopiedToClipboard)));
+        );
+        debugPrint("exportCode: $exception");
+      },
+    );
     setState(() {
       exportingCode = false;
     });

--- a/lib/screens/common_widgets/agentic_ui_features/tool_generation/generate_tool_dialog.dart
+++ b/lib/screens/common_widgets/agentic_ui_features/tool_generation/generate_tool_dialog.dart
@@ -68,18 +68,24 @@ class _GenerateToolDialogState extends ConsumerState<GenerateToolDialog> {
   String? generatedToolCode = '';
 
   generateAPITool() async {
-    try {
-      setState(() {
-        generatedToolCode = null;
-        index = 1;
-      });
-      final res = await generateAPIToolUsingRequestData(
-        ref: ref,
-        requestData: widget.requestDesc.generateREQDATA,
-        targetLanguage: selectedLanguage,
-        selectedAgent: selectedAgent,
-      );
-      if (res == null) {
+    setState(() {
+      generatedToolCode = null;
+      index = 1;
+    });
+    final result = await generateAPIToolUsingRequestData(
+      ref: ref,
+      requestData: widget.requestDesc.generateREQDATA,
+      targetLanguage: selectedLanguage,
+      selectedAgent: selectedAgent,
+    );
+    result.when(
+      success: (code) {
+        setState(() {
+          generatedToolCode = code;
+          index = 1;
+        });
+      },
+      failure: (exception) {
         setState(() {
           generatedToolCode = '';
           index = 0;
@@ -87,34 +93,14 @@ class _GenerateToolDialogState extends ConsumerState<GenerateToolDialog> {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(
-              kMsgAPIToolGenerationFailed,
+              exception.message,
               style: TextStyle(color: Colors.white),
             ),
             backgroundColor: Colors.redAccent,
           ),
         );
-        return;
-      }
-      setState(() {
-        generatedToolCode = res;
-        index = 1;
-      });
-    } catch (e) {
-      setState(() {
-        index = 0;
-      });
-      String errMsg = kMsgUnexpectedError;
-      if (e.toString().contains('NO_DEFAULT_LLM')) {
-        errMsg = kMsgSelectDefaultAIModel;
-      }
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(errMsg, style: TextStyle(color: Colors.white)),
-          backgroundColor: Colors.redAccent,
-        ),
-      );
-      Navigator.pop(context);
-    }
+      },
+    );
   }
 
   @override

--- a/lib/services/agentic_services/agent_caller.dart
+++ b/lib/services/agentic_services/agent_caller.dart
@@ -5,7 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 class APIDashAgentCaller {
   static APIDashAgentCaller instance = APIDashAgentCaller();
 
-  Future<dynamic> call(
+  Future<AgentResult<dynamic>> call(
     AIAgent agent, {
     required WidgetRef ref,
     required AgentInputs input,
@@ -13,15 +13,18 @@ class APIDashAgentCaller {
     final defaultAIModel =
         ref.read(settingsProvider.select((e) => e.defaultAIModel));
     if (defaultAIModel == null) {
-      throw Exception('NO_DEFAULT_LLM');
+      return AgentFailure(AgentException(
+        type: AgentErrorType.invalidRequest,
+        message: 'Please select a default AI model in Settings.',
+        agentName: agent.agentName,
+      ));
     }
     final baseAIRequestObject = AIRequestModel.fromJson(defaultAIModel);
-    final ans = await AIAgentService.callAgent(
+    return await AIAgentService.callAgent(
       agent,
       baseAIRequestObject,
       query: input.query,
       variables: input.variables,
     );
-    return ans;
   }
 }

--- a/lib/services/agentic_services/apidash_agent_calls.dart
+++ b/lib/services/agentic_services/apidash_agent_calls.dart
@@ -5,7 +5,7 @@ import 'package:apidash_core/apidash_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-Future<String?> generateSDUICodeFromResponse({
+Future<AgentResult<String>> generateSDUICodeFromResponse({
   required WidgetRef ref,
   required String apiResponse,
 }) async {
@@ -23,17 +23,33 @@ Future<String?> generateSDUICodeFromResponse({
       }),
     ),
   ]);
-  final sa = step1Res[0]?['SEMANTIC_ANALYSIS'];
-  final ir = step1Res[1]?['INTERMEDIATE_REPRESENTATION'];
+
+  final saResult = step1Res[0];
+  final irResult = step1Res[1];
+
+  // Return the first failure encountered
+  if (saResult.isFailure) {
+    return AgentFailure((saResult as AgentFailure).exception);
+  }
+  if (irResult.isFailure) {
+    return AgentFailure((irResult as AgentFailure).exception);
+  }
+
+  final sa = saResult.valueOrNull?['SEMANTIC_ANALYSIS'];
+  final ir = irResult.valueOrNull?['INTERMEDIATE_REPRESENTATION'];
 
   if (sa == null || ir == null) {
-    return null;
+    return AgentFailure(AgentException(
+      type: AgentErrorType.validationFailed,
+      message: 'Semantic analysis or intermediate representation was empty.',
+      agentName: 'SDUICodeGeneration',
+    ));
   }
 
   debugPrint("Semantic Analysis: $sa");
   debugPrint("Intermediate Representation: $ir");
 
-  final sduiCode = await APIDashAgentCaller.instance.call(
+  final sduiResult = await APIDashAgentCaller.instance.call(
     StacGenBot(),
     ref: ref,
     input: AgentInputs(variables: {
@@ -42,20 +58,29 @@ Future<String?> generateSDUICodeFromResponse({
       'VAR_SEMANTIC_ANALYSIS': sa,
     }),
   );
-  final stacCode = sduiCode?['STAC']?.toString();
-  if (stacCode == null) {
-    return null;
+
+  if (sduiResult.isFailure) {
+    return AgentFailure((sduiResult as AgentFailure).exception);
   }
 
-  return sduiCode['STAC'].toString();
+  final stacCode = sduiResult.valueOrNull?['STAC']?.toString();
+  if (stacCode == null) {
+    return AgentFailure(AgentException(
+      type: AgentErrorType.validationFailed,
+      message: 'STAC code generation returned empty output.',
+      agentName: 'StacGenBot',
+    ));
+  }
+
+  return AgentSuccess(stacCode);
 }
 
-Future<String?> modifySDUICodeUsingPrompt({
+Future<AgentResult<String>> modifySDUICodeUsingPrompt({
   required WidgetRef ref,
   required String generatedSDUI,
   required String modificationRequest,
 }) async {
-  final res = await APIDashAgentCaller.instance.call(
+  final result = await APIDashAgentCaller.instance.call(
     StacModifierBot(),
     ref: ref,
     input: AgentInputs(variables: {
@@ -63,17 +88,30 @@ Future<String?> modifySDUICodeUsingPrompt({
       'VAR_CLIENT_REQUEST': modificationRequest,
     }),
   );
-  final sdui = res?['STAC'];
-  return sdui;
+
+  if (result.isFailure) {
+    return AgentFailure((result as AgentFailure).exception);
+  }
+
+  final sdui = result.valueOrNull?['STAC'];
+  if (sdui == null) {
+    return AgentFailure(AgentException(
+      type: AgentErrorType.validationFailed,
+      message: 'STAC modification returned empty output.',
+      agentName: 'StacModifierBot',
+    ));
+  }
+
+  return AgentSuccess(sdui);
 }
 
-Future<String?> generateAPIToolUsingRequestData({
+Future<AgentResult<String>> generateAPIToolUsingRequestData({
   required WidgetRef ref,
   required String requestData,
   required String targetLanguage,
   required String selectedAgent,
 }) async {
-  final toolfuncRes = await APIDashAgentCaller.instance.call(
+  final toolfuncResult = await APIDashAgentCaller.instance.call(
     APIToolFunctionGenerator(),
     ref: ref,
     input: AgentInputs(variables: {
@@ -81,13 +119,23 @@ Future<String?> generateAPIToolUsingRequestData({
       'TARGET_LANGUAGE': targetLanguage,
     }),
   );
-  if (toolfuncRes == null) {
-    return null;
+
+  if (toolfuncResult.isFailure) {
+    return AgentFailure((toolfuncResult as AgentFailure).exception);
   }
 
-  String toolCode = toolfuncRes!['FUNC'];
+  final toolFunc = toolfuncResult.valueOrNull;
+  if (toolFunc == null) {
+    return AgentFailure(AgentException(
+      type: AgentErrorType.validationFailed,
+      message: 'API tool function generation returned empty output.',
+      agentName: 'APIToolFunctionGenerator',
+    ));
+  }
 
-  final toolres = await APIDashAgentCaller.instance.call(
+  String toolCode = toolFunc['FUNC'];
+
+  final toolResult = await APIDashAgentCaller.instance.call(
     ApiToolBodyGen(),
     ref: ref,
     input: AgentInputs(variables: {
@@ -96,9 +144,19 @@ Future<String?> generateAPIToolUsingRequestData({
               .substitutePromptVariable('FUNC', toolCode),
     }),
   );
-  if (toolres == null) {
-    return null;
+
+  if (toolResult.isFailure) {
+    return AgentFailure((toolResult as AgentFailure).exception);
   }
-  String toolDefinition = toolres!['TOOL'];
-  return toolDefinition;
+
+  final toolBody = toolResult.valueOrNull;
+  if (toolBody == null) {
+    return AgentFailure(AgentException(
+      type: AgentErrorType.validationFailed,
+      message: 'API tool body generation returned empty output.',
+      agentName: 'ApiToolBodyGen',
+    ));
+  }
+
+  return AgentSuccess(toolBody['TOOL'] as String);
 }

--- a/packages/genai/lib/agentic_engine/agent_result.dart
+++ b/packages/genai/lib/agentic_engine/agent_result.dart
@@ -1,0 +1,105 @@
+/// The type of error that caused an agent call to fail.
+enum AgentErrorType {
+  /// The LLM provider returned an authentication error (401/403).
+  authFailure,
+
+  /// The LLM provider returned a rate limit error (429).
+  rateLimited,
+
+  /// The LLM request or response model was invalid/null.
+  invalidRequest,
+
+  /// The LLM returned a response that failed the agent's validator
+  /// after all retry attempts were exhausted.
+  validationFailed,
+
+  /// A network or HTTP error occurred while calling the LLM provider.
+  networkError,
+
+  /// An unexpected error occurred.
+  unexpected,
+}
+
+/// Structured error returned when an agent call fails.
+class AgentException implements Exception {
+  /// The category of the error.
+  final AgentErrorType type;
+
+  /// A human-readable message describing what went wrong.
+  final String message;
+
+  /// The name of the agent that failed.
+  final String agentName;
+
+  /// How many retry attempts were made before giving up.
+  final int retryAttempts;
+
+  /// The underlying exception, if any.
+  final Object? cause;
+
+  const AgentException({
+    required this.type,
+    required this.message,
+    required this.agentName,
+    this.retryAttempts = 0,
+    this.cause,
+  });
+
+  @override
+  String toString() =>
+      'AgentException(${type.name}): [$agentName] $message'
+      '${retryAttempts > 0 ? ' (after $retryAttempts retries)' : ''}'
+      '${cause != null ? '\nCaused by: $cause' : ''}';
+}
+
+/// The result of calling an AI agent — either a success with data,
+/// or a failure with a structured [AgentException].
+sealed class AgentResult<T> {
+  const AgentResult();
+
+  /// Returns `true` if this is a successful result.
+  bool get isSuccess => this is AgentSuccess<T>;
+
+  /// Returns `true` if this is a failure result.
+  bool get isFailure => this is AgentFailure<T>;
+
+  /// Returns the success value, or `null` if this is a failure.
+  T? get valueOrNull => switch (this) {
+        AgentSuccess<T>(:final value) => value,
+        AgentFailure<T>() => null,
+      };
+
+  /// Returns the exception, or `null` if this is a success.
+  AgentException? get exceptionOrNull => switch (this) {
+        AgentSuccess<T>() => null,
+        AgentFailure<T>(:final exception) => exception,
+      };
+
+  /// Maps success value using [onSuccess], or returns [onFailure] result.
+  R when<R>({
+    required R Function(T value) success,
+    required R Function(AgentException exception) failure,
+  }) =>
+      switch (this) {
+        AgentSuccess<T>(:final value) => success(value),
+        AgentFailure<T>(:final exception) => failure(exception),
+      };
+}
+
+/// A successful agent result containing the output [value].
+class AgentSuccess<T> extends AgentResult<T> {
+  final T value;
+  const AgentSuccess(this.value);
+
+  @override
+  String toString() => 'AgentSuccess($value)';
+}
+
+/// A failed agent result containing a structured [exception].
+class AgentFailure<T> extends AgentResult<T> {
+  final AgentException exception;
+  const AgentFailure(this.exception);
+
+  @override
+  String toString() => 'AgentFailure($exception)';
+}

--- a/packages/genai/lib/agentic_engine/agent_service.dart
+++ b/packages/genai/lib/agentic_engine/agent_service.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/foundation.dart';
 import '../models/models.dart';
 import '../utils/utils.dart';
+import 'agent_result.dart';
 import 'blueprint.dart';
 
 class AIAgentService {
-  static Future<String?> _call_provider({
+  static Future<String?> _callProvider({
     required AIRequestModel baseAIRequestObject,
     required String systemPrompt,
     required String input,
@@ -31,21 +32,31 @@ class AIAgentService {
       }
     }
 
-    return await _call_provider(
+    return await _callProvider(
       systemPrompt: sP,
       input: query ?? '',
       baseAIRequestObject: baseAIRequestObject,
     );
   }
 
-  static Future<dynamic> _governor(
+  static Future<AgentResult<dynamic>> _governor(
     AIAgent agent,
     AIRequestModel baseAIRequestObject, {
     String? query,
     Map? variables,
   }) async {
-    int RETRY_COUNT = 0;
-    List<int> backoffDelays = [200, 400, 800, 1600, 3200];
+    if (baseAIRequestObject.httpRequestModel == null) {
+      return AgentFailure(AgentException(
+        type: AgentErrorType.invalidRequest,
+        message: 'Could not build HTTP request from AI model configuration.',
+        agentName: agent.agentName,
+      ));
+    }
+
+    int retryCount = 0;
+    Object? lastError;
+    const backoffDelays = [200, 400, 800, 1600, 3200];
+
     do {
       try {
         final res = await _orchestrator(
@@ -56,27 +67,93 @@ class AIAgentService {
         );
         if (res != null) {
           if (await agent.validator(res)) {
-            return agent.outputFormatter(res);
+            final output = await agent.outputFormatter(res);
+            return AgentSuccess(output);
           }
         }
       } catch (e) {
-        "AIAgentService::Governor: Exception Occurred: $e";
+        lastError = e;
+        debugPrint(
+          "AIAgentService::Governor: Exception in ${agent.agentName}: $e",
+        );
+
+        final errorType = _classifyError(e);
+        // Don't retry auth failures — they won't self-resolve.
+        if (errorType == AgentErrorType.authFailure) {
+          return AgentFailure(AgentException(
+            type: AgentErrorType.authFailure,
+            message:
+                'Authentication failed. Please check your API key in Settings.',
+            agentName: agent.agentName,
+            retryAttempts: retryCount,
+            cause: e,
+          ));
+        }
       }
+
       // Exponential Backoff
-      if (RETRY_COUNT < backoffDelays.length) {
+      if (retryCount < backoffDelays.length) {
         await Future.delayed(
-          Duration(milliseconds: backoffDelays[RETRY_COUNT]),
+          Duration(milliseconds: backoffDelays[retryCount]),
         );
       }
-      RETRY_COUNT += 1;
+      retryCount += 1;
       debugPrint(
-        "Retrying AgentCall for (${agent.agentName}): ATTEMPT: $RETRY_COUNT",
+        "Retrying AgentCall for (${agent.agentName}): ATTEMPT: $retryCount",
       );
-    } while (RETRY_COUNT < 5);
-    return null;
+    } while (retryCount < 5);
+
+    // All retries exhausted
+    final errorType =
+        lastError != null ? _classifyError(lastError) : AgentErrorType.validationFailed;
+    return AgentFailure(AgentException(
+      type: errorType,
+      message: _messageForErrorType(errorType, agent.agentName),
+      agentName: agent.agentName,
+      retryAttempts: retryCount,
+      cause: lastError,
+    ));
   }
 
-  static Future<dynamic> callAgent(
+  /// Classifies an error into an [AgentErrorType] based on common patterns.
+  static AgentErrorType _classifyError(Object error) {
+    final msg = error.toString().toLowerCase();
+    if (msg.contains('401') ||
+        msg.contains('403') ||
+        msg.contains('unauthorized') ||
+        msg.contains('forbidden')) {
+      return AgentErrorType.authFailure;
+    }
+    if (msg.contains('429') || msg.contains('rate limit')) {
+      return AgentErrorType.rateLimited;
+    }
+    if (msg.contains('socketexception') ||
+        msg.contains('connection') ||
+        msg.contains('timeout') ||
+        msg.contains('network')) {
+      return AgentErrorType.networkError;
+    }
+    return AgentErrorType.unexpected;
+  }
+
+  static String _messageForErrorType(AgentErrorType type, String agentName) {
+    return switch (type) {
+      AgentErrorType.authFailure =>
+        'Authentication failed. Please check your API key in Settings.',
+      AgentErrorType.rateLimited =>
+        'Rate limit exceeded. Please try again later.',
+      AgentErrorType.invalidRequest =>
+        'Invalid request configuration for $agentName.',
+      AgentErrorType.validationFailed =>
+        'Agent $agentName could not produce a valid response after multiple attempts.',
+      AgentErrorType.networkError =>
+        'Network error. Please check your internet connection.',
+      AgentErrorType.unexpected =>
+        'An unexpected error occurred in $agentName.',
+    };
+  }
+
+  static Future<AgentResult<dynamic>> callAgent(
     AIAgent agent,
     AIRequestModel baseAIRequestObject, {
     String? query,

--- a/packages/genai/lib/agentic_engine/agentic_engine.dart
+++ b/packages/genai/lib/agentic_engine/agentic_engine.dart
@@ -1,2 +1,3 @@
+export 'agent_result.dart';
 export 'agent_service.dart';
 export 'blueprint.dart';

--- a/packages/genai/test/agentic_engine/agent_result_test.dart
+++ b/packages/genai/test/agentic_engine/agent_result_test.dart
@@ -1,0 +1,377 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genai/agentic_engine/agent_result.dart';
+
+void main() {
+  group('AgentErrorType', () {
+    test('has all expected error types', () {
+      expect(AgentErrorType.values, containsAll([
+        AgentErrorType.authFailure,
+        AgentErrorType.rateLimited,
+        AgentErrorType.invalidRequest,
+        AgentErrorType.validationFailed,
+        AgentErrorType.networkError,
+        AgentErrorType.unexpected,
+      ]));
+    });
+
+    test('has exactly 6 error types', () {
+      expect(AgentErrorType.values.length, 6);
+    });
+  });
+
+  group('AgentException', () {
+    test('creates with required fields', () {
+      const exception = AgentException(
+        type: AgentErrorType.authFailure,
+        message: 'Auth failed',
+        agentName: 'TestAgent',
+      );
+
+      expect(exception.type, AgentErrorType.authFailure);
+      expect(exception.message, 'Auth failed');
+      expect(exception.agentName, 'TestAgent');
+      expect(exception.retryAttempts, 0);
+      expect(exception.cause, isNull);
+    });
+
+    test('creates with all fields', () {
+      final cause = Exception('underlying error');
+      final exception = AgentException(
+        type: AgentErrorType.rateLimited,
+        message: 'Rate limited',
+        agentName: 'TestAgent',
+        retryAttempts: 3,
+        cause: cause,
+      );
+
+      expect(exception.type, AgentErrorType.rateLimited);
+      expect(exception.message, 'Rate limited');
+      expect(exception.agentName, 'TestAgent');
+      expect(exception.retryAttempts, 3);
+      expect(exception.cause, cause);
+    });
+
+    test('implements Exception', () {
+      const exception = AgentException(
+        type: AgentErrorType.unexpected,
+        message: 'test',
+        agentName: 'TestAgent',
+      );
+      expect(exception, isA<Exception>());
+    });
+
+    test('toString includes type, agent name and message', () {
+      const exception = AgentException(
+        type: AgentErrorType.networkError,
+        message: 'Connection failed',
+        agentName: 'MyAgent',
+      );
+      final str = exception.toString();
+      expect(str, contains('networkError'));
+      expect(str, contains('MyAgent'));
+      expect(str, contains('Connection failed'));
+    });
+
+    test('toString includes retry attempts when non-zero', () {
+      const exception = AgentException(
+        type: AgentErrorType.validationFailed,
+        message: 'Failed validation',
+        agentName: 'TestAgent',
+        retryAttempts: 5,
+      );
+      final str = exception.toString();
+      expect(str, contains('after 5 retries'));
+    });
+
+    test('toString does not include retry info when zero', () {
+      const exception = AgentException(
+        type: AgentErrorType.authFailure,
+        message: 'Auth error',
+        agentName: 'TestAgent',
+        retryAttempts: 0,
+      );
+      final str = exception.toString();
+      expect(str, isNot(contains('retries')));
+    });
+
+    test('toString includes cause when present', () {
+      final exception = AgentException(
+        type: AgentErrorType.unexpected,
+        message: 'Error',
+        agentName: 'TestAgent',
+        cause: Exception('root cause'),
+      );
+      final str = exception.toString();
+      expect(str, contains('Caused by'));
+      expect(str, contains('root cause'));
+    });
+
+    test('toString excludes cause when null', () {
+      const exception = AgentException(
+        type: AgentErrorType.unexpected,
+        message: 'Error',
+        agentName: 'TestAgent',
+      );
+      final str = exception.toString();
+      expect(str, isNot(contains('Caused by')));
+    });
+  });
+
+  group('AgentResult', () {
+    group('AgentSuccess', () {
+      test('wraps a value', () {
+        const result = AgentSuccess('hello');
+        expect(result.value, 'hello');
+      });
+
+      test('isSuccess returns true', () {
+        const result = AgentSuccess(42);
+        expect(result.isSuccess, isTrue);
+      });
+
+      test('isFailure returns false', () {
+        const result = AgentSuccess(42);
+        expect(result.isFailure, isFalse);
+      });
+
+      test('valueOrNull returns the value', () {
+        const result = AgentSuccess<String>('data');
+        expect(result.valueOrNull, 'data');
+      });
+
+      test('exceptionOrNull returns null', () {
+        const result = AgentSuccess<String>('data');
+        expect(result.exceptionOrNull, isNull);
+      });
+
+      test('is an AgentResult', () {
+        const result = AgentSuccess('test');
+        expect(result, isA<AgentResult<String>>());
+      });
+
+      test('toString includes value', () {
+        const result = AgentSuccess('my_value');
+        expect(result.toString(), contains('my_value'));
+      });
+
+      test('wraps null value', () {
+        const result = AgentSuccess<String?>(null);
+        expect(result.value, isNull);
+        expect(result.isSuccess, isTrue);
+      });
+
+      test('wraps Map value', () {
+        const result = AgentSuccess({'key': 'value'});
+        expect(result.value, {'key': 'value'});
+      });
+    });
+
+    group('AgentFailure', () {
+      const exception = AgentException(
+        type: AgentErrorType.authFailure,
+        message: 'Auth failed',
+        agentName: 'TestAgent',
+      );
+
+      test('wraps an exception', () {
+        const result = AgentFailure<String>(exception);
+        expect(result.exception, exception);
+      });
+
+      test('isSuccess returns false', () {
+        const result = AgentFailure<String>(exception);
+        expect(result.isSuccess, isFalse);
+      });
+
+      test('isFailure returns true', () {
+        const result = AgentFailure<String>(exception);
+        expect(result.isFailure, isTrue);
+      });
+
+      test('valueOrNull returns null', () {
+        const result = AgentFailure<String>(exception);
+        expect(result.valueOrNull, isNull);
+      });
+
+      test('exceptionOrNull returns the exception', () {
+        const result = AgentFailure<String>(exception);
+        expect(result.exceptionOrNull, exception);
+      });
+
+      test('is an AgentResult', () {
+        const result = AgentFailure<String>(exception);
+        expect(result, isA<AgentResult<String>>());
+      });
+
+      test('toString includes exception', () {
+        const result = AgentFailure<String>(exception);
+        expect(result.toString(), contains('AgentFailure'));
+        expect(result.toString(), contains('Auth failed'));
+      });
+    });
+
+    group('when', () {
+      test('calls success callback for AgentSuccess', () {
+        const AgentResult<String> result = AgentSuccess('data');
+        final output = result.when(
+          success: (value) => 'Got: $value',
+          failure: (exception) => 'Error: ${exception.message}',
+        );
+        expect(output, 'Got: data');
+      });
+
+      test('calls failure callback for AgentFailure', () {
+        const AgentResult<String> result = AgentFailure(AgentException(
+          type: AgentErrorType.networkError,
+          message: 'No internet',
+          agentName: 'TestAgent',
+        ));
+        final output = result.when(
+          success: (value) => 'Got: $value',
+          failure: (exception) => 'Error: ${exception.message}',
+        );
+        expect(output, 'Error: No internet');
+      });
+
+      test('supports different return types', () {
+        const AgentResult<int> result = AgentSuccess(42);
+        final output = result.when(
+          success: (value) => value * 2,
+          failure: (exception) => -1,
+        );
+        expect(output, 84);
+      });
+
+      test('success callback receives the exact value', () {
+        final map = {'STAC': '{"type":"text"}'};
+        final AgentResult<Map<String, String>> result = AgentSuccess(map);
+        result.when(
+          success: (value) {
+            expect(value, same(map));
+            expect(value['STAC'], '{"type":"text"}');
+          },
+          failure: (exception) => fail('Should not reach failure'),
+        );
+      });
+
+      test('failure callback receives the exact exception', () {
+        const exception = AgentException(
+          type: AgentErrorType.validationFailed,
+          message: 'Invalid JSON',
+          agentName: 'StacGenBot',
+          retryAttempts: 5,
+        );
+        const AgentResult<String> result = AgentFailure(exception);
+        result.when(
+          success: (value) => fail('Should not reach success'),
+          failure: (e) {
+            expect(e.type, AgentErrorType.validationFailed);
+            expect(e.agentName, 'StacGenBot');
+            expect(e.retryAttempts, 5);
+          },
+        );
+      });
+    });
+
+    group('pattern matching', () {
+      test('switch expression works with AgentSuccess', () {
+        const AgentResult<String> result = AgentSuccess('test');
+        final output = switch (result) {
+          AgentSuccess(:final value) => 'Success: $value',
+          AgentFailure(:final exception) => 'Failure: ${exception.message}',
+        };
+        expect(output, 'Success: test');
+      });
+
+      test('switch expression works with AgentFailure', () {
+        const AgentResult<String> result = AgentFailure(AgentException(
+          type: AgentErrorType.rateLimited,
+          message: 'Too many requests',
+          agentName: 'TestAgent',
+        ));
+        final output = switch (result) {
+          AgentSuccess(:final value) => 'Success: $value',
+          AgentFailure(:final exception) => 'Failure: ${exception.message}',
+        };
+        expect(output, 'Failure: Too many requests');
+      });
+    });
+
+    group('type safety', () {
+      test('AgentSuccess with dynamic type', () {
+        final AgentResult<dynamic> result =
+            AgentSuccess({'FUNC': 'def my_func(): pass'});
+        expect(result.isSuccess, isTrue);
+        expect(result.valueOrNull, isA<Map>());
+      });
+
+      test('AgentFailure preserves type parameter', () {
+        const AgentResult<Map<String, dynamic>> result = AgentFailure(
+          AgentException(
+            type: AgentErrorType.unexpected,
+            message: 'Error',
+            agentName: 'TestAgent',
+          ),
+        );
+        expect(result.isFailure, isTrue);
+        expect(result.valueOrNull, isNull);
+      });
+    });
+  });
+
+  group('AgentErrorType coverage', () {
+    test('authFailure for authentication issues', () {
+      const exception = AgentException(
+        type: AgentErrorType.authFailure,
+        message: 'Invalid API key',
+        agentName: 'TestAgent',
+      );
+      expect(exception.type, AgentErrorType.authFailure);
+    });
+
+    test('rateLimited for rate limit errors', () {
+      const exception = AgentException(
+        type: AgentErrorType.rateLimited,
+        message: 'Too many requests',
+        agentName: 'TestAgent',
+      );
+      expect(exception.type, AgentErrorType.rateLimited);
+    });
+
+    test('invalidRequest for bad configuration', () {
+      const exception = AgentException(
+        type: AgentErrorType.invalidRequest,
+        message: 'No model configured',
+        agentName: 'TestAgent',
+      );
+      expect(exception.type, AgentErrorType.invalidRequest);
+    });
+
+    test('validationFailed for invalid LLM output', () {
+      const exception = AgentException(
+        type: AgentErrorType.validationFailed,
+        message: 'Response was not valid JSON',
+        agentName: 'StacGenBot',
+      );
+      expect(exception.type, AgentErrorType.validationFailed);
+    });
+
+    test('networkError for connectivity issues', () {
+      const exception = AgentException(
+        type: AgentErrorType.networkError,
+        message: 'No internet connection',
+        agentName: 'TestAgent',
+      );
+      expect(exception.type, AgentErrorType.networkError);
+    });
+
+    test('unexpected for unknown errors', () {
+      const exception = AgentException(
+        type: AgentErrorType.unexpected,
+        message: 'Something went wrong',
+        agentName: 'TestAgent',
+      );
+      expect(exception.type, AgentErrorType.unexpected);
+    });
+  });
+}

--- a/packages/genai/test/agentic_engine/agent_service_test.dart
+++ b/packages/genai/test/agentic_engine/agent_service_test.dart
@@ -1,0 +1,186 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genai/agentic_engine/agent_result.dart';
+import 'package:genai/agentic_engine/agent_service.dart';
+import 'package:genai/agentic_engine/blueprint.dart';
+import 'package:genai/models/models.dart';
+
+/// An agent that always validates and returns a formatted result.
+class SuccessAgent extends AIAgent {
+  @override
+  String get agentName => 'SuccessAgent';
+
+  @override
+  String getSystemPrompt() => 'You are a test agent.';
+
+  @override
+  Future<bool> validator(String aiResponse) async => true;
+
+  @override
+  Future<dynamic> outputFormatter(String validatedResponse) async =>
+      {'RESULT': validatedResponse};
+}
+
+/// An agent whose validator always rejects the LLM output.
+class AlwaysFailsValidationAgent extends AIAgent {
+  @override
+  String get agentName => 'AlwaysFailsValidation';
+
+  @override
+  String getSystemPrompt() => 'You are a test agent.';
+
+  @override
+  Future<bool> validator(String aiResponse) async => false;
+
+  @override
+  Future<dynamic> outputFormatter(String validatedResponse) async =>
+      validatedResponse;
+}
+
+/// An agent whose validator throws an exception.
+class ThrowingValidatorAgent extends AIAgent {
+  final Object errorToThrow;
+  ThrowingValidatorAgent(this.errorToThrow);
+
+  @override
+  String get agentName => 'ThrowingValidator';
+
+  @override
+  String getSystemPrompt() => 'You are a test agent.';
+
+  @override
+  Future<bool> validator(String aiResponse) async => throw errorToThrow;
+
+  @override
+  Future<dynamic> outputFormatter(String validatedResponse) async =>
+      validatedResponse;
+}
+
+/// An agent with prompt variables.
+class TemplatedAgent extends AIAgent {
+  @override
+  String get agentName => 'TemplatedAgent';
+
+  @override
+  String getSystemPrompt() => 'Process :DATA: now.';
+
+  @override
+  Future<bool> validator(String aiResponse) async => aiResponse.isNotEmpty;
+
+  @override
+  Future<dynamic> outputFormatter(String validatedResponse) async =>
+      {'OUTPUT': validatedResponse};
+}
+
+void main() {
+  group('AIAgentService.callAgent', () {
+    test('returns AgentFailure with invalidRequest when httpRequestModel is null', () async {
+      // An AIRequestModel with no modelApiProvider produces null httpRequestModel
+      const aiRequest = AIRequestModel();
+      final agent = SuccessAgent();
+
+      final result = await AIAgentService.callAgent(agent, aiRequest);
+
+      expect(result, isA<AgentFailure>());
+      expect(result.isFailure, isTrue);
+      final failure = result as AgentFailure;
+      expect(failure.exception.type, AgentErrorType.invalidRequest);
+      expect(failure.exception.agentName, 'SuccessAgent');
+    });
+
+    test('returns AgentResult type from callAgent', () async {
+      const aiRequest = AIRequestModel();
+      final agent = SuccessAgent();
+
+      final result = await AIAgentService.callAgent(agent, aiRequest);
+
+      expect(result, isA<AgentResult>());
+    });
+
+    test('AgentFailure exception contains agent name', () async {
+      const aiRequest = AIRequestModel();
+      final agent = AlwaysFailsValidationAgent();
+
+      final result = await AIAgentService.callAgent(agent, aiRequest);
+
+      expect(result.isFailure, isTrue);
+      expect(result.exceptionOrNull?.agentName, 'AlwaysFailsValidation');
+    });
+
+    test('callAgent passes query parameter', () async {
+      const aiRequest = AIRequestModel();
+      final agent = SuccessAgent();
+
+      final result = await AIAgentService.callAgent(
+        agent,
+        aiRequest,
+        query: 'test query',
+      );
+
+      // With null httpRequestModel, it returns invalidRequest failure
+      expect(result.isFailure, isTrue);
+    });
+
+    test('callAgent passes variables parameter', () async {
+      const aiRequest = AIRequestModel();
+      final agent = TemplatedAgent();
+
+      final result = await AIAgentService.callAgent(
+        agent,
+        aiRequest,
+        variables: {'DATA': 'test_value'},
+      );
+
+      // With null httpRequestModel, it returns invalidRequest failure
+      expect(result.isFailure, isTrue);
+    });
+  });
+
+  group('AgentResult integration', () {
+    test('AgentFailure from callAgent can be pattern matched', () async {
+      const aiRequest = AIRequestModel();
+      final agent = SuccessAgent();
+
+      final result = await AIAgentService.callAgent(agent, aiRequest);
+
+      final message = switch (result) {
+        AgentSuccess(:final value) => 'Got: $value',
+        AgentFailure(:final exception) => exception.message,
+      };
+
+      expect(message, contains('Could not build HTTP request'));
+    });
+
+    test('AgentFailure from callAgent works with when()', () async {
+      const aiRequest = AIRequestModel();
+      final agent = SuccessAgent();
+
+      final result = await AIAgentService.callAgent(agent, aiRequest);
+
+      final handled = result.when(
+        success: (value) => 'success',
+        failure: (exception) => 'failure: ${exception.type.name}',
+      );
+
+      expect(handled, 'failure: invalidRequest');
+    });
+
+    test('valueOrNull returns null for failure', () async {
+      const aiRequest = AIRequestModel();
+      final agent = SuccessAgent();
+
+      final result = await AIAgentService.callAgent(agent, aiRequest);
+
+      expect(result.valueOrNull, isNull);
+    });
+
+    test('exceptionOrNull returns exception for failure', () async {
+      const aiRequest = AIRequestModel();
+      final agent = SuccessAgent();
+
+      final result = await AIAgentService.callAgent(agent, aiRequest);
+
+      expect(result.exceptionOrNull, isNotNull);
+      expect(result.exceptionOrNull!.type, AgentErrorType.invalidRequest);
+    });
+  });
+}


### PR DESCRIPTION
## PR Description

The agentic engine currently returns `dynamic` from `callAgent()` — on any failure it returns `null` with zero context about what went wrong. Additionally, there's a bug in `AIAgentService._governor()` (line 63) where caught exceptions are silently swallowed via a dead string literal (`"AIAgentService::Governor: Exception Occurred: $e"` — creates a string but never logs/throws it).

This PR introduces structured error handling:

- **`AgentResult<T>`** sealed class with `AgentSuccess<T>` and `AgentFailure<T>` variants
- **`AgentException`** with classified `AgentErrorType` enum (`authFailure`, `rateLimited`, `invalidRequest`, `validationFailed`, `networkError`, `unexpected`)
- Auth failures now skip retries (they won't self-resolve)
- UI dialogs show specific, actionable error messages (e.g., "Please check your API key" instead of generic "Failed!")
- Callers use exhaustive `result.when()` pattern matching — compiler catches unhandled cases
- 50 new unit tests

## Related Issues
- Closes #1221

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
- [x] Yes
  - `agent_result_test.dart` — 41 tests covering AgentResult, AgentSuccess, AgentFailure, AgentException, AgentErrorType, pattern matching, and type safety
  - `agent_service_test.dart` — 9 tests covering AIAgentService.callAgent return types, invalidRequest detection, and AgentResult integration

## OS on which you have developed and tested the feature?
- [x] Windows
- [ ] macOS
- [ ] Linux

