### PR TITLE
feat: implement add custom AI model functionality

### DIFF
--- a/lib/screens/common_widgets/ai/ai_model_selector_dialog.dart
+++ b/lib/screens/common_widgets/ai/ai_model_selector_dialog.dart
@@ -1,6 +1,7 @@
 // import 'package:apidash/providers/providers.dart';
 import 'package:apidash/widgets/widgets.dart';
 import 'package:apidash/consts.dart';
+import 'package:apidash/screens/common_widgets/ai/dialog_add_ai_model.dart';
 import 'package:apidash_core/apidash_core.dart';
 import 'package:apidash_design_system/apidash_design_system.dart';
 import 'package:flutter/material.dart';
@@ -16,7 +17,8 @@ class AIModelSelectorDialog extends ConsumerStatefulWidget {
 }
 
 class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
-  late final Future<AvailableModels> aM;
+  late Future<AvailableModels> aM;
+  AvailableModels? availableModelsData;
   ModelAPIProvider? selectedProvider;
   AIRequestModel? newAIRequestModel;
 
@@ -40,7 +42,8 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
         if (snapshot.connectionState == ConnectionState.done &&
             snapshot.hasData &&
             snapshot.data != null) {
-          final data = snapshot.data!;
+          availableModelsData = snapshot.data!;
+          final data = availableModelsData!;
           final mappedData = data.map;
           if (context.isMediumWindow) {
             return Container(
@@ -194,8 +197,34 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             Text(kLabelModels),
-            // IconButton(
-            //     onPressed: () => addNewModel(context), icon: Icon(Icons.add))
+            IconButton(
+              onPressed: () async {
+                final newModel = await addNewModel(context);
+                if (newModel != null) {
+                  final updatedModels = <Model>[
+                    ...(aiModelProvider.models ?? []),
+                    newModel,
+                  ];
+                  final updatedProvider = aiModelProvider.copyWith(
+                    models: updatedModels,
+                  );
+                  final updatedProviders = availableModelsData!.modelProviders
+                      .map(
+                        (p) => p.providerId == aiModelProvider.providerId
+                            ? updatedProvider
+                            : p,
+                      )
+                      .toList();
+                  setState(() {
+                    availableModelsData = availableModelsData!.copyWith(
+                      modelProviders: updatedProviders,
+                    );
+                    aM = Future.value(availableModelsData);
+                  });
+                }
+              },
+              icon: Icon(Icons.add),
+            ),
           ],
         ),
         kVSpacer8,

--- a/lib/screens/common_widgets/ai/dialog_add_ai_model.dart
+++ b/lib/screens/common_widgets/ai/dialog_add_ai_model.dart
@@ -1,11 +1,12 @@
 import 'package:apidash_design_system/apidash_design_system.dart';
 import 'package:apidash/consts.dart';
+import 'package:apidash_core/apidash_core.dart';
 import 'package:flutter/material.dart';
 
-Future<void> addNewModel(BuildContext context) async {
+Future<Model?> addNewModel(BuildContext context) async {
   TextEditingController iC = TextEditingController();
   TextEditingController nC = TextEditingController();
-  final z = await showDialog(
+  final z = await showDialog<List<String>>(
     context: context,
     builder: (context) {
       return AlertDialog(
@@ -36,7 +37,8 @@ Future<void> addNewModel(BuildContext context) async {
   );
   iC.dispose();
   nC.dispose();
-  if (z == null) return;
-  // TODO: Add logic to add a new model
-  // setState(() {});
+  if (z == null || z[0].trim().isEmpty) return null;
+  final modelId = z[0].trim();
+  final modelName = z[1].trim().isNotEmpty ? z[1].trim() : modelId;
+  return Model(id: modelId, name: modelName);
 }

--- a/lib/screens/common_widgets/ai/dialog_add_ai_model.dart
+++ b/lib/screens/common_widgets/ai/dialog_add_ai_model.dart
@@ -4,41 +4,66 @@ import 'package:apidash_core/apidash_core.dart';
 import 'package:flutter/material.dart';
 
 Future<Model?> addNewModel(BuildContext context) async {
-  TextEditingController iC = TextEditingController();
-  TextEditingController nC = TextEditingController();
   final z = await showDialog<List<String>>(
     context: context,
     builder: (context) {
-      return AlertDialog(
-        title: Text(kLabelAddCustomModel),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ADOutlinedTextField(controller: iC, hintText: kHintModelId),
-            kVSpacer10,
-            ADOutlinedTextField(
-              controller: nC,
-              hintText: kHintModelDisplayName,
-            ),
-            kVSpacer10,
-            SizedBox(
-              width: double.infinity,
-              child: ElevatedButton(
-                onPressed: () {
-                  Navigator.of(context).pop([iC.value.text, nC.value.text]);
-                },
-                child: Text(kLabelAddModel),
-              ),
-            ),
-          ],
-        ),
-      );
+      return const AddCustomModelDialog();
     },
   );
-  iC.dispose();
-  nC.dispose();
   if (z == null || z[0].trim().isEmpty) return null;
   final modelId = z[0].trim();
   final modelName = z[1].trim().isNotEmpty ? z[1].trim() : modelId;
   return Model(id: modelId, name: modelName);
+}
+
+class AddCustomModelDialog extends StatefulWidget {
+  const AddCustomModelDialog({super.key});
+
+  @override
+  State<AddCustomModelDialog> createState() => _AddCustomModelDialogState();
+}
+
+class _AddCustomModelDialogState extends State<AddCustomModelDialog> {
+  late TextEditingController iC;
+  late TextEditingController nC;
+
+  @override
+  void initState() {
+    super.initState();
+    iC = TextEditingController();
+    nC = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    iC.dispose();
+    nC.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      scrollable: true,
+      title: const Text(kLabelAddCustomModel),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ADOutlinedTextField(controller: iC, hintText: kHintModelId),
+          kVSpacer10,
+          ADOutlinedTextField(controller: nC, hintText: kHintModelDisplayName),
+          kVSpacer10,
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).pop([iC.value.text, nC.value.text]);
+              },
+              child: const Text(kLabelAddModel),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
 }

--- a/test/widgets/dialog_add_ai_model_test.dart
+++ b/test/widgets/dialog_add_ai_model_test.dart
@@ -1,0 +1,231 @@
+import 'package:apidash/screens/common_widgets/ai/dialog_add_ai_model.dart';
+import 'package:apidash_core/apidash_core.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('addNewModel Tests', () {
+    testWidgets('displays dialog with correct title and fields', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              return ElevatedButton(
+                onPressed: () => addNewModel(context),
+                child: const Text('Show Dialog'),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add Custom Model'), findsOneWidget);
+      expect(find.text('Add Model'), findsOneWidget);
+      expect(find.byType(TextFormField), findsNWidgets(2));
+    });
+
+    testWidgets('returns Model with id and name when both are provided', (
+      tester,
+    ) async {
+      Model? result;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              return ElevatedButton(
+                onPressed: () async {
+                  result = await addNewModel(context);
+                },
+                child: const Text('Show Dialog'),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      final textFields = find.byType(TextFormField);
+      await tester.enterText(textFields.first, 'gpt-4o');
+      await tester.enterText(textFields.last, 'GPT 4o');
+
+      await tester.tap(find.text('Add Model'));
+      await tester.pumpAndSettle();
+
+      expect(result, isNotNull);
+      expect(result!.id, 'gpt-4o');
+      expect(result!.name, 'GPT 4o');
+    });
+
+    testWidgets('defaults name to id when display name is empty', (
+      tester,
+    ) async {
+      Model? result;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              return ElevatedButton(
+                onPressed: () async {
+                  result = await addNewModel(context);
+                },
+                child: const Text('Show Dialog'),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      final textFields = find.byType(TextFormField);
+      await tester.enterText(textFields.first, 'claude-3');
+
+      await tester.tap(find.text('Add Model'));
+      await tester.pumpAndSettle();
+
+      expect(result, isNotNull);
+      expect(result!.id, 'claude-3');
+      expect(result!.name, 'claude-3');
+    });
+
+    testWidgets('returns null when model id is empty', (tester) async {
+      Model? result;
+      bool callbackExecuted = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              return ElevatedButton(
+                onPressed: () async {
+                  result = await addNewModel(context);
+                  callbackExecuted = true;
+                },
+                child: const Text('Show Dialog'),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      // Leave both fields empty, tap Add Model
+      await tester.tap(find.text('Add Model'));
+      await tester.pumpAndSettle();
+
+      expect(callbackExecuted, isTrue);
+      expect(result, isNull);
+    });
+
+    testWidgets('returns null when model id is only whitespace', (
+      tester,
+    ) async {
+      Model? result;
+      bool callbackExecuted = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              return ElevatedButton(
+                onPressed: () async {
+                  result = await addNewModel(context);
+                  callbackExecuted = true;
+                },
+                child: const Text('Show Dialog'),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      final textFields = find.byType(TextFormField);
+      await tester.enterText(textFields.first, '   ');
+
+      await tester.tap(find.text('Add Model'));
+      await tester.pumpAndSettle();
+
+      expect(callbackExecuted, isTrue);
+      expect(result, isNull);
+    });
+
+    testWidgets('returns null when dialog is dismissed', (tester) async {
+      Model? result;
+      bool callbackExecuted = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              return ElevatedButton(
+                onPressed: () async {
+                  result = await addNewModel(context);
+                  callbackExecuted = true;
+                },
+                child: const Text('Show Dialog'),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      // Dismiss by tapping outside the dialog
+      await tester.tapAt(const Offset(0, 0));
+      await tester.pumpAndSettle();
+
+      expect(callbackExecuted, isTrue);
+      expect(result, isNull);
+    });
+
+    testWidgets('trims whitespace from id and name', (tester) async {
+      Model? result;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              return ElevatedButton(
+                onPressed: () async {
+                  result = await addNewModel(context);
+                },
+                child: const Text('Show Dialog'),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      final textFields = find.byType(TextFormField);
+      await tester.enterText(textFields.first, '  gpt-4o  ');
+      await tester.enterText(textFields.last, '  GPT 4o  ');
+
+      await tester.tap(find.text('Add Model'));
+      await tester.pumpAndSettle();
+
+      expect(result, isNotNull);
+      expect(result!.id, 'gpt-4o');
+      expect(result!.name, 'GPT 4o');
+    });
+  });
+}


### PR DESCRIPTION
## PR Description

Implements the "Add Custom Model" functionality in the AI Model Selector dialog by resolving the TODO in `dialog_add_ai_model.dart`.

**Changes:**

- **`dialog_add_ai_model.dart`**: Changed `addNewModel` return type from `Future<void>` to `Future<Model?>`. Added input validation (empty ID → `null`, empty name defaults to ID) and returns a `Model` object.
- **`ai_model_selector_dialog.dart`**: Imported `dialog_add_ai_model.dart`, made `aM` mutable, added `availableModelsData` to track state. Uncommented and implemented the add model `IconButton` - appends the new model to the selected provider's list and calls `setState` to refresh.

## Related Issues

- Closes #1315

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why:

## OS on which you have developed and tested the feature?

- [x] Windows
- [x] macOS
- [ ] Linux
