### PR TITLE
feat: show response latency in history sidebar cards

### DIFF
--- a/lib/models/history_meta_model.dart
+++ b/lib/models/history_meta_model.dart
@@ -15,6 +15,7 @@ class HistoryMetaModel with _$HistoryMetaModel {
     required HTTPVerb method,
     required int responseStatus,
     required DateTime timeStamp,
+    Duration? latency,
   }) = _HistoryMetaModel;
 
   factory HistoryMetaModel.fromJson(Map<String, Object?> json) =>

--- a/lib/models/history_meta_model.freezed.dart
+++ b/lib/models/history_meta_model.freezed.dart
@@ -28,6 +28,7 @@ mixin _$HistoryMetaModel {
   HTTPVerb get method => throw _privateConstructorUsedError;
   int get responseStatus => throw _privateConstructorUsedError;
   DateTime get timeStamp => throw _privateConstructorUsedError;
+  Duration? get latency => throw _privateConstructorUsedError;
 
   /// Serializes this HistoryMetaModel to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -53,7 +54,8 @@ abstract class $HistoryMetaModelCopyWith<$Res> {
       String url,
       HTTPVerb method,
       int responseStatus,
-      DateTime timeStamp});
+      DateTime timeStamp,
+      Duration? latency});
 }
 
 /// @nodoc
@@ -79,6 +81,7 @@ class _$HistoryMetaModelCopyWithImpl<$Res, $Val extends HistoryMetaModel>
     Object? method = null,
     Object? responseStatus = null,
     Object? timeStamp = null,
+    Object? latency = freezed,
   }) {
     return _then(_value.copyWith(
       historyId: null == historyId
@@ -113,6 +116,10 @@ class _$HistoryMetaModelCopyWithImpl<$Res, $Val extends HistoryMetaModel>
           ? _value.timeStamp
           : timeStamp // ignore: cast_nullable_to_non_nullable
               as DateTime,
+      latency: freezed == latency
+          ? _value.latency
+          : latency // ignore: cast_nullable_to_non_nullable
+              as Duration?,
     ) as $Val);
   }
 }
@@ -133,7 +140,8 @@ abstract class _$$HistoryMetaModelImplCopyWith<$Res>
       String url,
       HTTPVerb method,
       int responseStatus,
-      DateTime timeStamp});
+      DateTime timeStamp,
+      Duration? latency});
 }
 
 /// @nodoc
@@ -157,6 +165,7 @@ class __$$HistoryMetaModelImplCopyWithImpl<$Res>
     Object? method = null,
     Object? responseStatus = null,
     Object? timeStamp = null,
+    Object? latency = freezed,
   }) {
     return _then(_$HistoryMetaModelImpl(
       historyId: null == historyId
@@ -191,6 +200,10 @@ class __$$HistoryMetaModelImplCopyWithImpl<$Res>
           ? _value.timeStamp
           : timeStamp // ignore: cast_nullable_to_non_nullable
               as DateTime,
+      latency: freezed == latency
+          ? _value.latency
+          : latency // ignore: cast_nullable_to_non_nullable
+              as Duration?,
     ));
   }
 }
@@ -206,7 +219,8 @@ class _$HistoryMetaModelImpl implements _HistoryMetaModel {
       required this.url,
       required this.method,
       required this.responseStatus,
-      required this.timeStamp});
+      required this.timeStamp,
+      this.latency});
 
   factory _$HistoryMetaModelImpl.fromJson(Map<String, dynamic> json) =>
       _$$HistoryMetaModelImplFromJson(json);
@@ -228,10 +242,12 @@ class _$HistoryMetaModelImpl implements _HistoryMetaModel {
   final int responseStatus;
   @override
   final DateTime timeStamp;
+  @override
+  final Duration? latency;
 
   @override
   String toString() {
-    return 'HistoryMetaModel(historyId: $historyId, requestId: $requestId, apiType: $apiType, name: $name, url: $url, method: $method, responseStatus: $responseStatus, timeStamp: $timeStamp)';
+    return 'HistoryMetaModel(historyId: $historyId, requestId: $requestId, apiType: $apiType, name: $name, url: $url, method: $method, responseStatus: $responseStatus, timeStamp: $timeStamp, latency: $latency)';
   }
 
   @override
@@ -250,13 +266,15 @@ class _$HistoryMetaModelImpl implements _HistoryMetaModel {
             (identical(other.responseStatus, responseStatus) ||
                 other.responseStatus == responseStatus) &&
             (identical(other.timeStamp, timeStamp) ||
-                other.timeStamp == timeStamp));
+                other.timeStamp == timeStamp) &&
+            (identical(other.latency, latency) ||
+                other.latency == latency));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, historyId, requestId, apiType,
-      name, url, method, responseStatus, timeStamp);
+      name, url, method, responseStatus, timeStamp, latency);
 
   /// Create a copy of HistoryMetaModel
   /// with the given fields replaced by the non-null parameter values.
