### PR TITLE
docs: add missing code generation step to setup guide

### DIFF
--- a/doc/dev_guide/setup_run.md
+++ b/doc/dev_guide/setup_run.md
@@ -39,7 +39,15 @@ melos pub-get
 flutter pub get
 ```
 
-**Step 7 -** Run the project by executing the below command
+**Step 7 -** Run code generation
+
+API Dash uses Freezed for immutable models. Generate the required files:
+
+```
+melos build-gen
+```
+
+**Step 8 -** Run the project by executing the below command
 
 ```
 flutter run


### PR DESCRIPTION
## PR Description

Added the missing `melos build-gen` step (Step 7) to the local setup guide. This step is required for code generation (Freezed/json_serializable models) and was missing from the setup instructions.

## Related Issues

## Checklist

- [x] I have gone through the https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md
- [x] I have updated my branch and synced it with project main branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- No, and this is why: This is a documentation-only change (no code changes).

## OS on which you have developed and tested the feature?

- Linux