### PR TITLE
feat: add custom AI model support in selector

### DIFF
--- a/lib/screens/common_widgets/ai/ai_model_selector_dialog.dart
+++ b/lib/screens/common_widgets/ai/ai_model_selector_dialog.dart
@@ -1,4 +1,5 @@
 // import 'package:apidash/providers/providers.dart';
+import 'package:apidash/screens/common_widgets/ai/dialog_add_ai_model.dart';
 import 'package:apidash/widgets/widgets.dart';
 import 'package:apidash/consts.dart';
 import 'package:apidash_core/apidash_core.dart';
@@ -6,9 +7,34 @@ import 'package:apidash_design_system/apidash_design_system.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+AvailableModels addModelToProviderData(
+  AvailableModels data,
+  ModelAPIProvider providerId,
+  Model newModel,
+) {
+  final updatedProviders = data.modelProviders.map((provider) {
+    if (provider.providerId != providerId) {
+      return provider;
+    }
+
+    final existingModels = provider.models ?? <Model>[];
+    return provider.copyWith(
+      models: [...existingModels, newModel],
+    );
+  }).toList();
+
+  return data.copyWith(modelProviders: updatedProviders);
+}
+
 class AIModelSelectorDialog extends ConsumerStatefulWidget {
   final AIRequestModel? aiRequestModel;
-  const AIModelSelectorDialog({super.key, this.aiRequestModel});
+  final Future<AvailableModels>? availableModelsFuture;
+
+  const AIModelSelectorDialog({
+    super.key,
+    this.aiRequestModel,
+    this.availableModelsFuture,
+  });
 
   @override
   ConsumerState<AIModelSelectorDialog> createState() =>
@@ -17,6 +43,7 @@ class AIModelSelectorDialog extends ConsumerStatefulWidget {
 
 class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
   late final Future<AvailableModels> aM;
+  AvailableModels? availableModels;
   ModelAPIProvider? selectedProvider;
   AIRequestModel? newAIRequestModel;
 
@@ -27,21 +54,43 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
     if (selectedProvider != null && widget.aiRequestModel?.model != null) {
       newAIRequestModel = widget.aiRequestModel?.copyWith();
     }
-    aM = ModelManager.fetchAvailableModels();
+    aM = widget.availableModelsFuture ?? ModelManager.fetchAvailableModels();
+  }
+
+  Future<void> _handleAddModel(AIModelProvider aiModelProvider) async {
+    final newModel = await addNewModel(context);
+    if (newModel == null) return;
+
+    final currentData = availableModels ?? await aM;
+    final updatedData = addModelToProviderData(
+      currentData,
+      aiModelProvider.providerId!,
+      newModel,
+    );
+
+    final baseRequestModel =
+        newAIRequestModel ?? aiModelProvider.toAiRequestModel();
+
+    setState(() {
+      availableModels = updatedData;
+      newAIRequestModel = baseRequestModel?.copyWith(
+        model: newModel.id,
+      );
+    });
   }
 
   @override
   Widget build(BuildContext context) {
-    // ref.watch(aiApiCredentialProvider);
     final width = MediaQuery.of(context).size.width * 0.8;
-    return FutureBuilder(
+    return FutureBuilder<AvailableModels>(
       future: aM,
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.done &&
             snapshot.hasData &&
             snapshot.data != null) {
-          final data = snapshot.data!;
+          final data = availableModels ?? snapshot.data!;
           final mappedData = data.map;
+
           if (context.isMediumWindow) {
             return Container(
               padding: kP20,
@@ -51,11 +100,6 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
                 children: [
                   ElevatedButton(
                     onPressed: null,
-                    // TODO: Add update model logic
-                    //() async {
-                    // await LLMManager.fetchAvailableLLMs();
-                    // setState(() {});
-                    //},
                     child: Text(kLabelUpdateModels),
                   ),
                   kVSpacer10,
@@ -81,7 +125,11 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
                     ],
                   ),
                   kVSpacer10,
-                  _buildModelSelector(mappedData[selectedProvider]),
+                  Expanded(
+                    child: SingleChildScrollView(
+                      child: _buildModelSelector(mappedData[selectedProvider]),
+                    ),
+                  ),
                 ],
               ),
             );
@@ -101,11 +149,6 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
                       children: [
                         ElevatedButton(
                           onPressed: null,
-                          // TODO: Add update model logic
-                          //() async {
-                          // await LLMManager.fetchAvailableLLMs();
-                          // setState(() {});
-                          //},
                           child: Text(kLabelUpdateModels),
                         ),
                         SizedBox(height: 20),
@@ -140,17 +183,17 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
             ),
           );
         }