@@ -284,7 +302,8 @@ abstract class _HistoryMetaModel implements HistoryMetaModel {
       required final String url,
       required final HTTPVerb method,
       required final int responseStatus,
-      required final DateTime timeStamp}) = _$HistoryMetaModelImpl;
+      required final DateTime timeStamp,
+      final Duration? latency}) = _$HistoryMetaModelImpl;
 
   factory _HistoryMetaModel.fromJson(Map<String, dynamic> json) =
       _$HistoryMetaModelImpl.fromJson;
@@ -305,6 +324,8 @@ abstract class _HistoryMetaModel implements HistoryMetaModel {
   int get responseStatus;
   @override
   DateTime get timeStamp;
+  @override
+  Duration? get latency;
 
   /// Create a copy of HistoryMetaModel
   /// with the given fields replaced by the non-null parameter values.

--- a/lib/models/history_meta_model.g.dart
+++ b/lib/models/history_meta_model.g.dart
@@ -17,6 +17,9 @@ _$HistoryMetaModelImpl _$$HistoryMetaModelImplFromJson(
       method: $enumDecode(_$HTTPVerbEnumMap, json['method']),
       responseStatus: (json['responseStatus'] as num).toInt(),
       timeStamp: DateTime.parse(json['timeStamp'] as String),
+      latency: json['latency'] == null
+          ? null
+          : Duration(microseconds: (json['latency'] as num).toInt()),
     );
 
 Map<String, dynamic> _$$HistoryMetaModelImplToJson(
@@ -30,6 +33,7 @@ Map<String, dynamic> _$$HistoryMetaModelImplToJson(
       'method': _$HTTPVerbEnumMap[instance.method]!,
       'responseStatus': instance.responseStatus,
       'timeStamp': instance.timeStamp.toIso8601String(),
+      'latency': instance.latency?.inMicroseconds,
     };
 
 const _$APITypeEnumMap = {

--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -539,6 +539,7 @@ class CollectionStateNotifier
           method: substitutedHttpRequestModel.method,
           responseStatus: statusCode,
           timeStamp: DateTime.now(),
+          latency: duration,
         ),
         httpRequestModel: substitutedHttpRequestModel,
         aiRequestModel: executionRequestModel.aiRequestModel,

--- a/lib/widgets/card_history_request.dart
+++ b/lib/widgets/card_history_request.dart
@@ -52,6 +52,15 @@ class HistoryRequestCard extends StatelessWidget {
                   ),
                 ),
                 kHSpacer4,
+                if (model.latency != null) ...[
+                  Text(
+                    humanizeDuration(model.latency),
+                    style: kCodeStyle.copyWith(
+                      color: Theme.of(context).colorScheme.outline,
+                    ),
+                  ),
+                  kHSpacer4,
+                ],
                 StatusCode(statusCode: model.responseStatus),
               ],
             ),

--- a/test/models/history_models.dart
+++ b/test/models/history_models.dart
@@ -51,6 +51,7 @@ final Map<String, dynamic> historyMetaModelJson1 = {
   "method": "get",
   "timeStamp": '2024-01-01T00:00:00.000',
   "responseStatus": 200,
+  "latency": null,
 };
 
 final Map<String, dynamic> historyRequestModelJson1 = {
@@ -82,6 +83,7 @@ final Map<String, dynamic> historyMetaModelJson2 = {
   "method": "post",
   "timeStamp": '2024-01-01T00:00:00.000',
   "responseStatus": 200,
+  "latency": null,
 };
 
 final Map<String, dynamic> historyRequestModelJson2 = {


### PR DESCRIPTION
## PR Description

Adds `Duration? latency` to `HistoryMetaModel` so that response latency is stored in the lightweight metadata index and displayed inline on each history sidebar card, alongside the existing timestamp and status code.

**Before:** sidebar cards showed only `12:04:01 AM` + `200`  
**After:** sidebar cards show `12:04:01 AM` + `143 ms` + `200`

The `latency` field follows the same pattern as `responseStatus` already in `HistoryMetaModel`, stored eagerly in metadata so the sidebar list never needs to lazy-load full `HistoryRequestModel` records from Hive just to render it. Gracefully hidden (`null` check) for older history entries that predate this field.

**Files changed:**
- `lib/models/history_meta_model.dart` - added `Duration? latency` field
- `lib/models/history_meta_model.freezed.dart` - updated generated code
- `lib/models/history_meta_model.g.dart` - serialize/deserialize via `inMicroseconds`
- `lib/providers/collection_providers.dart` - populate `latency` from existing `duration` at request completion
- `lib/widgets/card_history_request.dart` - render latency between timestamp and status chip using `humanizeDuration()`
- `test/models/history_models.dart` - updated JSON fixtures to include `"latency": null`

## Related Issues

- Closes #1319

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [x] Yes, updated `test/models/history_models.dart` JSON fixtures; all 8 history model tests pass

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux