### PR TITLE
feat: auto-focus URL field when a request is opened

### DIFF
--- a/lib/screens/home_page/editor_pane/url_card.dart
+++ b/lib/screens/home_page/editor_pane/url_card.dart
@@ -94,13 +94,32 @@ class DropdownButtonHTTPMethod extends ConsumerWidget {
   }
 }
 
-class URLTextField extends ConsumerWidget {
+class URLTextField extends ConsumerStatefulWidget {
   const URLTextField({
     super.key,
   });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<URLTextField> createState() => _URLTextFieldState();
+}
+
+class _URLTextFieldState extends ConsumerState<URLTextField> {
+  late final FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode = FocusNode();
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final selectedId = ref.watch(selectedIdStateProvider);
     ref.watch(selectedRequestModelProvider
         .select((value) => value?.aiRequestModel?.url));
@@ -109,8 +128,54 @@ class URLTextField extends ConsumerWidget {
     final requestModel = ref
         .read(collectionStateNotifierProvider.notifier)
         .getRequestModel(selectedId!)!;
+
+    ref.listen(selectedIdStateProvider, (_, newId) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        if (context.isMediumWindow) {
+          // On mobile: only focus when the sidebar drawer is collapsed
+          if (ref.read(leftDrawerStateProvider)) return;
+          // ...and the URL field is empty
+          final reqModel = ref
+              .read(collectionStateNotifierProvider.notifier)
+              .getRequestModel(newId ?? '');
+          if (reqModel == null) return;
+          final url = switch (reqModel.apiType) {
+            APIType.ai => reqModel.aiRequestModel?.url,
+            _ => reqModel.httpRequestModel?.url,
+          };
+          if (url != null && url.isNotEmpty) return;
+        }
+        _focusNode.requestFocus();
+      });
+    });
+
+    // On mobile, also trigger when the drawer closes (e.g. new tab created then
+    // sidebar collapsed) — selectedId hasn't changed so the listener above
+    // won't fire.
+    ref.listen(leftDrawerStateProvider, (previous, isOpen) {
+      if (!context.isMediumWindow) return;
+      if (isOpen) return; // drawer just opened — do nothing
+      // drawer just closed
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        final currentId = ref.read(selectedIdStateProvider);
+        final reqModel = ref
+            .read(collectionStateNotifierProvider.notifier)
+            .getRequestModel(currentId ?? '');
+        if (reqModel == null) return;
+        final url = switch (reqModel.apiType) {
+          APIType.ai => reqModel.aiRequestModel?.url,
+          _ => reqModel.httpRequestModel?.url,
+        };
+        if (url != null && url.isNotEmpty) return;
+        _focusNode.requestFocus();
+      });
+    });
+
     return EnvURLField(
       selectedId: selectedId,
+      focusNode: _focusNode,
       initialValue: switch (requestModel.apiType) {
         APIType.ai => requestModel.aiRequestModel?.url,
         _ => requestModel.httpRequestModel?.url,
@@ -121,7 +186,9 @@ class URLTextField extends ConsumerWidget {
               aiRequestModel:
                   requestModel.aiRequestModel?.copyWith(url: value));
         } else {
-          ref.read(collectionStateNotifierProvider.notifier).update(url: value);
+          ref
+              .read(collectionStateNotifierProvider.notifier)
+              .update(url: value);
         }
       },
       onFieldSubmitted: (value) {


### PR DESCRIPTION
## PR Description

This PR improves the request creation workflow by automatically focusing the URL input field when a new request is opened.

Currently, after pressing the `+` button to create a new request, users need to manually click the URL field before typing. With this change:

* The URL field receives focus immediately after a new request is created.
* The cursor is placed inside the field so users can start typing instantly.
* Focus works correctly on both desktop and smaller screen layouts.

Additionally, focus handling was improved to account for the drawer behavior on smaller screens. The URL field waits until the drawer closes before requesting focus to ensure the editor is visible.

This PR is opened as a fresh branch to preserve commit history after the previous PR was closed due to a rebased branch.

### Before

[https://github.com/user-attachments/assets/ae2d749c-a966-494e-ad3e-e0ec882166fc](https://github.com/user-attachments/assets/ae2d749c-a966-494e-ad3e-e0ec882166fc)

### After

[https://github.com/user-attachments/assets/2e3a4107-871d-479b-8704-89cec305143c](https://github.com/user-attachments/assets/2e3a4107-871d-479b-8704-89cec305143c)

---

## Related Issues

* Closes #1244

---

### Checklist

* [x] I have gone through the contributing guide
* [x] I have updated my branch and synced it with project `main` branch before making this PR
* [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
* [x] I have run the tests (`flutter test`) and all tests are passing

---

## Added/updated tests?

* [x] No, and this is why: This change affects UI focus behavior and does not modify business logic or APIs.

---

## OS on which you have developed and tested the feature?

* [x] Windows
* [ ] macOS
* [ ] Linux