+
         return Center(child: CircularProgressIndicator());
       },
     );
   }
 
-  _buildModelSelector(AIModelProvider? aiModelProvider) {
+  Widget _buildModelSelector(AIModelProvider? aiModelProvider) {
     if (aiModelProvider == null) {
       return Center(child: Text(kLabelSelectAIProvider));
     }
-    // final currentCredential =
-    //     ref.watch(aiApiCredentialProvider)[aiModelProvider.providerId!] ?? "";
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.max,
@@ -165,16 +208,11 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
           kVSpacer8,
           BoundedTextField(
             onChanged: (x) {
-              // ref.read(aiApiCredentialProvider.notifier).state = {
-              //   ...ref.read(aiApiCredentialProvider),
-              //   aiModelProvider.providerId!: x
-              // };
               setState(() {
                 newAIRequestModel = newAIRequestModel?.copyWith(apiKey: x);
               });
             },
             value: newAIRequestModel?.apiKey ?? "",
-            // value: currentCredential,
           ),
           kVSpacer10,
         ],
@@ -194,8 +232,11 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             Text(kLabelModels),
-            // IconButton(
-            //     onPressed: () => addNewModel(context), icon: Icon(Icons.add))
+            IconButton(
+              onPressed: () => _handleAddModel(aiModelProvider),
+              icon: const Icon(Icons.add),
+              tooltip: kLabelAddModel,
+            ),
           ],
         ),
         kVSpacer8,

--- a/lib/screens/common_widgets/ai/dialog_add_ai_model.dart
+++ b/lib/screens/common_widgets/ai/dialog_add_ai_model.dart
@@ -1,42 +1,102 @@
-import 'package:apidash_design_system/apidash_design_system.dart';
 import 'package:apidash/consts.dart';
+import 'package:apidash_core/apidash_core.dart';
+import 'package:apidash_design_system/apidash_design_system.dart';
 import 'package:flutter/material.dart';
 
-Future<void> addNewModel(BuildContext context) async {
-  TextEditingController iC = TextEditingController();
-  TextEditingController nC = TextEditingController();
-  final z = await showDialog(
+Future<Model?> addNewModel(BuildContext context) {
+  return showDialog<Model?>(
     context: context,
-    builder: (context) {
-      return AlertDialog(
-        title: Text(kLabelAddCustomModel),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ADOutlinedTextField(controller: iC, hintText: kHintModelId),
-            kVSpacer10,
-            ADOutlinedTextField(
-              controller: nC,
-              hintText: kHintModelDisplayName,
-            ),
-            kVSpacer10,
-            SizedBox(
-              width: double.infinity,
-              child: ElevatedButton(
-                onPressed: () {
-                  Navigator.of(context).pop([iC.value.text, nC.value.text]);
-                },
-                child: Text(kLabelAddModel),
-              ),
-            ),
-          ],
-        ),
-      );
-    },
+    builder: (_) => const _AddNewModelDialog(),
   );
-  iC.dispose();
-  nC.dispose();
-  if (z == null) return;
-  // TODO: Add logic to add a new model
-  // setState(() {});
+}
+
+class _AddNewModelDialog extends StatefulWidget {
+  const _AddNewModelDialog();
+
+  @override
+  State<_AddNewModelDialog> createState() => _AddNewModelDialogState();
+}
+
+class _AddNewModelDialogState extends State<_AddNewModelDialog> {
+  late final TextEditingController iC;
+  late final TextEditingController nC;
+  String? errorText;
+
+  @override
+  void initState() {
+    super.initState();
+    iC = TextEditingController();
+    nC = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    iC.dispose();
+    nC.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    final modelId = iC.text.trim();
+    final displayName = nC.text.trim();
+
+    if (modelId.isEmpty) {
+      setState(() {
+        errorText = 'Model ID is required';
+      });
+      return;
+    }
+
+    Navigator.of(context).pop(
+      Model(
+        id: modelId,
+        name: displayName.isEmpty ? modelId : displayName,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(kLabelAddCustomModel),
+      content: SingleChildScrollView(
+        child: SizedBox(
+          width: 420,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              ADOutlinedTextField(
+                controller: iC,
+                hintText: kHintModelId,
+              ),
+              if (errorText != null) ...[
+                const SizedBox(height: 8),
+                Text(
+                  errorText!,
+                  style: TextStyle(
+                    color: Theme.of(context).colorScheme.error,
+                    fontSize: 12,
+                  ),
+                ),
+              ],
+              kVSpacer10,
+              ADOutlinedTextField(
+                controller: nC,
+                hintText: kHintModelDisplayName,
+              ),
+              kVSpacer10,
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: _submit,
+                  child: Text(kLabelAddModel),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
 }

--- a/test/screens/common_widgets/ai/ai_model_selector_dialog_test.dart
+++ b/test/screens/common_widgets/ai/ai_model_selector_dialog_test.dart
@@ -1,0 +1,164 @@
+import 'package:apidash/consts.dart';
+import 'package:apidash/screens/common_widgets/ai/ai_model_selector_dialog.dart';
+import 'package:apidash/screens/common_widgets/ai/dialog_add_ai_model.dart';
+import 'package:apidash_core/apidash_core.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('addNewModel', () {
+    testWidgets('rejects empty model ID', (tester) async {
+      Model? result;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                return ElevatedButton(
+                  onPressed: () async {
+                    result = await addNewModel(context);
+                  },
+                  child: const Text('open'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(kLabelAddModel));
+      await tester.pump();
+
+      expect(find.text('Model ID is required'), findsOneWidget);
+      expect(result, isNull);
+    });
+
+    testWidgets('uses model ID as display name when blank', (tester) async {
+      Model? result;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                return ElevatedButton(
+                  onPressed: () async {
+                    result = await addNewModel(context);
+                  },
+                  child: const Text('open'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      final dialogFields = find.descendant(
+        of: find.byType(AlertDialog),
+        matching: find.byType(EditableText),
+      );
+
+      await tester.enterText(dialogFields.at(0), 'custom-model-1315');
+      await tester.tap(find.text(kLabelAddModel));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(result, isNotNull);
+      expect(result!.id, 'custom-model-1315');
+      expect(result!.name, 'custom-model-1315');
+    });
+  });
+
+  test('addModelToProviderData appends model to the selected provider', () {
+    final data = AvailableModels(
+      version: 1.0,
+      modelProviders: [
+        AIModelProvider(
+          providerId: ModelAPIProvider.openai,
+          providerName: 'OpenAI',
+          sourceUrl: null,
+          models: const [
+            Model(id: 'gpt-5', name: 'GPT-5'),
+          ],
+        ),
+      ],
+    );
+
+    final updated = addModelToProviderData(
+      data,
+      ModelAPIProvider.openai,
+      const Model(id: 'my-test-model-1315', name: 'My Test Model 1315'),
+    );
+
+    expect(updated.modelProviders.first.models, hasLength(2));
+    expect(
+      updated.modelProviders.first.models!.last.id,
+      'my-test-model-1315',
+    );
+    expect(
+      updated.modelProviders.first.models!.last.name,
+      'My Test Model 1315',
+    );
+  });
+
+  testWidgets('successful add updates AI model selector UI immediately',
+      (tester) async {
+    final data = AvailableModels(
+      version: 1.0,
+      modelProviders: [
+        AIModelProvider(
+          providerId: ModelAPIProvider.openai,
+          providerName: 'OpenAI',
+          sourceUrl: null,
+          models: const [
+            Model(id: 'gpt-5', name: 'GPT-5'),
+          ],
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: AIModelSelectorDialog(
+              aiRequestModel: const AIRequestModel(
+                modelApiProvider: ModelAPIProvider.openai,
+                model: 'gpt-5',
+              ),
+              availableModelsFuture: Future.value(data),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pumpAndSettle();
+
+    final dialogFields = find.descendant(
+      of: find.byType(AlertDialog),
+      matching: find.byType(EditableText),
+    );
+
+    await tester.enterText(dialogFields.at(0), 'my-test-model-1315');
+    await tester.enterText(dialogFields.at(1), 'My Test Model 1315');
+
+    await tester.tap(find.text(kLabelAddModel));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.text('My Test Model 1315'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## PR Description

This PR adds support for creating and appending a custom AI model from the AI Model Selector dialog.

Implemented changes:
- `addNewModel` now returns a `Model`
- empty model ID is rejected
- display name defaults to model ID when left blank
- the Add button in the AI Model Selector is wired and appends the new model to the currently selected provider
- added tests for validation, display-name fallback, and successful add flow

## Related Issues

- Closes #1315

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?


- [x] Yes
- [ ] No

Added tests:
- rejects empty model ID
- uses model ID as display name when blank
- successful add flow updates selector data/UI

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [x] Linux