### PR TITLE
fix(#1131): resolve visible delay when closing app on Windows

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -73,7 +73,8 @@ class _AppState extends ConsumerState<App> with WindowListener {
                 child: const Text('No'),
                 onPressed: () async {
                   Navigator.of(context).pop();
-                  await windowManager.destroy();
+                  await windowManager.setPreventClose(false);
+                  await windowManager.close();
                 },
               ),
               FilledButton(
@@ -83,14 +84,16 @@ class _AppState extends ConsumerState<App> with WindowListener {
                       .read(collectionStateNotifierProvider.notifier)
                       .saveData();
                   Navigator.of(context).pop();
-                  await windowManager.destroy();
+                  await windowManager.setPreventClose(false);
+                  await windowManager.close();
                 },
               ),
             ],
           ),
         );
       } else {
-        await windowManager.destroy();
+        await windowManager.setPreventClose(false);
+        await windowManager.close();
       }
     }
   }


### PR DESCRIPTION
## PR Description

This PR resolves the visible delay that occurs when closing the application on Windows.

The root cause is a known issue with the `window_manager` package where calling `await windowManager.destroy();` blocks the main thread on recent Flutter Windows builds. The fix replaces this forced destruction with a graceful OS-level teardown:
1. Releasing the window lock via `await windowManager.setPreventClose(false);`
2. Triggering normal window closure via `await windowManager.close();`

## Visual Proof (Before & After)

| Before (With Delay) | After (Instant Close) |
| :---: | :---: |
|![Before](https://github.com/user-attachments/assets/6609a406-5752-49a6-818e-17cf3681f199)|![After](https://github.com/user-attachments/assets/88fe071c-acf5-49d2-853d-fb25fe214b4e)|

## Related Issues

- Closes #1131 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: 
This is a native OS window lifecycle event that requires manual visual verification of the desktop window closing behavior, which cannot be easily covered by unit tests.

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux
