### PR TITLE
extend Postman collection models with auth, variable, urlencoded, and…

### DIFF
--- a/packages/apidash_core/lib/import_export/postman_io.dart
+++ b/packages/apidash_core/lib/import_export/postman_io.dart
@@ -7,41 +7,61 @@ class PostmanIO {
     try {
       final pc = pm.postmanCollectionFromJsonStr(content);
       final requests = pm.getRequestsFromPostmanCollection(pc);
+
+      final collectionVariables = _buildVariableMap(pc.variable);
+      final collectionAuth = pc.auth;
+
       return requests
-          .map((req) => (req.$1, postmanRequestToHttpRequestModel(req.$2)))
+          .map(
+            (req) => (
+              req.$1,
+              postmanRequestToHttpRequestModel(
+                req.$2,
+                collectionVariables: collectionVariables,
+                collectionAuth: collectionAuth,
+              ),
+            ),
+          )
           .toList();
     } catch (e) {
       return null;
     }
   }
 
-  HttpRequestModel postmanRequestToHttpRequestModel(pm.Request request) {
+  HttpRequestModel postmanRequestToHttpRequestModel(
+    pm.Request request, {
+    Map<String, String> collectionVariables = const {},
+    pm.Auth? collectionAuth,
+  }) {
     HTTPVerb method;
 
     try {
-      method = HTTPVerb.values.byName((request.method ?? "").toLowerCase());
+      method = HTTPVerb.values.byName((request.method ?? '').toLowerCase());
     } catch (e) {
       method = kDefaultHttpMethod;
     }
-    String url = stripUrlParams(request.url?.raw ?? "");
-    List<NameValueModel> headers = [];
-    List<bool> isHeaderEnabledList = [];
 
-    List<NameValueModel> params = [];
-    List<bool> isParamEnabledList = [];
+    final rawUrl =
+        _resolveVariables(request.url?.raw ?? '', collectionVariables);
+    final url = stripUrlParams(rawUrl);
+    final headers = <NameValueModel>[];
+    final isHeaderEnabledList = <bool>[];
 
-    for (var header in request.header ?? <pm.Header>[]) {
-      var name = header.key ?? "";
-      var value = header.value;
-      var activeHeader = header.disabled ?? false;
+    final params = <NameValueModel>[];
+    final isParamEnabledList = <bool>[];
+
+    for (final header in request.header ?? <pm.Header>[]) {
+      final name = _resolveVariables(header.key ?? '', collectionVariables);
+      final value = _resolveVariables(header.value ?? '', collectionVariables);
+      final activeHeader = header.disabled ?? false;
       headers.add(NameValueModel(name: name, value: value));
       isHeaderEnabledList.add(!activeHeader);
     }
 
-    for (var query in request.url?.query ?? <pm.Query>[]) {
-      var name = query.key ?? "";
-      var value = query.value;
-      var activeQuery = query.disabled ?? false;
+    for (final query in request.url?.query ?? <pm.Query>[]) {
+      final name = _resolveVariables(query.key ?? '', collectionVariables);
+      final value = _resolveVariables(query.value ?? '', collectionVariables);
+      final activeQuery = query.disabled ?? false;
       params.add(NameValueModel(name: name, value: value));
       isParamEnabledList.add(!activeQuery);
     }
@@ -53,27 +73,36 @@ class PostmanIO {
       if (request.body?.mode == 'raw') {
         try {
           bodyContentType = ContentType.values
-              .byName(request.body?.options?.raw?.language ?? "");
+              .byName(request.body?.options?.raw?.language ?? '');
         } catch (e) {
           bodyContentType = kDefaultContentType;
         }
-        body = request.body?.raw;
+        body = _resolveVariables(request.body?.raw ?? '', collectionVariables);
       }
+
       if (request.body?.mode == 'formdata') {
         bodyContentType = ContentType.formdata;
         formData = [];
-        for (var fd in request.body?.formdata ?? <pm.Formdatum>[]) {
-          var name = fd.key ?? "";
+        for (final fd in request.body?.formdata ?? <pm.Formdatum>[]) {
+          if (fd.disabled ?? false) {
+            continue;
+          }
+
+          final name = _resolveVariables(fd.key ?? '', collectionVariables);
           FormDataType formDataType;
           try {
-            formDataType = FormDataType.values.byName(fd.type ?? "");
+            formDataType = FormDataType.values.byName(fd.type ?? '');
           } catch (e) {
             formDataType = FormDataType.text;
           }
-          var value = switch (formDataType) {
-            FormDataType.text => fd.value ?? "",
-            FormDataType.file => fd.src ?? ""
+
+          final value = switch (formDataType) {
+            FormDataType.text =>
+              _resolveVariables(fd.value ?? '', collectionVariables),
+            FormDataType.file =>
+              _resolveVariables(fd.src ?? '', collectionVariables),
           };
+
           formData.add(FormDataModel(
             name: name,
             value: value,
@@ -81,18 +110,189 @@ class PostmanIO {
           ));
         }
       }
+
+      if (request.body?.mode == 'urlencoded') {
+        bodyContentType = ContentType.formdata;
+        formData = [];
+        for (final field in request.body?.urlencoded ?? <pm.Urlencoded>[]) {
+          if (field.disabled ?? false) {
+            continue;
+          }
+
+          formData.add(
+            FormDataModel(
+              name: _resolveVariables(field.key ?? '', collectionVariables),
+              value:
+                  _resolveVariables(field.value ?? '', collectionVariables),
+              type: FormDataType.text,
+            ),
+          );
+        }
+      }
     }
+
+    final authModel = _postmanAuthToAuthModel(
+          request.auth ?? collectionAuth,
+          collectionVariables,
+        ) ??
+        const AuthModel(type: APIAuthType.none);
 
     return HttpRequestModel(
       method: method,
       url: url,
       headers: headers,
       params: params,
+      authModel: authModel,
       isHeaderEnabledList: isHeaderEnabledList,
       isParamEnabledList: isParamEnabledList,
       body: body,
       bodyContentType: bodyContentType,
       formData: formData,
     );
+  }
+
+  Map<String, String> _buildVariableMap(List<pm.Variable>? variables) {
+    final map = <String, String>{};
+    for (final variable in variables ?? <pm.Variable>[]) {
+      if (variable.disabled ?? false) {
+        continue;
+      }
+      final key = (variable.key ?? '').trim();
+      final value = variable.value;
+      if (key.isEmpty || value == null) {
+        continue;
+      }
+      map[key] = value.toString();
+    }
+    return map;
+  }
+
+  String _resolveVariables(String input, Map<String, String> variables) {
+    final regex = RegExp(r'{{\s*([^}]+)\s*}}');
+    return input.replaceAllMapped(regex, (match) {
+      final key = (match.group(1) ?? '').trim();
+      return variables[key] ?? match.group(0)!;
+    });
+  }
+
+  AuthModel? _postmanAuthToAuthModel(
+    pm.Auth? auth,
+    Map<String, String> variables,
+  ) {
+    if (auth == null) {
+      return null;
+    }
+
+    final type = (auth.type ?? '').toLowerCase();
+
+    if (type == 'bearer') {
+      final token = _resolveVariables(
+        _getAuthValue(auth.bearer, 'token') ?? '',
+        variables,
+      );
+      return token.isEmpty
+          ? const AuthModel(type: APIAuthType.none)
+          : AuthModel(
+              type: APIAuthType.bearer,
+              bearer: AuthBearerModel(token: token),
+            );
+    }
+
+    if (type == 'basic') {
+      final username = _resolveVariables(
+        _getAuthValue(auth.basic, 'username') ?? '',
+        variables,
+      );
+      final password = _resolveVariables(
+        _getAuthValue(auth.basic, 'password') ?? '',
+        variables,
+      );
+      if (username.isEmpty && password.isEmpty) {
+        return const AuthModel(type: APIAuthType.none);
+      }
+      return AuthModel(
+        type: APIAuthType.basic,
+        basic: AuthBasicAuthModel(
+          username: username,
+          password: password,
+        ),
+      );
+    }
+
+    if (type == 'apikey') {
+      final keyValue = _resolveVariables(
+        _getAuthValue(auth.apikey, 'value') ?? '',
+        variables,
+      );
+      final name = _resolveVariables(
+        _getAuthValue(auth.apikey, 'key') ?? 'x-api-key',
+        variables,
+      );
+      final where = (_getAuthValue(auth.apikey, 'in') ?? 'header').toLowerCase();
+      final location = where == 'query' ? 'query' : 'header';
+
+      if (keyValue.isEmpty) {
+        return const AuthModel(type: APIAuthType.none);
+      }
+
+      return AuthModel(
+        type: APIAuthType.apiKey,
+        apikey: AuthApiKeyModel(
+          key: keyValue,
+          name: name,
+          location: location,
+        ),
+      );
+    }
+
+    if (type == 'digest') {
+      return AuthModel(
+        type: APIAuthType.digest,
+        digest: AuthDigestModel(
+          username: _resolveVariables(
+            _getAuthValue(auth.digest, 'username') ?? '',
+            variables,
+          ),
+          password: _resolveVariables(
+            _getAuthValue(auth.digest, 'password') ?? '',
+            variables,
+          ),
+          realm: _resolveVariables(
+            _getAuthValue(auth.digest, 'realm') ?? '',
+            variables,
+          ),
+          nonce: _resolveVariables(
+            _getAuthValue(auth.digest, 'nonce') ?? '',
+            variables,
+          ),
+          algorithm: _resolveVariables(
+            _getAuthValue(auth.digest, 'algorithm') ?? 'MD5',
+            variables,
+          ),
+          qop: _resolveVariables(
+            _getAuthValue(auth.digest, 'qop') ?? 'auth',
+            variables,
+          ),
+          opaque: _resolveVariables(
+            _getAuthValue(auth.digest, 'opaque') ?? '',
+            variables,
+          ),
+        ),
+      );
+    }
+
+    return const AuthModel(type: APIAuthType.none);
+  }
+
+  String? _getAuthValue(List<pm.AuthKeyValue>? entries, String key) {
+    for (final entry in entries ?? <pm.AuthKeyValue>[]) {
+      if (entry.disabled ?? false) {
+        continue;
+      }
+      if ((entry.key ?? '').toLowerCase() == key.toLowerCase()) {
+        return entry.value;
+      }
+    }
+    return null;
   }
 }

--- a/packages/apidash_core/test/parsers/postman_test.dart
+++ b/packages/apidash_core/test/parsers/postman_test.dart
@@ -1,0 +1,189 @@
+import 'package:apidash_core/apidash_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PostmanIO parser tests', () {
+    late PostmanIO postmanIO;
+
+    setUp(() {
+      postmanIO = PostmanIO();
+    });
+
+    test('maps bearer auth and collection variables', () {
+      const content = r'''
+{
+  "info": {
+    "name": "Auth and Vars",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "https://api.example.com"
+    },
+    {
+      "key": "token",
+      "value": "abc123"
+    }
+  ],
+  "item": [
+    {
+      "name": "Get Users",
+      "request": {
+        "method": "GET",
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/users?limit=10",
+          "query": [
+            {
+              "key": "limit",
+              "value": "10"
+            }
+          ]
+        }
+      },
+      "response": []
+    }
+  ]
+}
+''';
+
+      final result = postmanIO.getHttpRequestModelList(content);
+
+      expect(result, isNotNull);
+      expect(result!.length, 1);
+      expect(result.first.$1, 'Get Users');
+
+      final request = result.first.$2;
+      expect(request.url, 'https://api.example.com/users');
+      expect(
+        request.params,
+        [const NameValueModel(name: 'limit', value: '10')],
+      );
+      expect(
+        request.authModel,
+        const AuthModel(
+          type: APIAuthType.bearer,
+          bearer: AuthBearerModel(token: 'abc123'),
+        ),
+      );
+    });
+
+    test('maps urlencoded body as text form rows', () {
+      const content = r'''
+{
+  "info": {
+    "name": "Urlencoded Body",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Token Request",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "urlencoded",
+          "urlencoded": [
+            {
+              "key": "grant_type",
+              "value": "client_credentials",
+              "type": "text"
+            },
+            {
+              "key": "scope",
+              "value": "read write",
+              "type": "text"
+            }
+          ]
+        },
+        "url": {
+          "raw": "https://auth.example.com/oauth/token"
+        }
+      },
+      "response": []
+    }
+  ]
+}
+''';
+
+      final result = postmanIO.getHttpRequestModelList(content);
+
+      expect(result, isNotNull);
+      final request = result!.first.$2;
+
+      expect(request.bodyContentType, ContentType.formdata);
+      expect(
+        request.formData,
+        const [
+          FormDataModel(
+            name: 'grant_type',
+            value: 'client_credentials',
+            type: FormDataType.text,
+          ),
+          FormDataModel(
+            name: 'scope',
+            value: 'read write',
+            type: FormDataType.text,
+          ),
+        ],
+      );
+    });
+
+    test('keeps unresolved placeholders unchanged', () {
+      const content = r'''
+{
+  "info": {
+    "name": "Missing Variable",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "https://api.example.com"
+    }
+  ],
+  "item": [
+    {
+      "name": "Get One User",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "X-Trace",
+            "value": "{{trace_id}}"
+          }
+        ],
+        "url": {
+          "raw": "{{base_url}}/users/{{user_id}}"
+        }
+      },
+      "response": []
+    }
+  ]
+}
+''';
+
+      final result = postmanIO.getHttpRequestModelList(content);
+
+      expect(result, isNotNull);
+      final request = result!.first.$2;
+
+      expect(request.url, 'https://api.example.com/users/{{user_id}}');
+      expect(
+        request.headers,
+        [const NameValueModel(name: 'X-Trace', value: '{{trace_id}}')],
+      );
+    });
+  });
+}

--- a/packages/postman/lib/models/postman_collection.dart
+++ b/packages/postman/lib/models/postman_collection.dart
@@ -14,7 +14,7 @@ String postmanCollectionToJsonStr(PostmanCollection data) =>
     JsonEncoder.withIndent('  ').convert(data);
 
 @freezed
-class PostmanCollection with _$PostmanCollection {
+abstract class PostmanCollection with _$PostmanCollection {
   @JsonSerializable(
     explicitToJson: true,
     anyMap: true,
@@ -23,6 +23,8 @@ class PostmanCollection with _$PostmanCollection {
   const factory PostmanCollection({
     Info? info,
     List<Item>? item,
+    Auth? auth,
+    List<Variable>? variable,
   }) = _PostmanCollection;
 
   factory PostmanCollection.fromJson(Map<String, dynamic> json) =>
@@ -30,7 +32,7 @@ class PostmanCollection with _$PostmanCollection {
 }
 
 @freezed
-class Info with _$Info {
+abstract class Info with _$Info {
   @JsonSerializable(
     explicitToJson: true,
     anyMap: true,
@@ -47,7 +49,7 @@ class Info with _$Info {
 }
 
 @freezed
-class Item with _$Item {
+abstract class Item with _$Item {
   @JsonSerializable(
     explicitToJson: true,
     anyMap: true,
@@ -64,7 +66,7 @@ class Item with _$Item {
 }
 
 @freezed
-class Request with _$Request {
+abstract class Request with _$Request {
   @JsonSerializable(
     explicitToJson: true,
     anyMap: true,
@@ -75,6 +77,7 @@ class Request with _$Request {
     List<Header>? header,
     Body? body,
     Url? url,
+    Auth? auth,
   }) = _Request;
 
   factory Request.fromJson(Map<String, dynamic> json) =>
@@ -82,7 +85,7 @@ class Request with _$Request {
 }
 
 @freezed
-class Header with _$Header {
+abstract class Header with _$Header {
   @JsonSerializable(
     explicitToJson: true,
     anyMap: true,
@@ -99,7 +102,7 @@ class Header with _$Header {
 }
 
 @freezed
-class Url with _$Url {
+abstract class Url with _$Url {
   @JsonSerializable(
     explicitToJson: true,
     anyMap: true,
@@ -117,7 +120,7 @@ class Url with _$Url {
 }
 
 @freezed
-class Query with _$Query {
+abstract class Query with _$Query {
   @JsonSerializable(
     explicitToJson: true,
     anyMap: true,
@@ -133,7 +136,7 @@ class Query with _$Query {
 }
 
 @freezed
-class Body with _$Body {
+abstract class Body with _$Body {
   @JsonSerializable(
     explicitToJson: true,
     anyMap: true,
@@ -144,13 +147,14 @@ class Body with _$Body {
     String? raw,
     Options? options,
     List<Formdatum>? formdata,
+    List<Urlencoded>? urlencoded,
   }) = _Body;
 
   factory Body.fromJson(Map<String, dynamic> json) => _$BodyFromJson(json);
 }
 
 @freezed
-class Options with _$Options {
+abstract class Options with _$Options {
   @JsonSerializable(
     explicitToJson: true,
     anyMap: true,
@@ -165,7 +169,7 @@ class Options with _$Options {
 }
 
 @freezed
-class Raw with _$Raw {
+abstract class Raw with _$Raw {
   @JsonSerializable(
     explicitToJson: true,
     anyMap: true,
@@ -179,7 +183,7 @@ class Raw with _$Raw {
 }
 
 @freezed
-class Formdatum with _$Formdatum {
+abstract class Formdatum with _$Formdatum {
   @JsonSerializable(
     explicitToJson: true,
     anyMap: true,
@@ -190,8 +194,67 @@ class Formdatum with _$Formdatum {
     String? value,
     String? type,
     String? src,
+    bool? disabled,
   }) = _Formdatum;
 
   factory Formdatum.fromJson(Map<String, dynamic> json) =>
       _$FormdatumFromJson(json);
+}
+
+@freezed
+abstract class Auth with _$Auth {
+  @JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
+  const factory Auth({
+    String? type,
+    List<AuthKeyValue>? bearer,
+    List<AuthKeyValue>? basic,
+    List<AuthKeyValue>? apikey,
+    List<AuthKeyValue>? digest,
+    List<AuthKeyValue>? oauth1,
+    List<AuthKeyValue>? oauth2,
+  }) = _Auth;
+
+  factory Auth.fromJson(Map<String, dynamic> json) => _$AuthFromJson(json);
+}
+
+@freezed
+abstract class AuthKeyValue with _$AuthKeyValue {
+  @JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
+  const factory AuthKeyValue({
+    String? key,
+    String? value,
+    String? type,
+    bool? disabled,
+  }) = _AuthKeyValue;
+
+  factory AuthKeyValue.fromJson(Map<String, dynamic> json) =>
+      _$AuthKeyValueFromJson(json);
+}
+
+@freezed
+abstract class Urlencoded with _$Urlencoded {
+  @JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
+  const factory Urlencoded({
+    String? key,
+    String? value,
+    String? type,
+    bool? disabled,
+  }) = _Urlencoded;
+
+  factory Urlencoded.fromJson(Map<String, dynamic> json) =>
+      _$UrlencodedFromJson(json);
+}
+
+@freezed
+abstract class Variable with _$Variable {
+  @JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
+  const factory Variable({
+    String? key,
+    dynamic value,
+    String? type,
+    bool? disabled,
+  }) = _Variable;
+
+  factory Variable.fromJson(Map<String, dynamic> json) =>
+      _$VariableFromJson(json);
 }

--- a/packages/postman/lib/models/postman_collection.freezed.dart
+++ b/packages/postman/lib/models/postman_collection.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,2293 +9,4406 @@ part of 'postman_collection.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-PostmanCollection _$PostmanCollectionFromJson(Map<String, dynamic> json) {
-  return _PostmanCollection.fromJson(json);
-}
 
 /// @nodoc
 mixin _$PostmanCollection {
-  Info? get info => throw _privateConstructorUsedError;
-  List<Item>? get item => throw _privateConstructorUsedError;
+
+ Info? get info; List<Item>? get item; Auth? get auth; List<Variable>? get variable;
+/// Create a copy of PostmanCollection
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PostmanCollectionCopyWith<PostmanCollection> get copyWith => _$PostmanCollectionCopyWithImpl<PostmanCollection>(this as PostmanCollection, _$identity);
 
   /// Serializes this PostmanCollection to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  Map<String, dynamic> toJson();
 
-  /// Create a copy of PostmanCollection
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $PostmanCollectionCopyWith<PostmanCollection> get copyWith =>
-      throw _privateConstructorUsedError;
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PostmanCollection&&(identical(other.info, info) || other.info == info)&&const DeepCollectionEquality().equals(other.item, item)&&(identical(other.auth, auth) || other.auth == auth)&&const DeepCollectionEquality().equals(other.variable, variable));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,info,const DeepCollectionEquality().hash(item),auth,const DeepCollectionEquality().hash(variable));
+
+@override
+String toString() {
+  return 'PostmanCollection(info: $info, item: $item, auth: $auth, variable: $variable)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $PostmanCollectionCopyWith<$Res> {
-  factory $PostmanCollectionCopyWith(
-          PostmanCollection value, $Res Function(PostmanCollection) then) =
-      _$PostmanCollectionCopyWithImpl<$Res, PostmanCollection>;
-  @useResult
-  $Res call({Info? info, List<Item>? item});
+abstract mixin class $PostmanCollectionCopyWith<$Res>  {
+  factory $PostmanCollectionCopyWith(PostmanCollection value, $Res Function(PostmanCollection) _then) = _$PostmanCollectionCopyWithImpl;
+@useResult
+$Res call({
+ Info? info, List<Item>? item, Auth? auth, List<Variable>? variable
+});
 
-  $InfoCopyWith<$Res>? get info;
+
+$InfoCopyWith<$Res>? get info;$AuthCopyWith<$Res>? get auth;
+
 }
-
 /// @nodoc
-class _$PostmanCollectionCopyWithImpl<$Res, $Val extends PostmanCollection>
+class _$PostmanCollectionCopyWithImpl<$Res>
     implements $PostmanCollectionCopyWith<$Res> {
-  _$PostmanCollectionCopyWithImpl(this._value, this._then);
+  _$PostmanCollectionCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final PostmanCollection _self;
+  final $Res Function(PostmanCollection) _then;
 
-  /// Create a copy of PostmanCollection
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? info = freezed,
-    Object? item = freezed,
-  }) {
-    return _then(_value.copyWith(
-      info: freezed == info
-          ? _value.info
-          : info // ignore: cast_nullable_to_non_nullable
-              as Info?,
-      item: freezed == item
-          ? _value.item
-          : item // ignore: cast_nullable_to_non_nullable
-              as List<Item>?,
-    ) as $Val);
+/// Create a copy of PostmanCollection
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? info = freezed,Object? item = freezed,Object? auth = freezed,Object? variable = freezed,}) {
+  return _then(_self.copyWith(
+info: freezed == info ? _self.info : info // ignore: cast_nullable_to_non_nullable
+as Info?,item: freezed == item ? _self.item : item // ignore: cast_nullable_to_non_nullable
+as List<Item>?,auth: freezed == auth ? _self.auth : auth // ignore: cast_nullable_to_non_nullable
+as Auth?,variable: freezed == variable ? _self.variable : variable // ignore: cast_nullable_to_non_nullable
+as List<Variable>?,
+  ));
+}
+/// Create a copy of PostmanCollection
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$InfoCopyWith<$Res>? get info {
+    if (_self.info == null) {
+    return null;
   }
 
-  /// Create a copy of PostmanCollection
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $InfoCopyWith<$Res>? get info {
-    if (_value.info == null) {
-      return null;
-    }
-
-    return $InfoCopyWith<$Res>(_value.info!, (value) {
-      return _then(_value.copyWith(info: value) as $Val);
-    });
+  return $InfoCopyWith<$Res>(_self.info!, (value) {
+    return _then(_self.copyWith(info: value));
+  });
+}/// Create a copy of PostmanCollection
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$AuthCopyWith<$Res>? get auth {
+    if (_self.auth == null) {
+    return null;
   }
+
+  return $AuthCopyWith<$Res>(_self.auth!, (value) {
+    return _then(_self.copyWith(auth: value));
+  });
+}
 }
 
-/// @nodoc
-abstract class _$$PostmanCollectionImplCopyWith<$Res>
-    implements $PostmanCollectionCopyWith<$Res> {
-  factory _$$PostmanCollectionImplCopyWith(_$PostmanCollectionImpl value,
-          $Res Function(_$PostmanCollectionImpl) then) =
-      __$$PostmanCollectionImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({Info? info, List<Item>? item});
 
-  @override
-  $InfoCopyWith<$Res>? get info;
+/// Adds pattern-matching-related methods to [PostmanCollection].
+extension PostmanCollectionPatterns on PostmanCollection {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PostmanCollection value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PostmanCollection() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PostmanCollection value)  $default,){
+final _that = this;
+switch (_that) {
+case _PostmanCollection():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PostmanCollection value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PostmanCollection() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Info? info,  List<Item>? item,  Auth? auth,  List<Variable>? variable)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PostmanCollection() when $default != null:
+return $default(_that.info,_that.item,_that.auth,_that.variable);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Info? info,  List<Item>? item,  Auth? auth,  List<Variable>? variable)  $default,) {final _that = this;
+switch (_that) {
+case _PostmanCollection():
+return $default(_that.info,_that.item,_that.auth,_that.variable);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Info? info,  List<Item>? item,  Auth? auth,  List<Variable>? variable)?  $default,) {final _that = this;
+switch (_that) {
+case _PostmanCollection() when $default != null:
+return $default(_that.info,_that.item,_that.auth,_that.variable);case _:
+  return null;
+
+}
 }
 
-/// @nodoc
-class __$$PostmanCollectionImplCopyWithImpl<$Res>
-    extends _$PostmanCollectionCopyWithImpl<$Res, _$PostmanCollectionImpl>
-    implements _$$PostmanCollectionImplCopyWith<$Res> {
-  __$$PostmanCollectionImplCopyWithImpl(_$PostmanCollectionImpl _value,
-      $Res Function(_$PostmanCollectionImpl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of PostmanCollection
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? info = freezed,
-    Object? item = freezed,
-  }) {
-    return _then(_$PostmanCollectionImpl(
-      info: freezed == info
-          ? _value.info
-          : info // ignore: cast_nullable_to_non_nullable
-              as Info?,
-      item: freezed == item
-          ? _value._item
-          : item // ignore: cast_nullable_to_non_nullable
-              as List<Item>?,
-    ));
-  }
 }
 
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
-class _$PostmanCollectionImpl implements _PostmanCollection {
-  const _$PostmanCollectionImpl({this.info, final List<Item>? item})
-      : _item = item;
+class _PostmanCollection implements PostmanCollection {
+  const _PostmanCollection({this.info, final  List<Item>? item, this.auth, final  List<Variable>? variable}): _item = item,_variable = variable;
+  factory _PostmanCollection.fromJson(Map<String, dynamic> json) => _$PostmanCollectionFromJson(json);
 
-  factory _$PostmanCollectionImpl.fromJson(Map<String, dynamic> json) =>
-      _$$PostmanCollectionImplFromJson(json);
-
-  @override
-  final Info? info;
-  final List<Item>? _item;
-  @override
-  List<Item>? get item {
-    final value = _item;
-    if (value == null) return null;
-    if (_item is EqualUnmodifiableListView) return _item;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
-
-  @override
-  String toString() {
-    return 'PostmanCollection(info: $info, item: $item)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$PostmanCollectionImpl &&
-            (identical(other.info, info) || other.info == info) &&
-            const DeepCollectionEquality().equals(other._item, _item));
-  }
-
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType, info, const DeepCollectionEquality().hash(_item));
-
-  /// Create a copy of PostmanCollection
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$PostmanCollectionImplCopyWith<_$PostmanCollectionImpl> get copyWith =>
-      __$$PostmanCollectionImplCopyWithImpl<_$PostmanCollectionImpl>(
-          this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$PostmanCollectionImplToJson(
-      this,
-    );
-  }
+@override final  Info? info;
+ final  List<Item>? _item;
+@override List<Item>? get item {
+  final value = _item;
+  if (value == null) return null;
+  if (_item is EqualUnmodifiableListView) return _item;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
 }
 
-abstract class _PostmanCollection implements PostmanCollection {
-  const factory _PostmanCollection({final Info? info, final List<Item>? item}) =
-      _$PostmanCollectionImpl;
-
-  factory _PostmanCollection.fromJson(Map<String, dynamic> json) =
-      _$PostmanCollectionImpl.fromJson;
-
-  @override
-  Info? get info;
-  @override
-  List<Item>? get item;
-
-  /// Create a copy of PostmanCollection
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$PostmanCollectionImplCopyWith<_$PostmanCollectionImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override final  Auth? auth;
+ final  List<Variable>? _variable;
+@override List<Variable>? get variable {
+  final value = _variable;
+  if (value == null) return null;
+  if (_variable is EqualUnmodifiableListView) return _variable;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
 }
 
-Info _$InfoFromJson(Map<String, dynamic> json) {
-  return _Info.fromJson(json);
+
+/// Create a copy of PostmanCollection
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PostmanCollectionCopyWith<_PostmanCollection> get copyWith => __$PostmanCollectionCopyWithImpl<_PostmanCollection>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PostmanCollectionToJson(this, );
 }
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PostmanCollection&&(identical(other.info, info) || other.info == info)&&const DeepCollectionEquality().equals(other._item, _item)&&(identical(other.auth, auth) || other.auth == auth)&&const DeepCollectionEquality().equals(other._variable, _variable));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,info,const DeepCollectionEquality().hash(_item),auth,const DeepCollectionEquality().hash(_variable));
+
+@override
+String toString() {
+  return 'PostmanCollection(info: $info, item: $item, auth: $auth, variable: $variable)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PostmanCollectionCopyWith<$Res> implements $PostmanCollectionCopyWith<$Res> {
+  factory _$PostmanCollectionCopyWith(_PostmanCollection value, $Res Function(_PostmanCollection) _then) = __$PostmanCollectionCopyWithImpl;
+@override @useResult
+$Res call({
+ Info? info, List<Item>? item, Auth? auth, List<Variable>? variable
+});
+
+
+@override $InfoCopyWith<$Res>? get info;@override $AuthCopyWith<$Res>? get auth;
+
+}
+/// @nodoc
+class __$PostmanCollectionCopyWithImpl<$Res>
+    implements _$PostmanCollectionCopyWith<$Res> {
+  __$PostmanCollectionCopyWithImpl(this._self, this._then);
+
+  final _PostmanCollection _self;
+  final $Res Function(_PostmanCollection) _then;
+
+/// Create a copy of PostmanCollection
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? info = freezed,Object? item = freezed,Object? auth = freezed,Object? variable = freezed,}) {
+  return _then(_PostmanCollection(
+info: freezed == info ? _self.info : info // ignore: cast_nullable_to_non_nullable
+as Info?,item: freezed == item ? _self._item : item // ignore: cast_nullable_to_non_nullable
+as List<Item>?,auth: freezed == auth ? _self.auth : auth // ignore: cast_nullable_to_non_nullable
+as Auth?,variable: freezed == variable ? _self._variable : variable // ignore: cast_nullable_to_non_nullable
+as List<Variable>?,
+  ));
+}
+
+/// Create a copy of PostmanCollection
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$InfoCopyWith<$Res>? get info {
+    if (_self.info == null) {
+    return null;
+  }
+
+  return $InfoCopyWith<$Res>(_self.info!, (value) {
+    return _then(_self.copyWith(info: value));
+  });
+}/// Create a copy of PostmanCollection
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$AuthCopyWith<$Res>? get auth {
+    if (_self.auth == null) {
+    return null;
+  }
+
+  return $AuthCopyWith<$Res>(_self.auth!, (value) {
+    return _then(_self.copyWith(auth: value));
+  });
+}
+}
+
 
 /// @nodoc
 mixin _$Info {
-  @JsonKey(name: '_postman_id')
-  String? get postmanId => throw _privateConstructorUsedError;
-  String? get name => throw _privateConstructorUsedError;
-  String? get schema => throw _privateConstructorUsedError;
-  @JsonKey(name: '_exporter_id')
-  String? get exporterId => throw _privateConstructorUsedError;
+
+@JsonKey(name: '_postman_id') String? get postmanId; String? get name; String? get schema;@JsonKey(name: '_exporter_id') String? get exporterId;
+/// Create a copy of Info
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$InfoCopyWith<Info> get copyWith => _$InfoCopyWithImpl<Info>(this as Info, _$identity);
 
   /// Serializes this Info to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  Map<String, dynamic> toJson();
 
-  /// Create a copy of Info
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $InfoCopyWith<Info> get copyWith => throw _privateConstructorUsedError;
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Info&&(identical(other.postmanId, postmanId) || other.postmanId == postmanId)&&(identical(other.name, name) || other.name == name)&&(identical(other.schema, schema) || other.schema == schema)&&(identical(other.exporterId, exporterId) || other.exporterId == exporterId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,postmanId,name,schema,exporterId);
+
+@override
+String toString() {
+  return 'Info(postmanId: $postmanId, name: $name, schema: $schema, exporterId: $exporterId)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $InfoCopyWith<$Res> {
-  factory $InfoCopyWith(Info value, $Res Function(Info) then) =
-      _$InfoCopyWithImpl<$Res, Info>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: '_postman_id') String? postmanId,
-      String? name,
-      String? schema,
-      @JsonKey(name: '_exporter_id') String? exporterId});
-}
+abstract mixin class $InfoCopyWith<$Res>  {
+  factory $InfoCopyWith(Info value, $Res Function(Info) _then) = _$InfoCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: '_postman_id') String? postmanId, String? name, String? schema,@JsonKey(name: '_exporter_id') String? exporterId
+});
 
+
+
+
+}
 /// @nodoc
-class _$InfoCopyWithImpl<$Res, $Val extends Info>
+class _$InfoCopyWithImpl<$Res>
     implements $InfoCopyWith<$Res> {
-  _$InfoCopyWithImpl(this._value, this._then);
+  _$InfoCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final Info _self;
+  final $Res Function(Info) _then;
 
-  /// Create a copy of Info
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? postmanId = freezed,
-    Object? name = freezed,
-    Object? schema = freezed,
-    Object? exporterId = freezed,
-  }) {
-    return _then(_value.copyWith(
-      postmanId: freezed == postmanId
-          ? _value.postmanId
-          : postmanId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      name: freezed == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String?,
-      schema: freezed == schema
-          ? _value.schema
-          : schema // ignore: cast_nullable_to_non_nullable
-              as String?,
-      exporterId: freezed == exporterId
-          ? _value.exporterId
-          : exporterId // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ) as $Val);
-  }
+/// Create a copy of Info
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? postmanId = freezed,Object? name = freezed,Object? schema = freezed,Object? exporterId = freezed,}) {
+  return _then(_self.copyWith(
+postmanId: freezed == postmanId ? _self.postmanId : postmanId // ignore: cast_nullable_to_non_nullable
+as String?,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,schema: freezed == schema ? _self.schema : schema // ignore: cast_nullable_to_non_nullable
+as String?,exporterId: freezed == exporterId ? _self.exporterId : exporterId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
 }
 
-/// @nodoc
-abstract class _$$InfoImplCopyWith<$Res> implements $InfoCopyWith<$Res> {
-  factory _$$InfoImplCopyWith(
-          _$InfoImpl value, $Res Function(_$InfoImpl) then) =
-      __$$InfoImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: '_postman_id') String? postmanId,
-      String? name,
-      String? schema,
-      @JsonKey(name: '_exporter_id') String? exporterId});
 }
 
-/// @nodoc
-class __$$InfoImplCopyWithImpl<$Res>
-    extends _$InfoCopyWithImpl<$Res, _$InfoImpl>
-    implements _$$InfoImplCopyWith<$Res> {
-  __$$InfoImplCopyWithImpl(_$InfoImpl _value, $Res Function(_$InfoImpl) _then)
-      : super(_value, _then);
 
-  /// Create a copy of Info
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? postmanId = freezed,
-    Object? name = freezed,
-    Object? schema = freezed,
-    Object? exporterId = freezed,
-  }) {
-    return _then(_$InfoImpl(
-      postmanId: freezed == postmanId
-          ? _value.postmanId
-          : postmanId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      name: freezed == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String?,
-      schema: freezed == schema
-          ? _value.schema
-          : schema // ignore: cast_nullable_to_non_nullable
-              as String?,
-      exporterId: freezed == exporterId
-          ? _value.exporterId
-          : exporterId // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Adds pattern-matching-related methods to [Info].
+extension InfoPatterns on Info {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Info value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Info() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Info value)  $default,){
+final _that = this;
+switch (_that) {
+case _Info():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Info value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Info() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: '_postman_id')  String? postmanId,  String? name,  String? schema, @JsonKey(name: '_exporter_id')  String? exporterId)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Info() when $default != null:
+return $default(_that.postmanId,_that.name,_that.schema,_that.exporterId);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: '_postman_id')  String? postmanId,  String? name,  String? schema, @JsonKey(name: '_exporter_id')  String? exporterId)  $default,) {final _that = this;
+switch (_that) {
+case _Info():
+return $default(_that.postmanId,_that.name,_that.schema,_that.exporterId);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: '_postman_id')  String? postmanId,  String? name,  String? schema, @JsonKey(name: '_exporter_id')  String? exporterId)?  $default,) {final _that = this;
+switch (_that) {
+case _Info() when $default != null:
+return $default(_that.postmanId,_that.name,_that.schema,_that.exporterId);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
-class _$InfoImpl implements _Info {
-  const _$InfoImpl(
-      {@JsonKey(name: '_postman_id') this.postmanId,
-      this.name,
-      this.schema,
-      @JsonKey(name: '_exporter_id') this.exporterId});
+class _Info implements Info {
+  const _Info({@JsonKey(name: '_postman_id') this.postmanId, this.name, this.schema, @JsonKey(name: '_exporter_id') this.exporterId});
+  factory _Info.fromJson(Map<String, dynamic> json) => _$InfoFromJson(json);
 
-  factory _$InfoImpl.fromJson(Map<String, dynamic> json) =>
-      _$$InfoImplFromJson(json);
+@override@JsonKey(name: '_postman_id') final  String? postmanId;
+@override final  String? name;
+@override final  String? schema;
+@override@JsonKey(name: '_exporter_id') final  String? exporterId;
 
-  @override
-  @JsonKey(name: '_postman_id')
-  final String? postmanId;
-  @override
-  final String? name;
-  @override
-  final String? schema;
-  @override
-  @JsonKey(name: '_exporter_id')
-  final String? exporterId;
+/// Create a copy of Info
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$InfoCopyWith<_Info> get copyWith => __$InfoCopyWithImpl<_Info>(this, _$identity);
 
-  @override
-  String toString() {
-    return 'Info(postmanId: $postmanId, name: $name, schema: $schema, exporterId: $exporterId)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$InfoImpl &&
-            (identical(other.postmanId, postmanId) ||
-                other.postmanId == postmanId) &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.schema, schema) || other.schema == schema) &&
-            (identical(other.exporterId, exporterId) ||
-                other.exporterId == exporterId));
-  }
-
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode =>
-      Object.hash(runtimeType, postmanId, name, schema, exporterId);
-
-  /// Create a copy of Info
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$InfoImplCopyWith<_$InfoImpl> get copyWith =>
-      __$$InfoImplCopyWithImpl<_$InfoImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$InfoImplToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$InfoToJson(this, );
 }
 
-abstract class _Info implements Info {
-  const factory _Info(
-      {@JsonKey(name: '_postman_id') final String? postmanId,
-      final String? name,
-      final String? schema,
-      @JsonKey(name: '_exporter_id') final String? exporterId}) = _$InfoImpl;
-
-  factory _Info.fromJson(Map<String, dynamic> json) = _$InfoImpl.fromJson;
-
-  @override
-  @JsonKey(name: '_postman_id')
-  String? get postmanId;
-  @override
-  String? get name;
-  @override
-  String? get schema;
-  @override
-  @JsonKey(name: '_exporter_id')
-  String? get exporterId;
-
-  /// Create a copy of Info
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$InfoImplCopyWith<_$InfoImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Info&&(identical(other.postmanId, postmanId) || other.postmanId == postmanId)&&(identical(other.name, name) || other.name == name)&&(identical(other.schema, schema) || other.schema == schema)&&(identical(other.exporterId, exporterId) || other.exporterId == exporterId));
 }
 
-Item _$ItemFromJson(Map<String, dynamic> json) {
-  return _Item.fromJson(json);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,postmanId,name,schema,exporterId);
+
+@override
+String toString() {
+  return 'Info(postmanId: $postmanId, name: $name, schema: $schema, exporterId: $exporterId)';
 }
+
+
+}
+
+/// @nodoc
+abstract mixin class _$InfoCopyWith<$Res> implements $InfoCopyWith<$Res> {
+  factory _$InfoCopyWith(_Info value, $Res Function(_Info) _then) = __$InfoCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: '_postman_id') String? postmanId, String? name, String? schema,@JsonKey(name: '_exporter_id') String? exporterId
+});
+
+
+
+
+}
+/// @nodoc
+class __$InfoCopyWithImpl<$Res>
+    implements _$InfoCopyWith<$Res> {
+  __$InfoCopyWithImpl(this._self, this._then);
+
+  final _Info _self;
+  final $Res Function(_Info) _then;
+
+/// Create a copy of Info
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? postmanId = freezed,Object? name = freezed,Object? schema = freezed,Object? exporterId = freezed,}) {
+  return _then(_Info(
+postmanId: freezed == postmanId ? _self.postmanId : postmanId // ignore: cast_nullable_to_non_nullable
+as String?,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,schema: freezed == schema ? _self.schema : schema // ignore: cast_nullable_to_non_nullable
+as String?,exporterId: freezed == exporterId ? _self.exporterId : exporterId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
 
 /// @nodoc
 mixin _$Item {
-  String? get name => throw _privateConstructorUsedError;
-  List<Item>? get item => throw _privateConstructorUsedError;
-  Request? get request => throw _privateConstructorUsedError;
-  List<dynamic>? get response => throw _privateConstructorUsedError;
+
+ String? get name; List<Item>? get item; Request? get request; List<dynamic>? get response;
+/// Create a copy of Item
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ItemCopyWith<Item> get copyWith => _$ItemCopyWithImpl<Item>(this as Item, _$identity);
 
   /// Serializes this Item to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  Map<String, dynamic> toJson();
 
-  /// Create a copy of Item
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $ItemCopyWith<Item> get copyWith => throw _privateConstructorUsedError;
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Item&&(identical(other.name, name) || other.name == name)&&const DeepCollectionEquality().equals(other.item, item)&&(identical(other.request, request) || other.request == request)&&const DeepCollectionEquality().equals(other.response, response));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,name,const DeepCollectionEquality().hash(item),request,const DeepCollectionEquality().hash(response));
+
+@override
+String toString() {
+  return 'Item(name: $name, item: $item, request: $request, response: $response)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $ItemCopyWith<$Res> {
-  factory $ItemCopyWith(Item value, $Res Function(Item) then) =
-      _$ItemCopyWithImpl<$Res, Item>;
-  @useResult
-  $Res call(
-      {String? name,
-      List<Item>? item,
-      Request? request,
-      List<dynamic>? response});
+abstract mixin class $ItemCopyWith<$Res>  {
+  factory $ItemCopyWith(Item value, $Res Function(Item) _then) = _$ItemCopyWithImpl;
+@useResult
+$Res call({
+ String? name, List<Item>? item, Request? request, List<dynamic>? response
+});
 
-  $RequestCopyWith<$Res>? get request;
+
+$RequestCopyWith<$Res>? get request;
+
 }
-
 /// @nodoc
-class _$ItemCopyWithImpl<$Res, $Val extends Item>
+class _$ItemCopyWithImpl<$Res>
     implements $ItemCopyWith<$Res> {
-  _$ItemCopyWithImpl(this._value, this._then);
+  _$ItemCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final Item _self;
+  final $Res Function(Item) _then;
 
-  /// Create a copy of Item
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? name = freezed,
-    Object? item = freezed,
-    Object? request = freezed,
-    Object? response = freezed,
-  }) {
-    return _then(_value.copyWith(
-      name: freezed == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String?,
-      item: freezed == item
-          ? _value.item
-          : item // ignore: cast_nullable_to_non_nullable
-              as List<Item>?,
-      request: freezed == request
-          ? _value.request
-          : request // ignore: cast_nullable_to_non_nullable
-              as Request?,
-      response: freezed == response
-          ? _value.response
-          : response // ignore: cast_nullable_to_non_nullable
-              as List<dynamic>?,
-    ) as $Val);
+/// Create a copy of Item
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? name = freezed,Object? item = freezed,Object? request = freezed,Object? response = freezed,}) {
+  return _then(_self.copyWith(
+name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,item: freezed == item ? _self.item : item // ignore: cast_nullable_to_non_nullable
+as List<Item>?,request: freezed == request ? _self.request : request // ignore: cast_nullable_to_non_nullable
+as Request?,response: freezed == response ? _self.response : response // ignore: cast_nullable_to_non_nullable
+as List<dynamic>?,
+  ));
+}
+/// Create a copy of Item
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$RequestCopyWith<$Res>? get request {
+    if (_self.request == null) {
+    return null;
   }
 
-  /// Create a copy of Item
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $RequestCopyWith<$Res>? get request {
-    if (_value.request == null) {
-      return null;
-    }
-
-    return $RequestCopyWith<$Res>(_value.request!, (value) {
-      return _then(_value.copyWith(request: value) as $Val);
-    });
-  }
+  return $RequestCopyWith<$Res>(_self.request!, (value) {
+    return _then(_self.copyWith(request: value));
+  });
+}
 }
 
-/// @nodoc
-abstract class _$$ItemImplCopyWith<$Res> implements $ItemCopyWith<$Res> {
-  factory _$$ItemImplCopyWith(
-          _$ItemImpl value, $Res Function(_$ItemImpl) then) =
-      __$$ItemImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {String? name,
-      List<Item>? item,
-      Request? request,
-      List<dynamic>? response});
 
-  @override
-  $RequestCopyWith<$Res>? get request;
+/// Adds pattern-matching-related methods to [Item].
+extension ItemPatterns on Item {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Item value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Item() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Item value)  $default,){
+final _that = this;
+switch (_that) {
+case _Item():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Item value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Item() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? name,  List<Item>? item,  Request? request,  List<dynamic>? response)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Item() when $default != null:
+return $default(_that.name,_that.item,_that.request,_that.response);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? name,  List<Item>? item,  Request? request,  List<dynamic>? response)  $default,) {final _that = this;
+switch (_that) {
+case _Item():
+return $default(_that.name,_that.item,_that.request,_that.response);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? name,  List<Item>? item,  Request? request,  List<dynamic>? response)?  $default,) {final _that = this;
+switch (_that) {
+case _Item() when $default != null:
+return $default(_that.name,_that.item,_that.request,_that.response);case _:
+  return null;
+
+}
 }
 
-/// @nodoc
-class __$$ItemImplCopyWithImpl<$Res>
-    extends _$ItemCopyWithImpl<$Res, _$ItemImpl>
-    implements _$$ItemImplCopyWith<$Res> {
-  __$$ItemImplCopyWithImpl(_$ItemImpl _value, $Res Function(_$ItemImpl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of Item
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? name = freezed,
-    Object? item = freezed,
-    Object? request = freezed,
-    Object? response = freezed,
-  }) {
-    return _then(_$ItemImpl(
-      name: freezed == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String?,
-      item: freezed == item
-          ? _value._item
-          : item // ignore: cast_nullable_to_non_nullable
-              as List<Item>?,
-      request: freezed == request
-          ? _value.request
-          : request // ignore: cast_nullable_to_non_nullable
-              as Request?,
-      response: freezed == response
-          ? _value._response
-          : response // ignore: cast_nullable_to_non_nullable
-              as List<dynamic>?,
-    ));
-  }
 }
 
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
-class _$ItemImpl implements _Item {
-  const _$ItemImpl(
-      {this.name,
-      final List<Item>? item,
-      this.request,
-      final List<dynamic>? response})
-      : _item = item,
-        _response = response;
+class _Item implements Item {
+  const _Item({this.name, final  List<Item>? item, this.request, final  List<dynamic>? response}): _item = item,_response = response;
+  factory _Item.fromJson(Map<String, dynamic> json) => _$ItemFromJson(json);
 
-  factory _$ItemImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ItemImplFromJson(json);
-
-  @override
-  final String? name;
-  final List<Item>? _item;
-  @override
-  List<Item>? get item {
-    final value = _item;
-    if (value == null) return null;
-    if (_item is EqualUnmodifiableListView) return _item;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
-
-  @override
-  final Request? request;
-  final List<dynamic>? _response;
-  @override
-  List<dynamic>? get response {
-    final value = _response;
-    if (value == null) return null;
-    if (_response is EqualUnmodifiableListView) return _response;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
-
-  @override
-  String toString() {
-    return 'Item(name: $name, item: $item, request: $request, response: $response)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$ItemImpl &&
-            (identical(other.name, name) || other.name == name) &&
-            const DeepCollectionEquality().equals(other._item, _item) &&
-            (identical(other.request, request) || other.request == request) &&
-            const DeepCollectionEquality().equals(other._response, _response));
-  }
-
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      name,
-      const DeepCollectionEquality().hash(_item),
-      request,
-      const DeepCollectionEquality().hash(_response));
-
-  /// Create a copy of Item
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$ItemImplCopyWith<_$ItemImpl> get copyWith =>
-      __$$ItemImplCopyWithImpl<_$ItemImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$ItemImplToJson(
-      this,
-    );
-  }
+@override final  String? name;
+ final  List<Item>? _item;
+@override List<Item>? get item {
+  final value = _item;
+  if (value == null) return null;
+  if (_item is EqualUnmodifiableListView) return _item;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
 }
 
-abstract class _Item implements Item {
-  const factory _Item(
-      {final String? name,
-      final List<Item>? item,
-      final Request? request,
-      final List<dynamic>? response}) = _$ItemImpl;
-
-  factory _Item.fromJson(Map<String, dynamic> json) = _$ItemImpl.fromJson;
-
-  @override
-  String? get name;
-  @override
-  List<Item>? get item;
-  @override
-  Request? get request;
-  @override
-  List<dynamic>? get response;
-
-  /// Create a copy of Item
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$ItemImplCopyWith<_$ItemImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override final  Request? request;
+ final  List<dynamic>? _response;
+@override List<dynamic>? get response {
+  final value = _response;
+  if (value == null) return null;
+  if (_response is EqualUnmodifiableListView) return _response;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
 }
 
-Request _$RequestFromJson(Map<String, dynamic> json) {
-  return _Request.fromJson(json);
+
+/// Create a copy of Item
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ItemCopyWith<_Item> get copyWith => __$ItemCopyWithImpl<_Item>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ItemToJson(this, );
 }
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Item&&(identical(other.name, name) || other.name == name)&&const DeepCollectionEquality().equals(other._item, _item)&&(identical(other.request, request) || other.request == request)&&const DeepCollectionEquality().equals(other._response, _response));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,name,const DeepCollectionEquality().hash(_item),request,const DeepCollectionEquality().hash(_response));
+
+@override
+String toString() {
+  return 'Item(name: $name, item: $item, request: $request, response: $response)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ItemCopyWith<$Res> implements $ItemCopyWith<$Res> {
+  factory _$ItemCopyWith(_Item value, $Res Function(_Item) _then) = __$ItemCopyWithImpl;
+@override @useResult
+$Res call({
+ String? name, List<Item>? item, Request? request, List<dynamic>? response
+});
+
+
+@override $RequestCopyWith<$Res>? get request;
+
+}
+/// @nodoc
+class __$ItemCopyWithImpl<$Res>
+    implements _$ItemCopyWith<$Res> {
+  __$ItemCopyWithImpl(this._self, this._then);
+
+  final _Item _self;
+  final $Res Function(_Item) _then;
+
+/// Create a copy of Item
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? name = freezed,Object? item = freezed,Object? request = freezed,Object? response = freezed,}) {
+  return _then(_Item(
+name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,item: freezed == item ? _self._item : item // ignore: cast_nullable_to_non_nullable
+as List<Item>?,request: freezed == request ? _self.request : request // ignore: cast_nullable_to_non_nullable
+as Request?,response: freezed == response ? _self._response : response // ignore: cast_nullable_to_non_nullable
+as List<dynamic>?,
+  ));
+}
+
+/// Create a copy of Item
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$RequestCopyWith<$Res>? get request {
+    if (_self.request == null) {
+    return null;
+  }
+
+  return $RequestCopyWith<$Res>(_self.request!, (value) {
+    return _then(_self.copyWith(request: value));
+  });
+}
+}
+
 
 /// @nodoc
 mixin _$Request {
-  String? get method => throw _privateConstructorUsedError;
-  List<Header>? get header => throw _privateConstructorUsedError;
-  Body? get body => throw _privateConstructorUsedError;
-  Url? get url => throw _privateConstructorUsedError;
+
+ String? get method; List<Header>? get header; Body? get body; Url? get url; Auth? get auth;
+/// Create a copy of Request
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RequestCopyWith<Request> get copyWith => _$RequestCopyWithImpl<Request>(this as Request, _$identity);
 
   /// Serializes this Request to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  Map<String, dynamic> toJson();
 
-  /// Create a copy of Request
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $RequestCopyWith<Request> get copyWith => throw _privateConstructorUsedError;
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Request&&(identical(other.method, method) || other.method == method)&&const DeepCollectionEquality().equals(other.header, header)&&(identical(other.body, body) || other.body == body)&&(identical(other.url, url) || other.url == url)&&(identical(other.auth, auth) || other.auth == auth));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,method,const DeepCollectionEquality().hash(header),body,url,auth);
+
+@override
+String toString() {
+  return 'Request(method: $method, header: $header, body: $body, url: $url, auth: $auth)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $RequestCopyWith<$Res> {
-  factory $RequestCopyWith(Request value, $Res Function(Request) then) =
-      _$RequestCopyWithImpl<$Res, Request>;
-  @useResult
-  $Res call({String? method, List<Header>? header, Body? body, Url? url});
+abstract mixin class $RequestCopyWith<$Res>  {
+  factory $RequestCopyWith(Request value, $Res Function(Request) _then) = _$RequestCopyWithImpl;
+@useResult
+$Res call({
+ String? method, List<Header>? header, Body? body, Url? url, Auth? auth
+});
 
-  $BodyCopyWith<$Res>? get body;
-  $UrlCopyWith<$Res>? get url;
+
+$BodyCopyWith<$Res>? get body;$UrlCopyWith<$Res>? get url;$AuthCopyWith<$Res>? get auth;
+
 }
-
 /// @nodoc
-class _$RequestCopyWithImpl<$Res, $Val extends Request>
+class _$RequestCopyWithImpl<$Res>
     implements $RequestCopyWith<$Res> {
-  _$RequestCopyWithImpl(this._value, this._then);
+  _$RequestCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final Request _self;
+  final $Res Function(Request) _then;
 
-  /// Create a copy of Request
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? method = freezed,
-    Object? header = freezed,
-    Object? body = freezed,
-    Object? url = freezed,
-  }) {
-    return _then(_value.copyWith(
-      method: freezed == method
-          ? _value.method
-          : method // ignore: cast_nullable_to_non_nullable
-              as String?,
-      header: freezed == header
-          ? _value.header
-          : header // ignore: cast_nullable_to_non_nullable
-              as List<Header>?,
-      body: freezed == body
-          ? _value.body
-          : body // ignore: cast_nullable_to_non_nullable
-              as Body?,
-      url: freezed == url
-          ? _value.url
-          : url // ignore: cast_nullable_to_non_nullable
-              as Url?,
-    ) as $Val);
+/// Create a copy of Request
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? method = freezed,Object? header = freezed,Object? body = freezed,Object? url = freezed,Object? auth = freezed,}) {
+  return _then(_self.copyWith(
+method: freezed == method ? _self.method : method // ignore: cast_nullable_to_non_nullable
+as String?,header: freezed == header ? _self.header : header // ignore: cast_nullable_to_non_nullable
+as List<Header>?,body: freezed == body ? _self.body : body // ignore: cast_nullable_to_non_nullable
+as Body?,url: freezed == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
+as Url?,auth: freezed == auth ? _self.auth : auth // ignore: cast_nullable_to_non_nullable
+as Auth?,
+  ));
+}
+/// Create a copy of Request
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$BodyCopyWith<$Res>? get body {
+    if (_self.body == null) {
+    return null;
   }
 
-  /// Create a copy of Request
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $BodyCopyWith<$Res>? get body {
-    if (_value.body == null) {
-      return null;
-    }
-
-    return $BodyCopyWith<$Res>(_value.body!, (value) {
-      return _then(_value.copyWith(body: value) as $Val);
-    });
+  return $BodyCopyWith<$Res>(_self.body!, (value) {
+    return _then(_self.copyWith(body: value));
+  });
+}/// Create a copy of Request
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UrlCopyWith<$Res>? get url {
+    if (_self.url == null) {
+    return null;
   }
 
-  /// Create a copy of Request
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $UrlCopyWith<$Res>? get url {
-    if (_value.url == null) {
-      return null;
-    }
-
-    return $UrlCopyWith<$Res>(_value.url!, (value) {
-      return _then(_value.copyWith(url: value) as $Val);
-    });
+  return $UrlCopyWith<$Res>(_self.url!, (value) {
+    return _then(_self.copyWith(url: value));
+  });
+}/// Create a copy of Request
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$AuthCopyWith<$Res>? get auth {
+    if (_self.auth == null) {
+    return null;
   }
+
+  return $AuthCopyWith<$Res>(_self.auth!, (value) {
+    return _then(_self.copyWith(auth: value));
+  });
+}
 }
 
-/// @nodoc
-abstract class _$$RequestImplCopyWith<$Res> implements $RequestCopyWith<$Res> {
-  factory _$$RequestImplCopyWith(
-          _$RequestImpl value, $Res Function(_$RequestImpl) then) =
-      __$$RequestImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String? method, List<Header>? header, Body? body, Url? url});
 
-  @override
-  $BodyCopyWith<$Res>? get body;
-  @override
-  $UrlCopyWith<$Res>? get url;
+/// Adds pattern-matching-related methods to [Request].
+extension RequestPatterns on Request {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Request value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Request() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Request value)  $default,){
+final _that = this;
+switch (_that) {
+case _Request():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Request value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Request() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? method,  List<Header>? header,  Body? body,  Url? url,  Auth? auth)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Request() when $default != null:
+return $default(_that.method,_that.header,_that.body,_that.url,_that.auth);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? method,  List<Header>? header,  Body? body,  Url? url,  Auth? auth)  $default,) {final _that = this;
+switch (_that) {
+case _Request():
+return $default(_that.method,_that.header,_that.body,_that.url,_that.auth);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? method,  List<Header>? header,  Body? body,  Url? url,  Auth? auth)?  $default,) {final _that = this;
+switch (_that) {
+case _Request() when $default != null:
+return $default(_that.method,_that.header,_that.body,_that.url,_that.auth);case _:
+  return null;
+
+}
 }
 
-/// @nodoc
-class __$$RequestImplCopyWithImpl<$Res>
-    extends _$RequestCopyWithImpl<$Res, _$RequestImpl>
-    implements _$$RequestImplCopyWith<$Res> {
-  __$$RequestImplCopyWithImpl(
-      _$RequestImpl _value, $Res Function(_$RequestImpl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of Request
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? method = freezed,
-    Object? header = freezed,
-    Object? body = freezed,
-    Object? url = freezed,
-  }) {
-    return _then(_$RequestImpl(
-      method: freezed == method
-          ? _value.method
-          : method // ignore: cast_nullable_to_non_nullable
-              as String?,
-      header: freezed == header
-          ? _value._header
-          : header // ignore: cast_nullable_to_non_nullable
-              as List<Header>?,
-      body: freezed == body
-          ? _value.body
-          : body // ignore: cast_nullable_to_non_nullable
-              as Body?,
-      url: freezed == url
-          ? _value.url
-          : url // ignore: cast_nullable_to_non_nullable
-              as Url?,
-    ));
-  }
 }
 
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
-class _$RequestImpl implements _Request {
-  const _$RequestImpl(
-      {this.method, final List<Header>? header, this.body, this.url})
-      : _header = header;
+class _Request implements Request {
+  const _Request({this.method, final  List<Header>? header, this.body, this.url, this.auth}): _header = header;
+  factory _Request.fromJson(Map<String, dynamic> json) => _$RequestFromJson(json);
 
-  factory _$RequestImpl.fromJson(Map<String, dynamic> json) =>
-      _$$RequestImplFromJson(json);
-
-  @override
-  final String? method;
-  final List<Header>? _header;
-  @override
-  List<Header>? get header {
-    final value = _header;
-    if (value == null) return null;
-    if (_header is EqualUnmodifiableListView) return _header;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
-
-  @override
-  final Body? body;
-  @override
-  final Url? url;
-
-  @override
-  String toString() {
-    return 'Request(method: $method, header: $header, body: $body, url: $url)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$RequestImpl &&
-            (identical(other.method, method) || other.method == method) &&
-            const DeepCollectionEquality().equals(other._header, _header) &&
-            (identical(other.body, body) || other.body == body) &&
-            (identical(other.url, url) || other.url == url));
-  }
-
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, method,
-      const DeepCollectionEquality().hash(_header), body, url);
-
-  /// Create a copy of Request
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$RequestImplCopyWith<_$RequestImpl> get copyWith =>
-      __$$RequestImplCopyWithImpl<_$RequestImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$RequestImplToJson(
-      this,
-    );
-  }
+@override final  String? method;
+ final  List<Header>? _header;
+@override List<Header>? get header {
+  final value = _header;
+  if (value == null) return null;
+  if (_header is EqualUnmodifiableListView) return _header;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
 }
 
-abstract class _Request implements Request {
-  const factory _Request(
-      {final String? method,
-      final List<Header>? header,
-      final Body? body,
-      final Url? url}) = _$RequestImpl;
+@override final  Body? body;
+@override final  Url? url;
+@override final  Auth? auth;
 
-  factory _Request.fromJson(Map<String, dynamic> json) = _$RequestImpl.fromJson;
+/// Create a copy of Request
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$RequestCopyWith<_Request> get copyWith => __$RequestCopyWithImpl<_Request>(this, _$identity);
 
-  @override
-  String? get method;
-  @override
-  List<Header>? get header;
-  @override
-  Body? get body;
-  @override
-  Url? get url;
-
-  /// Create a copy of Request
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$RequestImplCopyWith<_$RequestImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+Map<String, dynamic> toJson() {
+  return _$RequestToJson(this, );
 }
 
-Header _$HeaderFromJson(Map<String, dynamic> json) {
-  return _Header.fromJson(json);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Request&&(identical(other.method, method) || other.method == method)&&const DeepCollectionEquality().equals(other._header, _header)&&(identical(other.body, body) || other.body == body)&&(identical(other.url, url) || other.url == url)&&(identical(other.auth, auth) || other.auth == auth));
 }
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,method,const DeepCollectionEquality().hash(_header),body,url,auth);
+
+@override
+String toString() {
+  return 'Request(method: $method, header: $header, body: $body, url: $url, auth: $auth)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$RequestCopyWith<$Res> implements $RequestCopyWith<$Res> {
+  factory _$RequestCopyWith(_Request value, $Res Function(_Request) _then) = __$RequestCopyWithImpl;
+@override @useResult
+$Res call({
+ String? method, List<Header>? header, Body? body, Url? url, Auth? auth
+});
+
+
+@override $BodyCopyWith<$Res>? get body;@override $UrlCopyWith<$Res>? get url;@override $AuthCopyWith<$Res>? get auth;
+
+}
+/// @nodoc
+class __$RequestCopyWithImpl<$Res>
+    implements _$RequestCopyWith<$Res> {
+  __$RequestCopyWithImpl(this._self, this._then);
+
+  final _Request _self;
+  final $Res Function(_Request) _then;
+
+/// Create a copy of Request
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? method = freezed,Object? header = freezed,Object? body = freezed,Object? url = freezed,Object? auth = freezed,}) {
+  return _then(_Request(
+method: freezed == method ? _self.method : method // ignore: cast_nullable_to_non_nullable
+as String?,header: freezed == header ? _self._header : header // ignore: cast_nullable_to_non_nullable
+as List<Header>?,body: freezed == body ? _self.body : body // ignore: cast_nullable_to_non_nullable
+as Body?,url: freezed == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
+as Url?,auth: freezed == auth ? _self.auth : auth // ignore: cast_nullable_to_non_nullable
+as Auth?,
+  ));
+}
+
+/// Create a copy of Request
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$BodyCopyWith<$Res>? get body {
+    if (_self.body == null) {
+    return null;
+  }
+
+  return $BodyCopyWith<$Res>(_self.body!, (value) {
+    return _then(_self.copyWith(body: value));
+  });
+}/// Create a copy of Request
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UrlCopyWith<$Res>? get url {
+    if (_self.url == null) {
+    return null;
+  }
+
+  return $UrlCopyWith<$Res>(_self.url!, (value) {
+    return _then(_self.copyWith(url: value));
+  });
+}/// Create a copy of Request
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$AuthCopyWith<$Res>? get auth {
+    if (_self.auth == null) {
+    return null;
+  }
+
+  return $AuthCopyWith<$Res>(_self.auth!, (value) {
+    return _then(_self.copyWith(auth: value));
+  });
+}
+}
+
 
 /// @nodoc
 mixin _$Header {
-  String? get key => throw _privateConstructorUsedError;
-  String? get value => throw _privateConstructorUsedError;
-  String? get type => throw _privateConstructorUsedError;
-  bool? get disabled => throw _privateConstructorUsedError;
+
+ String? get key; String? get value; String? get type; bool? get disabled;
+/// Create a copy of Header
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$HeaderCopyWith<Header> get copyWith => _$HeaderCopyWithImpl<Header>(this as Header, _$identity);
 
   /// Serializes this Header to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  Map<String, dynamic> toJson();
 
-  /// Create a copy of Header
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $HeaderCopyWith<Header> get copyWith => throw _privateConstructorUsedError;
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Header&&(identical(other.key, key) || other.key == key)&&(identical(other.value, value) || other.value == value)&&(identical(other.type, type) || other.type == type)&&(identical(other.disabled, disabled) || other.disabled == disabled));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,key,value,type,disabled);
+
+@override
+String toString() {
+  return 'Header(key: $key, value: $value, type: $type, disabled: $disabled)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $HeaderCopyWith<$Res> {
-  factory $HeaderCopyWith(Header value, $Res Function(Header) then) =
-      _$HeaderCopyWithImpl<$Res, Header>;
-  @useResult
-  $Res call({String? key, String? value, String? type, bool? disabled});
-}
+abstract mixin class $HeaderCopyWith<$Res>  {
+  factory $HeaderCopyWith(Header value, $Res Function(Header) _then) = _$HeaderCopyWithImpl;
+@useResult
+$Res call({
+ String? key, String? value, String? type, bool? disabled
+});
 
+
+
+
+}
 /// @nodoc
-class _$HeaderCopyWithImpl<$Res, $Val extends Header>
+class _$HeaderCopyWithImpl<$Res>
     implements $HeaderCopyWith<$Res> {
-  _$HeaderCopyWithImpl(this._value, this._then);
+  _$HeaderCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final Header _self;
+  final $Res Function(Header) _then;
 
-  /// Create a copy of Header
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? key = freezed,
-    Object? value = freezed,
-    Object? type = freezed,
-    Object? disabled = freezed,
-  }) {
-    return _then(_value.copyWith(
-      key: freezed == key
-          ? _value.key
-          : key // ignore: cast_nullable_to_non_nullable
-              as String?,
-      value: freezed == value
-          ? _value.value
-          : value // ignore: cast_nullable_to_non_nullable
-              as String?,
-      type: freezed == type
-          ? _value.type
-          : type // ignore: cast_nullable_to_non_nullable
-              as String?,
-      disabled: freezed == disabled
-          ? _value.disabled
-          : disabled // ignore: cast_nullable_to_non_nullable
-              as bool?,
-    ) as $Val);
-  }
+/// Create a copy of Header
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? key = freezed,Object? value = freezed,Object? type = freezed,Object? disabled = freezed,}) {
+  return _then(_self.copyWith(
+key: freezed == key ? _self.key : key // ignore: cast_nullable_to_non_nullable
+as String?,value: freezed == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
+as String?,type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String?,disabled: freezed == disabled ? _self.disabled : disabled // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
 }
 
-/// @nodoc
-abstract class _$$HeaderImplCopyWith<$Res> implements $HeaderCopyWith<$Res> {
-  factory _$$HeaderImplCopyWith(
-          _$HeaderImpl value, $Res Function(_$HeaderImpl) then) =
-      __$$HeaderImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String? key, String? value, String? type, bool? disabled});
 }
 
-/// @nodoc
-class __$$HeaderImplCopyWithImpl<$Res>
-    extends _$HeaderCopyWithImpl<$Res, _$HeaderImpl>
-    implements _$$HeaderImplCopyWith<$Res> {
-  __$$HeaderImplCopyWithImpl(
-      _$HeaderImpl _value, $Res Function(_$HeaderImpl) _then)
-      : super(_value, _then);
 
-  /// Create a copy of Header
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? key = freezed,
-    Object? value = freezed,
-    Object? type = freezed,
-    Object? disabled = freezed,
-  }) {
-    return _then(_$HeaderImpl(
-      key: freezed == key
-          ? _value.key
-          : key // ignore: cast_nullable_to_non_nullable
-              as String?,
-      value: freezed == value
-          ? _value.value
-          : value // ignore: cast_nullable_to_non_nullable
-              as String?,
-      type: freezed == type
-          ? _value.type
-          : type // ignore: cast_nullable_to_non_nullable
-              as String?,
-      disabled: freezed == disabled
-          ? _value.disabled
-          : disabled // ignore: cast_nullable_to_non_nullable
-              as bool?,
-    ));
-  }
+/// Adds pattern-matching-related methods to [Header].
+extension HeaderPatterns on Header {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Header value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Header() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Header value)  $default,){
+final _that = this;
+switch (_that) {
+case _Header():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Header value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Header() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? key,  String? value,  String? type,  bool? disabled)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Header() when $default != null:
+return $default(_that.key,_that.value,_that.type,_that.disabled);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? key,  String? value,  String? type,  bool? disabled)  $default,) {final _that = this;
+switch (_that) {
+case _Header():
+return $default(_that.key,_that.value,_that.type,_that.disabled);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? key,  String? value,  String? type,  bool? disabled)?  $default,) {final _that = this;
+switch (_that) {
+case _Header() when $default != null:
+return $default(_that.key,_that.value,_that.type,_that.disabled);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
-class _$HeaderImpl implements _Header {
-  const _$HeaderImpl({this.key, this.value, this.type, this.disabled});
+class _Header implements Header {
+  const _Header({this.key, this.value, this.type, this.disabled});
+  factory _Header.fromJson(Map<String, dynamic> json) => _$HeaderFromJson(json);
 
-  factory _$HeaderImpl.fromJson(Map<String, dynamic> json) =>
-      _$$HeaderImplFromJson(json);
+@override final  String? key;
+@override final  String? value;
+@override final  String? type;
+@override final  bool? disabled;
 
-  @override
-  final String? key;
-  @override
-  final String? value;
-  @override
-  final String? type;
-  @override
-  final bool? disabled;
+/// Create a copy of Header
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$HeaderCopyWith<_Header> get copyWith => __$HeaderCopyWithImpl<_Header>(this, _$identity);
 
-  @override
-  String toString() {
-    return 'Header(key: $key, value: $value, type: $type, disabled: $disabled)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$HeaderImpl &&
-            (identical(other.key, key) || other.key == key) &&
-            (identical(other.value, value) || other.value == value) &&
-            (identical(other.type, type) || other.type == type) &&
-            (identical(other.disabled, disabled) ||
-                other.disabled == disabled));
-  }
-
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, key, value, type, disabled);
-
-  /// Create a copy of Header
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$HeaderImplCopyWith<_$HeaderImpl> get copyWith =>
-      __$$HeaderImplCopyWithImpl<_$HeaderImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$HeaderImplToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$HeaderToJson(this, );
 }
 
-abstract class _Header implements Header {
-  const factory _Header(
-      {final String? key,
-      final String? value,
-      final String? type,
-      final bool? disabled}) = _$HeaderImpl;
-
-  factory _Header.fromJson(Map<String, dynamic> json) = _$HeaderImpl.fromJson;
-
-  @override
-  String? get key;
-  @override
-  String? get value;
-  @override
-  String? get type;
-  @override
-  bool? get disabled;
-
-  /// Create a copy of Header
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$HeaderImplCopyWith<_$HeaderImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Header&&(identical(other.key, key) || other.key == key)&&(identical(other.value, value) || other.value == value)&&(identical(other.type, type) || other.type == type)&&(identical(other.disabled, disabled) || other.disabled == disabled));
 }
 
-Url _$UrlFromJson(Map<String, dynamic> json) {
-  return _Url.fromJson(json);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,key,value,type,disabled);
+
+@override
+String toString() {
+  return 'Header(key: $key, value: $value, type: $type, disabled: $disabled)';
 }
+
+
+}
+
+/// @nodoc
+abstract mixin class _$HeaderCopyWith<$Res> implements $HeaderCopyWith<$Res> {
+  factory _$HeaderCopyWith(_Header value, $Res Function(_Header) _then) = __$HeaderCopyWithImpl;
+@override @useResult
+$Res call({
+ String? key, String? value, String? type, bool? disabled
+});
+
+
+
+
+}
+/// @nodoc
+class __$HeaderCopyWithImpl<$Res>
+    implements _$HeaderCopyWith<$Res> {
+  __$HeaderCopyWithImpl(this._self, this._then);
+
+  final _Header _self;
+  final $Res Function(_Header) _then;
+
+/// Create a copy of Header
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? key = freezed,Object? value = freezed,Object? type = freezed,Object? disabled = freezed,}) {
+  return _then(_Header(
+key: freezed == key ? _self.key : key // ignore: cast_nullable_to_non_nullable
+as String?,value: freezed == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
+as String?,type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String?,disabled: freezed == disabled ? _self.disabled : disabled // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+
+}
+
 
 /// @nodoc
 mixin _$Url {
-  String? get raw => throw _privateConstructorUsedError;
-  String? get protocol => throw _privateConstructorUsedError;
-  List<String>? get host => throw _privateConstructorUsedError;
-  List<String>? get path => throw _privateConstructorUsedError;
-  List<Query>? get query => throw _privateConstructorUsedError;
+
+ String? get raw; String? get protocol; List<String>? get host; List<String>? get path; List<Query>? get query;
+/// Create a copy of Url
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$UrlCopyWith<Url> get copyWith => _$UrlCopyWithImpl<Url>(this as Url, _$identity);
 
   /// Serializes this Url to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  Map<String, dynamic> toJson();
 
-  /// Create a copy of Url
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $UrlCopyWith<Url> get copyWith => throw _privateConstructorUsedError;
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Url&&(identical(other.raw, raw) || other.raw == raw)&&(identical(other.protocol, protocol) || other.protocol == protocol)&&const DeepCollectionEquality().equals(other.host, host)&&const DeepCollectionEquality().equals(other.path, path)&&const DeepCollectionEquality().equals(other.query, query));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,raw,protocol,const DeepCollectionEquality().hash(host),const DeepCollectionEquality().hash(path),const DeepCollectionEquality().hash(query));
+
+@override
+String toString() {
+  return 'Url(raw: $raw, protocol: $protocol, host: $host, path: $path, query: $query)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $UrlCopyWith<$Res> {
-  factory $UrlCopyWith(Url value, $Res Function(Url) then) =
-      _$UrlCopyWithImpl<$Res, Url>;
-  @useResult
-  $Res call(
-      {String? raw,
-      String? protocol,
-      List<String>? host,
-      List<String>? path,
-      List<Query>? query});
+abstract mixin class $UrlCopyWith<$Res>  {
+  factory $UrlCopyWith(Url value, $Res Function(Url) _then) = _$UrlCopyWithImpl;
+@useResult
+$Res call({
+ String? raw, String? protocol, List<String>? host, List<String>? path, List<Query>? query
+});
+
+
+
+
+}
+/// @nodoc
+class _$UrlCopyWithImpl<$Res>
+    implements $UrlCopyWith<$Res> {
+  _$UrlCopyWithImpl(this._self, this._then);
+
+  final Url _self;
+  final $Res Function(Url) _then;
+
+/// Create a copy of Url
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? raw = freezed,Object? protocol = freezed,Object? host = freezed,Object? path = freezed,Object? query = freezed,}) {
+  return _then(_self.copyWith(
+raw: freezed == raw ? _self.raw : raw // ignore: cast_nullable_to_non_nullable
+as String?,protocol: freezed == protocol ? _self.protocol : protocol // ignore: cast_nullable_to_non_nullable
+as String?,host: freezed == host ? _self.host : host // ignore: cast_nullable_to_non_nullable
+as List<String>?,path: freezed == path ? _self.path : path // ignore: cast_nullable_to_non_nullable
+as List<String>?,query: freezed == query ? _self.query : query // ignore: cast_nullable_to_non_nullable
+as List<Query>?,
+  ));
 }
 
-/// @nodoc
-class _$UrlCopyWithImpl<$Res, $Val extends Url> implements $UrlCopyWith<$Res> {
-  _$UrlCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of Url
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? raw = freezed,
-    Object? protocol = freezed,
-    Object? host = freezed,
-    Object? path = freezed,
-    Object? query = freezed,
-  }) {
-    return _then(_value.copyWith(
-      raw: freezed == raw
-          ? _value.raw
-          : raw // ignore: cast_nullable_to_non_nullable
-              as String?,
-      protocol: freezed == protocol
-          ? _value.protocol
-          : protocol // ignore: cast_nullable_to_non_nullable
-              as String?,
-      host: freezed == host
-          ? _value.host
-          : host // ignore: cast_nullable_to_non_nullable
-              as List<String>?,
-      path: freezed == path
-          ? _value.path
-          : path // ignore: cast_nullable_to_non_nullable
-              as List<String>?,
-      query: freezed == query
-          ? _value.query
-          : query // ignore: cast_nullable_to_non_nullable
-              as List<Query>?,
-    ) as $Val);
-  }
 }
 
-/// @nodoc
-abstract class _$$UrlImplCopyWith<$Res> implements $UrlCopyWith<$Res> {
-  factory _$$UrlImplCopyWith(_$UrlImpl value, $Res Function(_$UrlImpl) then) =
-      __$$UrlImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {String? raw,
-      String? protocol,
-      List<String>? host,
-      List<String>? path,
-      List<Query>? query});
+
+/// Adds pattern-matching-related methods to [Url].
+extension UrlPatterns on Url {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Url value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Url() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Url value)  $default,){
+final _that = this;
+switch (_that) {
+case _Url():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Url value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Url() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? raw,  String? protocol,  List<String>? host,  List<String>? path,  List<Query>? query)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Url() when $default != null:
+return $default(_that.raw,_that.protocol,_that.host,_that.path,_that.query);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? raw,  String? protocol,  List<String>? host,  List<String>? path,  List<Query>? query)  $default,) {final _that = this;
+switch (_that) {
+case _Url():
+return $default(_that.raw,_that.protocol,_that.host,_that.path,_that.query);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? raw,  String? protocol,  List<String>? host,  List<String>? path,  List<Query>? query)?  $default,) {final _that = this;
+switch (_that) {
+case _Url() when $default != null:
+return $default(_that.raw,_that.protocol,_that.host,_that.path,_that.query);case _:
+  return null;
+
+}
 }
 
-/// @nodoc
-class __$$UrlImplCopyWithImpl<$Res> extends _$UrlCopyWithImpl<$Res, _$UrlImpl>
-    implements _$$UrlImplCopyWith<$Res> {
-  __$$UrlImplCopyWithImpl(_$UrlImpl _value, $Res Function(_$UrlImpl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of Url
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? raw = freezed,
-    Object? protocol = freezed,
-    Object? host = freezed,
-    Object? path = freezed,
-    Object? query = freezed,
-  }) {
-    return _then(_$UrlImpl(
-      raw: freezed == raw
-          ? _value.raw
-          : raw // ignore: cast_nullable_to_non_nullable
-              as String?,
-      protocol: freezed == protocol
-          ? _value.protocol
-          : protocol // ignore: cast_nullable_to_non_nullable
-              as String?,
-      host: freezed == host
-          ? _value._host
-          : host // ignore: cast_nullable_to_non_nullable
-              as List<String>?,
-      path: freezed == path
-          ? _value._path
-          : path // ignore: cast_nullable_to_non_nullable
-              as List<String>?,
-      query: freezed == query
-          ? _value._query
-          : query // ignore: cast_nullable_to_non_nullable
-              as List<Query>?,
-    ));
-  }
 }
 
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
-class _$UrlImpl implements _Url {
-  const _$UrlImpl(
-      {this.raw,
-      this.protocol,
-      final List<String>? host,
-      final List<String>? path,
-      final List<Query>? query})
-      : _host = host,
-        _path = path,
-        _query = query;
+class _Url implements Url {
+  const _Url({this.raw, this.protocol, final  List<String>? host, final  List<String>? path, final  List<Query>? query}): _host = host,_path = path,_query = query;
+  factory _Url.fromJson(Map<String, dynamic> json) => _$UrlFromJson(json);
 
-  factory _$UrlImpl.fromJson(Map<String, dynamic> json) =>
-      _$$UrlImplFromJson(json);
-
-  @override
-  final String? raw;
-  @override
-  final String? protocol;
-  final List<String>? _host;
-  @override
-  List<String>? get host {
-    final value = _host;
-    if (value == null) return null;
-    if (_host is EqualUnmodifiableListView) return _host;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
-
-  final List<String>? _path;
-  @override
-  List<String>? get path {
-    final value = _path;
-    if (value == null) return null;
-    if (_path is EqualUnmodifiableListView) return _path;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
-
-  final List<Query>? _query;
-  @override
-  List<Query>? get query {
-    final value = _query;
-    if (value == null) return null;
-    if (_query is EqualUnmodifiableListView) return _query;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
-
-  @override
-  String toString() {
-    return 'Url(raw: $raw, protocol: $protocol, host: $host, path: $path, query: $query)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$UrlImpl &&
-            (identical(other.raw, raw) || other.raw == raw) &&
-            (identical(other.protocol, protocol) ||
-                other.protocol == protocol) &&
-            const DeepCollectionEquality().equals(other._host, _host) &&
-            const DeepCollectionEquality().equals(other._path, _path) &&
-            const DeepCollectionEquality().equals(other._query, _query));
-  }
-
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      raw,
-      protocol,
-      const DeepCollectionEquality().hash(_host),
-      const DeepCollectionEquality().hash(_path),
-      const DeepCollectionEquality().hash(_query));
-
-  /// Create a copy of Url
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$UrlImplCopyWith<_$UrlImpl> get copyWith =>
-      __$$UrlImplCopyWithImpl<_$UrlImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$UrlImplToJson(
-      this,
-    );
-  }
+@override final  String? raw;
+@override final  String? protocol;
+ final  List<String>? _host;
+@override List<String>? get host {
+  final value = _host;
+  if (value == null) return null;
+  if (_host is EqualUnmodifiableListView) return _host;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
 }
 
-abstract class _Url implements Url {
-  const factory _Url(
-      {final String? raw,
-      final String? protocol,
-      final List<String>? host,
-      final List<String>? path,
-      final List<Query>? query}) = _$UrlImpl;
-
-  factory _Url.fromJson(Map<String, dynamic> json) = _$UrlImpl.fromJson;
-
-  @override
-  String? get raw;
-  @override
-  String? get protocol;
-  @override
-  List<String>? get host;
-  @override
-  List<String>? get path;
-  @override
-  List<Query>? get query;
-
-  /// Create a copy of Url
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$UrlImplCopyWith<_$UrlImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+ final  List<String>? _path;
+@override List<String>? get path {
+  final value = _path;
+  if (value == null) return null;
+  if (_path is EqualUnmodifiableListView) return _path;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
 }
 
-Query _$QueryFromJson(Map<String, dynamic> json) {
-  return _Query.fromJson(json);
+ final  List<Query>? _query;
+@override List<Query>? get query {
+  final value = _query;
+  if (value == null) return null;
+  if (_query is EqualUnmodifiableListView) return _query;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
 }
+
+
+/// Create a copy of Url
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$UrlCopyWith<_Url> get copyWith => __$UrlCopyWithImpl<_Url>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$UrlToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Url&&(identical(other.raw, raw) || other.raw == raw)&&(identical(other.protocol, protocol) || other.protocol == protocol)&&const DeepCollectionEquality().equals(other._host, _host)&&const DeepCollectionEquality().equals(other._path, _path)&&const DeepCollectionEquality().equals(other._query, _query));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,raw,protocol,const DeepCollectionEquality().hash(_host),const DeepCollectionEquality().hash(_path),const DeepCollectionEquality().hash(_query));
+
+@override
+String toString() {
+  return 'Url(raw: $raw, protocol: $protocol, host: $host, path: $path, query: $query)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$UrlCopyWith<$Res> implements $UrlCopyWith<$Res> {
+  factory _$UrlCopyWith(_Url value, $Res Function(_Url) _then) = __$UrlCopyWithImpl;
+@override @useResult
+$Res call({
+ String? raw, String? protocol, List<String>? host, List<String>? path, List<Query>? query
+});
+
+
+
+
+}
+/// @nodoc
+class __$UrlCopyWithImpl<$Res>
+    implements _$UrlCopyWith<$Res> {
+  __$UrlCopyWithImpl(this._self, this._then);
+
+  final _Url _self;
+  final $Res Function(_Url) _then;
+
+/// Create a copy of Url
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? raw = freezed,Object? protocol = freezed,Object? host = freezed,Object? path = freezed,Object? query = freezed,}) {
+  return _then(_Url(
+raw: freezed == raw ? _self.raw : raw // ignore: cast_nullable_to_non_nullable
+as String?,protocol: freezed == protocol ? _self.protocol : protocol // ignore: cast_nullable_to_non_nullable
+as String?,host: freezed == host ? _self._host : host // ignore: cast_nullable_to_non_nullable
+as List<String>?,path: freezed == path ? _self._path : path // ignore: cast_nullable_to_non_nullable
+as List<String>?,query: freezed == query ? _self._query : query // ignore: cast_nullable_to_non_nullable
+as List<Query>?,
+  ));
+}
+
+
+}
+
 
 /// @nodoc
 mixin _$Query {
-  String? get key => throw _privateConstructorUsedError;
-  String? get value => throw _privateConstructorUsedError;
-  bool? get disabled => throw _privateConstructorUsedError;
+
+ String? get key; String? get value; bool? get disabled;
+/// Create a copy of Query
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$QueryCopyWith<Query> get copyWith => _$QueryCopyWithImpl<Query>(this as Query, _$identity);
 
   /// Serializes this Query to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  Map<String, dynamic> toJson();
 
-  /// Create a copy of Query
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $QueryCopyWith<Query> get copyWith => throw _privateConstructorUsedError;
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Query&&(identical(other.key, key) || other.key == key)&&(identical(other.value, value) || other.value == value)&&(identical(other.disabled, disabled) || other.disabled == disabled));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,key,value,disabled);
+
+@override
+String toString() {
+  return 'Query(key: $key, value: $value, disabled: $disabled)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $QueryCopyWith<$Res> {
-  factory $QueryCopyWith(Query value, $Res Function(Query) then) =
-      _$QueryCopyWithImpl<$Res, Query>;
-  @useResult
-  $Res call({String? key, String? value, bool? disabled});
-}
+abstract mixin class $QueryCopyWith<$Res>  {
+  factory $QueryCopyWith(Query value, $Res Function(Query) _then) = _$QueryCopyWithImpl;
+@useResult
+$Res call({
+ String? key, String? value, bool? disabled
+});
 
+
+
+
+}
 /// @nodoc
-class _$QueryCopyWithImpl<$Res, $Val extends Query>
+class _$QueryCopyWithImpl<$Res>
     implements $QueryCopyWith<$Res> {
-  _$QueryCopyWithImpl(this._value, this._then);
+  _$QueryCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final Query _self;
+  final $Res Function(Query) _then;
 
-  /// Create a copy of Query
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? key = freezed,
-    Object? value = freezed,
-    Object? disabled = freezed,
-  }) {
-    return _then(_value.copyWith(
-      key: freezed == key
-          ? _value.key
-          : key // ignore: cast_nullable_to_non_nullable
-              as String?,
-      value: freezed == value
-          ? _value.value
-          : value // ignore: cast_nullable_to_non_nullable
-              as String?,
-      disabled: freezed == disabled
-          ? _value.disabled
-          : disabled // ignore: cast_nullable_to_non_nullable
-              as bool?,
-    ) as $Val);
-  }
+/// Create a copy of Query
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? key = freezed,Object? value = freezed,Object? disabled = freezed,}) {
+  return _then(_self.copyWith(
+key: freezed == key ? _self.key : key // ignore: cast_nullable_to_non_nullable
+as String?,value: freezed == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
+as String?,disabled: freezed == disabled ? _self.disabled : disabled // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
 }
 
-/// @nodoc
-abstract class _$$QueryImplCopyWith<$Res> implements $QueryCopyWith<$Res> {
-  factory _$$QueryImplCopyWith(
-          _$QueryImpl value, $Res Function(_$QueryImpl) then) =
-      __$$QueryImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String? key, String? value, bool? disabled});
 }
 
-/// @nodoc
-class __$$QueryImplCopyWithImpl<$Res>
-    extends _$QueryCopyWithImpl<$Res, _$QueryImpl>
-    implements _$$QueryImplCopyWith<$Res> {
-  __$$QueryImplCopyWithImpl(
-      _$QueryImpl _value, $Res Function(_$QueryImpl) _then)
-      : super(_value, _then);
 
-  /// Create a copy of Query
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? key = freezed,
-    Object? value = freezed,
-    Object? disabled = freezed,
-  }) {
-    return _then(_$QueryImpl(
-      key: freezed == key
-          ? _value.key
-          : key // ignore: cast_nullable_to_non_nullable
-              as String?,
-      value: freezed == value
-          ? _value.value
-          : value // ignore: cast_nullable_to_non_nullable
-              as String?,
-      disabled: freezed == disabled
-          ? _value.disabled
-          : disabled // ignore: cast_nullable_to_non_nullable
-              as bool?,
-    ));
-  }
+/// Adds pattern-matching-related methods to [Query].
+extension QueryPatterns on Query {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Query value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Query() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Query value)  $default,){
+final _that = this;
+switch (_that) {
+case _Query():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Query value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Query() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? key,  String? value,  bool? disabled)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Query() when $default != null:
+return $default(_that.key,_that.value,_that.disabled);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? key,  String? value,  bool? disabled)  $default,) {final _that = this;
+switch (_that) {
+case _Query():
+return $default(_that.key,_that.value,_that.disabled);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? key,  String? value,  bool? disabled)?  $default,) {final _that = this;
+switch (_that) {
+case _Query() when $default != null:
+return $default(_that.key,_that.value,_that.disabled);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
-class _$QueryImpl implements _Query {
-  const _$QueryImpl({this.key, this.value, this.disabled});
+class _Query implements Query {
+  const _Query({this.key, this.value, this.disabled});
+  factory _Query.fromJson(Map<String, dynamic> json) => _$QueryFromJson(json);
 
-  factory _$QueryImpl.fromJson(Map<String, dynamic> json) =>
-      _$$QueryImplFromJson(json);
+@override final  String? key;
+@override final  String? value;
+@override final  bool? disabled;
 
-  @override
-  final String? key;
-  @override
-  final String? value;
-  @override
-  final bool? disabled;
+/// Create a copy of Query
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$QueryCopyWith<_Query> get copyWith => __$QueryCopyWithImpl<_Query>(this, _$identity);
 
-  @override
-  String toString() {
-    return 'Query(key: $key, value: $value, disabled: $disabled)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$QueryImpl &&
-            (identical(other.key, key) || other.key == key) &&
-            (identical(other.value, value) || other.value == value) &&
-            (identical(other.disabled, disabled) ||
-                other.disabled == disabled));
-  }
-
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, key, value, disabled);
-
-  /// Create a copy of Query
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$QueryImplCopyWith<_$QueryImpl> get copyWith =>
-      __$$QueryImplCopyWithImpl<_$QueryImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$QueryImplToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$QueryToJson(this, );
 }
 
-abstract class _Query implements Query {
-  const factory _Query(
-      {final String? key,
-      final String? value,
-      final bool? disabled}) = _$QueryImpl;
-
-  factory _Query.fromJson(Map<String, dynamic> json) = _$QueryImpl.fromJson;
-
-  @override
-  String? get key;
-  @override
-  String? get value;
-  @override
-  bool? get disabled;
-
-  /// Create a copy of Query
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$QueryImplCopyWith<_$QueryImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Query&&(identical(other.key, key) || other.key == key)&&(identical(other.value, value) || other.value == value)&&(identical(other.disabled, disabled) || other.disabled == disabled));
 }
 
-Body _$BodyFromJson(Map<String, dynamic> json) {
-  return _Body.fromJson(json);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,key,value,disabled);
+
+@override
+String toString() {
+  return 'Query(key: $key, value: $value, disabled: $disabled)';
 }
+
+
+}
+
+/// @nodoc
+abstract mixin class _$QueryCopyWith<$Res> implements $QueryCopyWith<$Res> {
+  factory _$QueryCopyWith(_Query value, $Res Function(_Query) _then) = __$QueryCopyWithImpl;
+@override @useResult
+$Res call({
+ String? key, String? value, bool? disabled
+});
+
+
+
+
+}
+/// @nodoc
+class __$QueryCopyWithImpl<$Res>
+    implements _$QueryCopyWith<$Res> {
+  __$QueryCopyWithImpl(this._self, this._then);
+
+  final _Query _self;
+  final $Res Function(_Query) _then;
+
+/// Create a copy of Query
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? key = freezed,Object? value = freezed,Object? disabled = freezed,}) {
+  return _then(_Query(
+key: freezed == key ? _self.key : key // ignore: cast_nullable_to_non_nullable
+as String?,value: freezed == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
+as String?,disabled: freezed == disabled ? _self.disabled : disabled // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+
+}
+
 
 /// @nodoc
 mixin _$Body {
-  String? get mode => throw _privateConstructorUsedError;
-  String? get raw => throw _privateConstructorUsedError;
-  Options? get options => throw _privateConstructorUsedError;
-  List<Formdatum>? get formdata => throw _privateConstructorUsedError;
+
+ String? get mode; String? get raw; Options? get options; List<Formdatum>? get formdata; List<Urlencoded>? get urlencoded;
+/// Create a copy of Body
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$BodyCopyWith<Body> get copyWith => _$BodyCopyWithImpl<Body>(this as Body, _$identity);
 
   /// Serializes this Body to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  Map<String, dynamic> toJson();
 
-  /// Create a copy of Body
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $BodyCopyWith<Body> get copyWith => throw _privateConstructorUsedError;
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Body&&(identical(other.mode, mode) || other.mode == mode)&&(identical(other.raw, raw) || other.raw == raw)&&(identical(other.options, options) || other.options == options)&&const DeepCollectionEquality().equals(other.formdata, formdata)&&const DeepCollectionEquality().equals(other.urlencoded, urlencoded));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,mode,raw,options,const DeepCollectionEquality().hash(formdata),const DeepCollectionEquality().hash(urlencoded));
+
+@override
+String toString() {
+  return 'Body(mode: $mode, raw: $raw, options: $options, formdata: $formdata, urlencoded: $urlencoded)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $BodyCopyWith<$Res> {
-  factory $BodyCopyWith(Body value, $Res Function(Body) then) =
-      _$BodyCopyWithImpl<$Res, Body>;
-  @useResult
-  $Res call(
-      {String? mode, String? raw, Options? options, List<Formdatum>? formdata});
+abstract mixin class $BodyCopyWith<$Res>  {
+  factory $BodyCopyWith(Body value, $Res Function(Body) _then) = _$BodyCopyWithImpl;
+@useResult
+$Res call({
+ String? mode, String? raw, Options? options, List<Formdatum>? formdata, List<Urlencoded>? urlencoded
+});
 
-  $OptionsCopyWith<$Res>? get options;
+
+$OptionsCopyWith<$Res>? get options;
+
 }
-
 /// @nodoc
-class _$BodyCopyWithImpl<$Res, $Val extends Body>
+class _$BodyCopyWithImpl<$Res>
     implements $BodyCopyWith<$Res> {
-  _$BodyCopyWithImpl(this._value, this._then);
+  _$BodyCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final Body _self;
+  final $Res Function(Body) _then;
 
-  /// Create a copy of Body
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? mode = freezed,
-    Object? raw = freezed,
-    Object? options = freezed,
-    Object? formdata = freezed,
-  }) {
-    return _then(_value.copyWith(
-      mode: freezed == mode
-          ? _value.mode
-          : mode // ignore: cast_nullable_to_non_nullable
-              as String?,
-      raw: freezed == raw
-          ? _value.raw
-          : raw // ignore: cast_nullable_to_non_nullable
-              as String?,
-      options: freezed == options
-          ? _value.options
-          : options // ignore: cast_nullable_to_non_nullable
-              as Options?,
-      formdata: freezed == formdata
-          ? _value.formdata
-          : formdata // ignore: cast_nullable_to_non_nullable
-              as List<Formdatum>?,
-    ) as $Val);
+/// Create a copy of Body
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? mode = freezed,Object? raw = freezed,Object? options = freezed,Object? formdata = freezed,Object? urlencoded = freezed,}) {
+  return _then(_self.copyWith(
+mode: freezed == mode ? _self.mode : mode // ignore: cast_nullable_to_non_nullable
+as String?,raw: freezed == raw ? _self.raw : raw // ignore: cast_nullable_to_non_nullable
+as String?,options: freezed == options ? _self.options : options // ignore: cast_nullable_to_non_nullable
+as Options?,formdata: freezed == formdata ? _self.formdata : formdata // ignore: cast_nullable_to_non_nullable
+as List<Formdatum>?,urlencoded: freezed == urlencoded ? _self.urlencoded : urlencoded // ignore: cast_nullable_to_non_nullable
+as List<Urlencoded>?,
+  ));
+}
+/// Create a copy of Body
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$OptionsCopyWith<$Res>? get options {
+    if (_self.options == null) {
+    return null;
   }
 
-  /// Create a copy of Body
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $OptionsCopyWith<$Res>? get options {
-    if (_value.options == null) {
-      return null;
-    }
-
-    return $OptionsCopyWith<$Res>(_value.options!, (value) {
-      return _then(_value.copyWith(options: value) as $Val);
-    });
-  }
+  return $OptionsCopyWith<$Res>(_self.options!, (value) {
+    return _then(_self.copyWith(options: value));
+  });
+}
 }
 
-/// @nodoc
-abstract class _$$BodyImplCopyWith<$Res> implements $BodyCopyWith<$Res> {
-  factory _$$BodyImplCopyWith(
-          _$BodyImpl value, $Res Function(_$BodyImpl) then) =
-      __$$BodyImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {String? mode, String? raw, Options? options, List<Formdatum>? formdata});
 
-  @override
-  $OptionsCopyWith<$Res>? get options;
+/// Adds pattern-matching-related methods to [Body].
+extension BodyPatterns on Body {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Body value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Body() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Body value)  $default,){
+final _that = this;
+switch (_that) {
+case _Body():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Body value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Body() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? mode,  String? raw,  Options? options,  List<Formdatum>? formdata,  List<Urlencoded>? urlencoded)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Body() when $default != null:
+return $default(_that.mode,_that.raw,_that.options,_that.formdata,_that.urlencoded);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? mode,  String? raw,  Options? options,  List<Formdatum>? formdata,  List<Urlencoded>? urlencoded)  $default,) {final _that = this;
+switch (_that) {
+case _Body():
+return $default(_that.mode,_that.raw,_that.options,_that.formdata,_that.urlencoded);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? mode,  String? raw,  Options? options,  List<Formdatum>? formdata,  List<Urlencoded>? urlencoded)?  $default,) {final _that = this;
+switch (_that) {
+case _Body() when $default != null:
+return $default(_that.mode,_that.raw,_that.options,_that.formdata,_that.urlencoded);case _:
+  return null;
+
+}
 }
 
-/// @nodoc
-class __$$BodyImplCopyWithImpl<$Res>
-    extends _$BodyCopyWithImpl<$Res, _$BodyImpl>
-    implements _$$BodyImplCopyWith<$Res> {
-  __$$BodyImplCopyWithImpl(_$BodyImpl _value, $Res Function(_$BodyImpl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of Body
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? mode = freezed,
-    Object? raw = freezed,
-    Object? options = freezed,
-    Object? formdata = freezed,
-  }) {
-    return _then(_$BodyImpl(
-      mode: freezed == mode
-          ? _value.mode
-          : mode // ignore: cast_nullable_to_non_nullable
-              as String?,
-      raw: freezed == raw
-          ? _value.raw
-          : raw // ignore: cast_nullable_to_non_nullable
-              as String?,
-      options: freezed == options
-          ? _value.options
-          : options // ignore: cast_nullable_to_non_nullable
-              as Options?,
-      formdata: freezed == formdata
-          ? _value._formdata
-          : formdata // ignore: cast_nullable_to_non_nullable
-              as List<Formdatum>?,
-    ));
-  }
 }
 
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
-class _$BodyImpl implements _Body {
-  const _$BodyImpl(
-      {this.mode, this.raw, this.options, final List<Formdatum>? formdata})
-      : _formdata = formdata;
+class _Body implements Body {
+  const _Body({this.mode, this.raw, this.options, final  List<Formdatum>? formdata, final  List<Urlencoded>? urlencoded}): _formdata = formdata,_urlencoded = urlencoded;
+  factory _Body.fromJson(Map<String, dynamic> json) => _$BodyFromJson(json);
 
-  factory _$BodyImpl.fromJson(Map<String, dynamic> json) =>
-      _$$BodyImplFromJson(json);
-
-  @override
-  final String? mode;
-  @override
-  final String? raw;
-  @override
-  final Options? options;
-  final List<Formdatum>? _formdata;
-  @override
-  List<Formdatum>? get formdata {
-    final value = _formdata;
-    if (value == null) return null;
-    if (_formdata is EqualUnmodifiableListView) return _formdata;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
-
-  @override
-  String toString() {
-    return 'Body(mode: $mode, raw: $raw, options: $options, formdata: $formdata)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$BodyImpl &&
-            (identical(other.mode, mode) || other.mode == mode) &&
-            (identical(other.raw, raw) || other.raw == raw) &&
-            (identical(other.options, options) || other.options == options) &&
-            const DeepCollectionEquality().equals(other._formdata, _formdata));
-  }
-
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, mode, raw, options,
-      const DeepCollectionEquality().hash(_formdata));
-
-  /// Create a copy of Body
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$BodyImplCopyWith<_$BodyImpl> get copyWith =>
-      __$$BodyImplCopyWithImpl<_$BodyImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$BodyImplToJson(
-      this,
-    );
-  }
+@override final  String? mode;
+@override final  String? raw;
+@override final  Options? options;
+ final  List<Formdatum>? _formdata;
+@override List<Formdatum>? get formdata {
+  final value = _formdata;
+  if (value == null) return null;
+  if (_formdata is EqualUnmodifiableListView) return _formdata;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
 }
 
-abstract class _Body implements Body {
-  const factory _Body(
-      {final String? mode,
-      final String? raw,
-      final Options? options,
-      final List<Formdatum>? formdata}) = _$BodyImpl;
-
-  factory _Body.fromJson(Map<String, dynamic> json) = _$BodyImpl.fromJson;
-
-  @override
-  String? get mode;
-  @override
-  String? get raw;
-  @override
-  Options? get options;
-  @override
-  List<Formdatum>? get formdata;
-
-  /// Create a copy of Body
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$BodyImplCopyWith<_$BodyImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+ final  List<Urlencoded>? _urlencoded;
+@override List<Urlencoded>? get urlencoded {
+  final value = _urlencoded;
+  if (value == null) return null;
+  if (_urlencoded is EqualUnmodifiableListView) return _urlencoded;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
 }
 
-Options _$OptionsFromJson(Map<String, dynamic> json) {
-  return _Options.fromJson(json);
+
+/// Create a copy of Body
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$BodyCopyWith<_Body> get copyWith => __$BodyCopyWithImpl<_Body>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$BodyToJson(this, );
 }
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Body&&(identical(other.mode, mode) || other.mode == mode)&&(identical(other.raw, raw) || other.raw == raw)&&(identical(other.options, options) || other.options == options)&&const DeepCollectionEquality().equals(other._formdata, _formdata)&&const DeepCollectionEquality().equals(other._urlencoded, _urlencoded));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,mode,raw,options,const DeepCollectionEquality().hash(_formdata),const DeepCollectionEquality().hash(_urlencoded));
+
+@override
+String toString() {
+  return 'Body(mode: $mode, raw: $raw, options: $options, formdata: $formdata, urlencoded: $urlencoded)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$BodyCopyWith<$Res> implements $BodyCopyWith<$Res> {
+  factory _$BodyCopyWith(_Body value, $Res Function(_Body) _then) = __$BodyCopyWithImpl;
+@override @useResult
+$Res call({
+ String? mode, String? raw, Options? options, List<Formdatum>? formdata, List<Urlencoded>? urlencoded
+});
+
+
+@override $OptionsCopyWith<$Res>? get options;
+
+}
+/// @nodoc
+class __$BodyCopyWithImpl<$Res>
+    implements _$BodyCopyWith<$Res> {
+  __$BodyCopyWithImpl(this._self, this._then);
+
+  final _Body _self;
+  final $Res Function(_Body) _then;
+
+/// Create a copy of Body
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? mode = freezed,Object? raw = freezed,Object? options = freezed,Object? formdata = freezed,Object? urlencoded = freezed,}) {
+  return _then(_Body(
+mode: freezed == mode ? _self.mode : mode // ignore: cast_nullable_to_non_nullable
+as String?,raw: freezed == raw ? _self.raw : raw // ignore: cast_nullable_to_non_nullable
+as String?,options: freezed == options ? _self.options : options // ignore: cast_nullable_to_non_nullable
+as Options?,formdata: freezed == formdata ? _self._formdata : formdata // ignore: cast_nullable_to_non_nullable
+as List<Formdatum>?,urlencoded: freezed == urlencoded ? _self._urlencoded : urlencoded // ignore: cast_nullable_to_non_nullable
+as List<Urlencoded>?,
+  ));
+}
+
+/// Create a copy of Body
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$OptionsCopyWith<$Res>? get options {
+    if (_self.options == null) {
+    return null;
+  }
+
+  return $OptionsCopyWith<$Res>(_self.options!, (value) {
+    return _then(_self.copyWith(options: value));
+  });
+}
+}
+
 
 /// @nodoc
 mixin _$Options {
-  Raw? get raw => throw _privateConstructorUsedError;
+
+ Raw? get raw;
+/// Create a copy of Options
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$OptionsCopyWith<Options> get copyWith => _$OptionsCopyWithImpl<Options>(this as Options, _$identity);
 
   /// Serializes this Options to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  Map<String, dynamic> toJson();
 
-  /// Create a copy of Options
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $OptionsCopyWith<Options> get copyWith => throw _privateConstructorUsedError;
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Options&&(identical(other.raw, raw) || other.raw == raw));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,raw);
+
+@override
+String toString() {
+  return 'Options(raw: $raw)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $OptionsCopyWith<$Res> {
-  factory $OptionsCopyWith(Options value, $Res Function(Options) then) =
-      _$OptionsCopyWithImpl<$Res, Options>;
-  @useResult
-  $Res call({Raw? raw});
+abstract mixin class $OptionsCopyWith<$Res>  {
+  factory $OptionsCopyWith(Options value, $Res Function(Options) _then) = _$OptionsCopyWithImpl;
+@useResult
+$Res call({
+ Raw? raw
+});
 
-  $RawCopyWith<$Res>? get raw;
+
+$RawCopyWith<$Res>? get raw;
+
 }
-
 /// @nodoc
-class _$OptionsCopyWithImpl<$Res, $Val extends Options>
+class _$OptionsCopyWithImpl<$Res>
     implements $OptionsCopyWith<$Res> {
-  _$OptionsCopyWithImpl(this._value, this._then);
+  _$OptionsCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final Options _self;
+  final $Res Function(Options) _then;
 
-  /// Create a copy of Options
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? raw = freezed,
-  }) {
-    return _then(_value.copyWith(
-      raw: freezed == raw
-          ? _value.raw
-          : raw // ignore: cast_nullable_to_non_nullable
-              as Raw?,
-    ) as $Val);
+/// Create a copy of Options
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? raw = freezed,}) {
+  return _then(_self.copyWith(
+raw: freezed == raw ? _self.raw : raw // ignore: cast_nullable_to_non_nullable
+as Raw?,
+  ));
+}
+/// Create a copy of Options
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$RawCopyWith<$Res>? get raw {
+    if (_self.raw == null) {
+    return null;
   }
 
-  /// Create a copy of Options
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $RawCopyWith<$Res>? get raw {
-    if (_value.raw == null) {
-      return null;
-    }
-
-    return $RawCopyWith<$Res>(_value.raw!, (value) {
-      return _then(_value.copyWith(raw: value) as $Val);
-    });
-  }
+  return $RawCopyWith<$Res>(_self.raw!, (value) {
+    return _then(_self.copyWith(raw: value));
+  });
+}
 }
 
-/// @nodoc
-abstract class _$$OptionsImplCopyWith<$Res> implements $OptionsCopyWith<$Res> {
-  factory _$$OptionsImplCopyWith(
-          _$OptionsImpl value, $Res Function(_$OptionsImpl) then) =
-      __$$OptionsImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({Raw? raw});
 
-  @override
-  $RawCopyWith<$Res>? get raw;
+/// Adds pattern-matching-related methods to [Options].
+extension OptionsPatterns on Options {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Options value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Options() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Options value)  $default,){
+final _that = this;
+switch (_that) {
+case _Options():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Options value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Options() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Raw? raw)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Options() when $default != null:
+return $default(_that.raw);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Raw? raw)  $default,) {final _that = this;
+switch (_that) {
+case _Options():
+return $default(_that.raw);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Raw? raw)?  $default,) {final _that = this;
+switch (_that) {
+case _Options() when $default != null:
+return $default(_that.raw);case _:
+  return null;
+
+}
 }
 
-/// @nodoc
-class __$$OptionsImplCopyWithImpl<$Res>
-    extends _$OptionsCopyWithImpl<$Res, _$OptionsImpl>
-    implements _$$OptionsImplCopyWith<$Res> {
-  __$$OptionsImplCopyWithImpl(
-      _$OptionsImpl _value, $Res Function(_$OptionsImpl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of Options
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? raw = freezed,
-  }) {
-    return _then(_$OptionsImpl(
-      raw: freezed == raw
-          ? _value.raw
-          : raw // ignore: cast_nullable_to_non_nullable
-              as Raw?,
-    ));
-  }
 }
 
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
-class _$OptionsImpl implements _Options {
-  const _$OptionsImpl({this.raw});
+class _Options implements Options {
+  const _Options({this.raw});
+  factory _Options.fromJson(Map<String, dynamic> json) => _$OptionsFromJson(json);
 
-  factory _$OptionsImpl.fromJson(Map<String, dynamic> json) =>
-      _$$OptionsImplFromJson(json);
+@override final  Raw? raw;
 
-  @override
-  final Raw? raw;
+/// Create a copy of Options
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$OptionsCopyWith<_Options> get copyWith => __$OptionsCopyWithImpl<_Options>(this, _$identity);
 
-  @override
-  String toString() {
-    return 'Options(raw: $raw)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$OptionsImpl &&
-            (identical(other.raw, raw) || other.raw == raw));
-  }
-
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, raw);
-
-  /// Create a copy of Options
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$OptionsImplCopyWith<_$OptionsImpl> get copyWith =>
-      __$$OptionsImplCopyWithImpl<_$OptionsImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$OptionsImplToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$OptionsToJson(this, );
 }
 
-abstract class _Options implements Options {
-  const factory _Options({final Raw? raw}) = _$OptionsImpl;
-
-  factory _Options.fromJson(Map<String, dynamic> json) = _$OptionsImpl.fromJson;
-
-  @override
-  Raw? get raw;
-
-  /// Create a copy of Options
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$OptionsImplCopyWith<_$OptionsImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Options&&(identical(other.raw, raw) || other.raw == raw));
 }
 
-Raw _$RawFromJson(Map<String, dynamic> json) {
-  return _Raw.fromJson(json);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,raw);
+
+@override
+String toString() {
+  return 'Options(raw: $raw)';
 }
+
+
+}
+
+/// @nodoc
+abstract mixin class _$OptionsCopyWith<$Res> implements $OptionsCopyWith<$Res> {
+  factory _$OptionsCopyWith(_Options value, $Res Function(_Options) _then) = __$OptionsCopyWithImpl;
+@override @useResult
+$Res call({
+ Raw? raw
+});
+
+
+@override $RawCopyWith<$Res>? get raw;
+
+}
+/// @nodoc
+class __$OptionsCopyWithImpl<$Res>
+    implements _$OptionsCopyWith<$Res> {
+  __$OptionsCopyWithImpl(this._self, this._then);
+
+  final _Options _self;
+  final $Res Function(_Options) _then;
+
+/// Create a copy of Options
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? raw = freezed,}) {
+  return _then(_Options(
+raw: freezed == raw ? _self.raw : raw // ignore: cast_nullable_to_non_nullable
+as Raw?,
+  ));
+}
+
+/// Create a copy of Options
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$RawCopyWith<$Res>? get raw {
+    if (_self.raw == null) {
+    return null;
+  }
+
+  return $RawCopyWith<$Res>(_self.raw!, (value) {
+    return _then(_self.copyWith(raw: value));
+  });
+}
+}
+
 
 /// @nodoc
 mixin _$Raw {
-  String? get language => throw _privateConstructorUsedError;
+
+ String? get language;
+/// Create a copy of Raw
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RawCopyWith<Raw> get copyWith => _$RawCopyWithImpl<Raw>(this as Raw, _$identity);
 
   /// Serializes this Raw to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  Map<String, dynamic> toJson();
 
-  /// Create a copy of Raw
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $RawCopyWith<Raw> get copyWith => throw _privateConstructorUsedError;
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Raw&&(identical(other.language, language) || other.language == language));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,language);
+
+@override
+String toString() {
+  return 'Raw(language: $language)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $RawCopyWith<$Res> {
-  factory $RawCopyWith(Raw value, $Res Function(Raw) then) =
-      _$RawCopyWithImpl<$Res, Raw>;
-  @useResult
-  $Res call({String? language});
+abstract mixin class $RawCopyWith<$Res>  {
+  factory $RawCopyWith(Raw value, $Res Function(Raw) _then) = _$RawCopyWithImpl;
+@useResult
+$Res call({
+ String? language
+});
+
+
+
+
+}
+/// @nodoc
+class _$RawCopyWithImpl<$Res>
+    implements $RawCopyWith<$Res> {
+  _$RawCopyWithImpl(this._self, this._then);
+
+  final Raw _self;
+  final $Res Function(Raw) _then;
+
+/// Create a copy of Raw
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? language = freezed,}) {
+  return _then(_self.copyWith(
+language: freezed == language ? _self.language : language // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
 }
 
-/// @nodoc
-class _$RawCopyWithImpl<$Res, $Val extends Raw> implements $RawCopyWith<$Res> {
-  _$RawCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of Raw
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? language = freezed,
-  }) {
-    return _then(_value.copyWith(
-      language: freezed == language
-          ? _value.language
-          : language // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ) as $Val);
-  }
 }
 
-/// @nodoc
-abstract class _$$RawImplCopyWith<$Res> implements $RawCopyWith<$Res> {
-  factory _$$RawImplCopyWith(_$RawImpl value, $Res Function(_$RawImpl) then) =
-      __$$RawImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String? language});
+
+/// Adds pattern-matching-related methods to [Raw].
+extension RawPatterns on Raw {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Raw value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Raw() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Raw value)  $default,){
+final _that = this;
+switch (_that) {
+case _Raw():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Raw value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Raw() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? language)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Raw() when $default != null:
+return $default(_that.language);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? language)  $default,) {final _that = this;
+switch (_that) {
+case _Raw():
+return $default(_that.language);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? language)?  $default,) {final _that = this;
+switch (_that) {
+case _Raw() when $default != null:
+return $default(_that.language);case _:
+  return null;
+
+}
 }
 
-/// @nodoc
-class __$$RawImplCopyWithImpl<$Res> extends _$RawCopyWithImpl<$Res, _$RawImpl>
-    implements _$$RawImplCopyWith<$Res> {
-  __$$RawImplCopyWithImpl(_$RawImpl _value, $Res Function(_$RawImpl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of Raw
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? language = freezed,
-  }) {
-    return _then(_$RawImpl(
-      language: freezed == language
-          ? _value.language
-          : language // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
 }
 
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
-class _$RawImpl implements _Raw {
-  const _$RawImpl({this.language});
+class _Raw implements Raw {
+  const _Raw({this.language});
+  factory _Raw.fromJson(Map<String, dynamic> json) => _$RawFromJson(json);
 
-  factory _$RawImpl.fromJson(Map<String, dynamic> json) =>
-      _$$RawImplFromJson(json);
+@override final  String? language;
 
-  @override
-  final String? language;
+/// Create a copy of Raw
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$RawCopyWith<_Raw> get copyWith => __$RawCopyWithImpl<_Raw>(this, _$identity);
 
-  @override
-  String toString() {
-    return 'Raw(language: $language)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$RawImpl &&
-            (identical(other.language, language) ||
-                other.language == language));
-  }
-
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, language);
-
-  /// Create a copy of Raw
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$RawImplCopyWith<_$RawImpl> get copyWith =>
-      __$$RawImplCopyWithImpl<_$RawImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$RawImplToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$RawToJson(this, );
 }
 
-abstract class _Raw implements Raw {
-  const factory _Raw({final String? language}) = _$RawImpl;
-
-  factory _Raw.fromJson(Map<String, dynamic> json) = _$RawImpl.fromJson;
-
-  @override
-  String? get language;
-
-  /// Create a copy of Raw
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$RawImplCopyWith<_$RawImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Raw&&(identical(other.language, language) || other.language == language));
 }
 
-Formdatum _$FormdatumFromJson(Map<String, dynamic> json) {
-  return _Formdatum.fromJson(json);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,language);
+
+@override
+String toString() {
+  return 'Raw(language: $language)';
 }
+
+
+}
+
+/// @nodoc
+abstract mixin class _$RawCopyWith<$Res> implements $RawCopyWith<$Res> {
+  factory _$RawCopyWith(_Raw value, $Res Function(_Raw) _then) = __$RawCopyWithImpl;
+@override @useResult
+$Res call({
+ String? language
+});
+
+
+
+
+}
+/// @nodoc
+class __$RawCopyWithImpl<$Res>
+    implements _$RawCopyWith<$Res> {
+  __$RawCopyWithImpl(this._self, this._then);
+
+  final _Raw _self;
+  final $Res Function(_Raw) _then;
+
+/// Create a copy of Raw
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? language = freezed,}) {
+  return _then(_Raw(
+language: freezed == language ? _self.language : language // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
 
 /// @nodoc
 mixin _$Formdatum {
-  String? get key => throw _privateConstructorUsedError;
-  String? get value => throw _privateConstructorUsedError;
-  String? get type => throw _privateConstructorUsedError;
-  String? get src => throw _privateConstructorUsedError;
+
+ String? get key; String? get value; String? get type; String? get src; bool? get disabled;
+/// Create a copy of Formdatum
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$FormdatumCopyWith<Formdatum> get copyWith => _$FormdatumCopyWithImpl<Formdatum>(this as Formdatum, _$identity);
 
   /// Serializes this Formdatum to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  Map<String, dynamic> toJson();
 
-  /// Create a copy of Formdatum
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $FormdatumCopyWith<Formdatum> get copyWith =>
-      throw _privateConstructorUsedError;
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Formdatum&&(identical(other.key, key) || other.key == key)&&(identical(other.value, value) || other.value == value)&&(identical(other.type, type) || other.type == type)&&(identical(other.src, src) || other.src == src)&&(identical(other.disabled, disabled) || other.disabled == disabled));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,key,value,type,src,disabled);
+
+@override
+String toString() {
+  return 'Formdatum(key: $key, value: $value, type: $type, src: $src, disabled: $disabled)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $FormdatumCopyWith<$Res> {
-  factory $FormdatumCopyWith(Formdatum value, $Res Function(Formdatum) then) =
-      _$FormdatumCopyWithImpl<$Res, Formdatum>;
-  @useResult
-  $Res call({String? key, String? value, String? type, String? src});
-}
+abstract mixin class $FormdatumCopyWith<$Res>  {
+  factory $FormdatumCopyWith(Formdatum value, $Res Function(Formdatum) _then) = _$FormdatumCopyWithImpl;
+@useResult
+$Res call({
+ String? key, String? value, String? type, String? src, bool? disabled
+});
 
+
+
+
+}
 /// @nodoc
-class _$FormdatumCopyWithImpl<$Res, $Val extends Formdatum>
+class _$FormdatumCopyWithImpl<$Res>
     implements $FormdatumCopyWith<$Res> {
-  _$FormdatumCopyWithImpl(this._value, this._then);
+  _$FormdatumCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final Formdatum _self;
+  final $Res Function(Formdatum) _then;
 
-  /// Create a copy of Formdatum
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? key = freezed,
-    Object? value = freezed,
-    Object? type = freezed,
-    Object? src = freezed,
-  }) {
-    return _then(_value.copyWith(
-      key: freezed == key
-          ? _value.key
-          : key // ignore: cast_nullable_to_non_nullable
-              as String?,
-      value: freezed == value
-          ? _value.value
-          : value // ignore: cast_nullable_to_non_nullable
-              as String?,
-      type: freezed == type
-          ? _value.type
-          : type // ignore: cast_nullable_to_non_nullable
-              as String?,
-      src: freezed == src
-          ? _value.src
-          : src // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ) as $Val);
-  }
+/// Create a copy of Formdatum
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? key = freezed,Object? value = freezed,Object? type = freezed,Object? src = freezed,Object? disabled = freezed,}) {
+  return _then(_self.copyWith(
+key: freezed == key ? _self.key : key // ignore: cast_nullable_to_non_nullable
+as String?,value: freezed == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
+as String?,type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String?,src: freezed == src ? _self.src : src // ignore: cast_nullable_to_non_nullable
+as String?,disabled: freezed == disabled ? _self.disabled : disabled // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
 }
 
-/// @nodoc
-abstract class _$$FormdatumImplCopyWith<$Res>
-    implements $FormdatumCopyWith<$Res> {
-  factory _$$FormdatumImplCopyWith(
-          _$FormdatumImpl value, $Res Function(_$FormdatumImpl) then) =
-      __$$FormdatumImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String? key, String? value, String? type, String? src});
 }
 
-/// @nodoc
-class __$$FormdatumImplCopyWithImpl<$Res>
-    extends _$FormdatumCopyWithImpl<$Res, _$FormdatumImpl>
-    implements _$$FormdatumImplCopyWith<$Res> {
-  __$$FormdatumImplCopyWithImpl(
-      _$FormdatumImpl _value, $Res Function(_$FormdatumImpl) _then)
-      : super(_value, _then);
 
-  /// Create a copy of Formdatum
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? key = freezed,
-    Object? value = freezed,
-    Object? type = freezed,
-    Object? src = freezed,
-  }) {
-    return _then(_$FormdatumImpl(
-      key: freezed == key
-          ? _value.key
-          : key // ignore: cast_nullable_to_non_nullable
-              as String?,
-      value: freezed == value
-          ? _value.value
-          : value // ignore: cast_nullable_to_non_nullable
-              as String?,
-      type: freezed == type
-          ? _value.type
-          : type // ignore: cast_nullable_to_non_nullable
-              as String?,
-      src: freezed == src
-          ? _value.src
-          : src // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Adds pattern-matching-related methods to [Formdatum].
+extension FormdatumPatterns on Formdatum {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Formdatum value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Formdatum() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Formdatum value)  $default,){
+final _that = this;
+switch (_that) {
+case _Formdatum():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Formdatum value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Formdatum() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? key,  String? value,  String? type,  String? src,  bool? disabled)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Formdatum() when $default != null:
+return $default(_that.key,_that.value,_that.type,_that.src,_that.disabled);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? key,  String? value,  String? type,  String? src,  bool? disabled)  $default,) {final _that = this;
+switch (_that) {
+case _Formdatum():
+return $default(_that.key,_that.value,_that.type,_that.src,_that.disabled);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? key,  String? value,  String? type,  String? src,  bool? disabled)?  $default,) {final _that = this;
+switch (_that) {
+case _Formdatum() when $default != null:
+return $default(_that.key,_that.value,_that.type,_that.src,_that.disabled);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
-class _$FormdatumImpl implements _Formdatum {
-  const _$FormdatumImpl({this.key, this.value, this.type, this.src});
+class _Formdatum implements Formdatum {
+  const _Formdatum({this.key, this.value, this.type, this.src, this.disabled});
+  factory _Formdatum.fromJson(Map<String, dynamic> json) => _$FormdatumFromJson(json);
 
-  factory _$FormdatumImpl.fromJson(Map<String, dynamic> json) =>
-      _$$FormdatumImplFromJson(json);
+@override final  String? key;
+@override final  String? value;
+@override final  String? type;
+@override final  String? src;
+@override final  bool? disabled;
 
-  @override
-  final String? key;
-  @override
-  final String? value;
-  @override
-  final String? type;
-  @override
-  final String? src;
+/// Create a copy of Formdatum
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$FormdatumCopyWith<_Formdatum> get copyWith => __$FormdatumCopyWithImpl<_Formdatum>(this, _$identity);
 
-  @override
-  String toString() {
-    return 'Formdatum(key: $key, value: $value, type: $type, src: $src)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$FormdatumImpl &&
-            (identical(other.key, key) || other.key == key) &&
-            (identical(other.value, value) || other.value == value) &&
-            (identical(other.type, type) || other.type == type) &&
-            (identical(other.src, src) || other.src == src));
-  }
-
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, key, value, type, src);
-
-  /// Create a copy of Formdatum
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$FormdatumImplCopyWith<_$FormdatumImpl> get copyWith =>
-      __$$FormdatumImplCopyWithImpl<_$FormdatumImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$FormdatumImplToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$FormdatumToJson(this, );
 }
 
-abstract class _Formdatum implements Formdatum {
-  const factory _Formdatum(
-      {final String? key,
-      final String? value,
-      final String? type,
-      final String? src}) = _$FormdatumImpl;
-
-  factory _Formdatum.fromJson(Map<String, dynamic> json) =
-      _$FormdatumImpl.fromJson;
-
-  @override
-  String? get key;
-  @override
-  String? get value;
-  @override
-  String? get type;
-  @override
-  String? get src;
-
-  /// Create a copy of Formdatum
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$FormdatumImplCopyWith<_$FormdatumImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Formdatum&&(identical(other.key, key) || other.key == key)&&(identical(other.value, value) || other.value == value)&&(identical(other.type, type) || other.type == type)&&(identical(other.src, src) || other.src == src)&&(identical(other.disabled, disabled) || other.disabled == disabled));
 }
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,key,value,type,src,disabled);
+
+@override
+String toString() {
+  return 'Formdatum(key: $key, value: $value, type: $type, src: $src, disabled: $disabled)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$FormdatumCopyWith<$Res> implements $FormdatumCopyWith<$Res> {
+  factory _$FormdatumCopyWith(_Formdatum value, $Res Function(_Formdatum) _then) = __$FormdatumCopyWithImpl;
+@override @useResult
+$Res call({
+ String? key, String? value, String? type, String? src, bool? disabled
+});
+
+
+
+
+}
+/// @nodoc
+class __$FormdatumCopyWithImpl<$Res>
+    implements _$FormdatumCopyWith<$Res> {
+  __$FormdatumCopyWithImpl(this._self, this._then);
+
+  final _Formdatum _self;
+  final $Res Function(_Formdatum) _then;
+
+/// Create a copy of Formdatum
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? key = freezed,Object? value = freezed,Object? type = freezed,Object? src = freezed,Object? disabled = freezed,}) {
+  return _then(_Formdatum(
+key: freezed == key ? _self.key : key // ignore: cast_nullable_to_non_nullable
+as String?,value: freezed == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
+as String?,type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String?,src: freezed == src ? _self.src : src // ignore: cast_nullable_to_non_nullable
+as String?,disabled: freezed == disabled ? _self.disabled : disabled // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$Auth {
+
+ String? get type; List<AuthKeyValue>? get bearer; List<AuthKeyValue>? get basic; List<AuthKeyValue>? get apikey; List<AuthKeyValue>? get digest; List<AuthKeyValue>? get oauth1; List<AuthKeyValue>? get oauth2;
+/// Create a copy of Auth
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$AuthCopyWith<Auth> get copyWith => _$AuthCopyWithImpl<Auth>(this as Auth, _$identity);
+
+  /// Serializes this Auth to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Auth&&(identical(other.type, type) || other.type == type)&&const DeepCollectionEquality().equals(other.bearer, bearer)&&const DeepCollectionEquality().equals(other.basic, basic)&&const DeepCollectionEquality().equals(other.apikey, apikey)&&const DeepCollectionEquality().equals(other.digest, digest)&&const DeepCollectionEquality().equals(other.oauth1, oauth1)&&const DeepCollectionEquality().equals(other.oauth2, oauth2));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,type,const DeepCollectionEquality().hash(bearer),const DeepCollectionEquality().hash(basic),const DeepCollectionEquality().hash(apikey),const DeepCollectionEquality().hash(digest),const DeepCollectionEquality().hash(oauth1),const DeepCollectionEquality().hash(oauth2));
+
+@override
+String toString() {
+  return 'Auth(type: $type, bearer: $bearer, basic: $basic, apikey: $apikey, digest: $digest, oauth1: $oauth1, oauth2: $oauth2)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $AuthCopyWith<$Res>  {
+  factory $AuthCopyWith(Auth value, $Res Function(Auth) _then) = _$AuthCopyWithImpl;
+@useResult
+$Res call({
+ String? type, List<AuthKeyValue>? bearer, List<AuthKeyValue>? basic, List<AuthKeyValue>? apikey, List<AuthKeyValue>? digest, List<AuthKeyValue>? oauth1, List<AuthKeyValue>? oauth2
+});
+
+
+
+
+}
+/// @nodoc
+class _$AuthCopyWithImpl<$Res>
+    implements $AuthCopyWith<$Res> {
+  _$AuthCopyWithImpl(this._self, this._then);
+
+  final Auth _self;
+  final $Res Function(Auth) _then;
+
+/// Create a copy of Auth
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? type = freezed,Object? bearer = freezed,Object? basic = freezed,Object? apikey = freezed,Object? digest = freezed,Object? oauth1 = freezed,Object? oauth2 = freezed,}) {
+  return _then(_self.copyWith(
+type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String?,bearer: freezed == bearer ? _self.bearer : bearer // ignore: cast_nullable_to_non_nullable
+as List<AuthKeyValue>?,basic: freezed == basic ? _self.basic : basic // ignore: cast_nullable_to_non_nullable
+as List<AuthKeyValue>?,apikey: freezed == apikey ? _self.apikey : apikey // ignore: cast_nullable_to_non_nullable
+as List<AuthKeyValue>?,digest: freezed == digest ? _self.digest : digest // ignore: cast_nullable_to_non_nullable
+as List<AuthKeyValue>?,oauth1: freezed == oauth1 ? _self.oauth1 : oauth1 // ignore: cast_nullable_to_non_nullable
+as List<AuthKeyValue>?,oauth2: freezed == oauth2 ? _self.oauth2 : oauth2 // ignore: cast_nullable_to_non_nullable
+as List<AuthKeyValue>?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [Auth].
+extension AuthPatterns on Auth {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Auth value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Auth() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Auth value)  $default,){
+final _that = this;
+switch (_that) {
+case _Auth():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Auth value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Auth() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? type,  List<AuthKeyValue>? bearer,  List<AuthKeyValue>? basic,  List<AuthKeyValue>? apikey,  List<AuthKeyValue>? digest,  List<AuthKeyValue>? oauth1,  List<AuthKeyValue>? oauth2)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Auth() when $default != null:
+return $default(_that.type,_that.bearer,_that.basic,_that.apikey,_that.digest,_that.oauth1,_that.oauth2);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? type,  List<AuthKeyValue>? bearer,  List<AuthKeyValue>? basic,  List<AuthKeyValue>? apikey,  List<AuthKeyValue>? digest,  List<AuthKeyValue>? oauth1,  List<AuthKeyValue>? oauth2)  $default,) {final _that = this;
+switch (_that) {
+case _Auth():
+return $default(_that.type,_that.bearer,_that.basic,_that.apikey,_that.digest,_that.oauth1,_that.oauth2);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? type,  List<AuthKeyValue>? bearer,  List<AuthKeyValue>? basic,  List<AuthKeyValue>? apikey,  List<AuthKeyValue>? digest,  List<AuthKeyValue>? oauth1,  List<AuthKeyValue>? oauth2)?  $default,) {final _that = this;
+switch (_that) {
+case _Auth() when $default != null:
+return $default(_that.type,_that.bearer,_that.basic,_that.apikey,_that.digest,_that.oauth1,_that.oauth2);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+@JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
+class _Auth implements Auth {
+  const _Auth({this.type, final  List<AuthKeyValue>? bearer, final  List<AuthKeyValue>? basic, final  List<AuthKeyValue>? apikey, final  List<AuthKeyValue>? digest, final  List<AuthKeyValue>? oauth1, final  List<AuthKeyValue>? oauth2}): _bearer = bearer,_basic = basic,_apikey = apikey,_digest = digest,_oauth1 = oauth1,_oauth2 = oauth2;
+  factory _Auth.fromJson(Map<String, dynamic> json) => _$AuthFromJson(json);
+
+@override final  String? type;
+ final  List<AuthKeyValue>? _bearer;
+@override List<AuthKeyValue>? get bearer {
+  final value = _bearer;
+  if (value == null) return null;
+  if (_bearer is EqualUnmodifiableListView) return _bearer;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
+ final  List<AuthKeyValue>? _basic;
+@override List<AuthKeyValue>? get basic {
+  final value = _basic;
+  if (value == null) return null;
+  if (_basic is EqualUnmodifiableListView) return _basic;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
+ final  List<AuthKeyValue>? _apikey;
+@override List<AuthKeyValue>? get apikey {
+  final value = _apikey;
+  if (value == null) return null;
+  if (_apikey is EqualUnmodifiableListView) return _apikey;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
+ final  List<AuthKeyValue>? _digest;
+@override List<AuthKeyValue>? get digest {
+  final value = _digest;
+  if (value == null) return null;
+  if (_digest is EqualUnmodifiableListView) return _digest;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
+ final  List<AuthKeyValue>? _oauth1;
+@override List<AuthKeyValue>? get oauth1 {
+  final value = _oauth1;
+  if (value == null) return null;
+  if (_oauth1 is EqualUnmodifiableListView) return _oauth1;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
+ final  List<AuthKeyValue>? _oauth2;
+@override List<AuthKeyValue>? get oauth2 {
+  final value = _oauth2;
+  if (value == null) return null;
+  if (_oauth2 is EqualUnmodifiableListView) return _oauth2;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
+
+/// Create a copy of Auth
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$AuthCopyWith<_Auth> get copyWith => __$AuthCopyWithImpl<_Auth>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$AuthToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Auth&&(identical(other.type, type) || other.type == type)&&const DeepCollectionEquality().equals(other._bearer, _bearer)&&const DeepCollectionEquality().equals(other._basic, _basic)&&const DeepCollectionEquality().equals(other._apikey, _apikey)&&const DeepCollectionEquality().equals(other._digest, _digest)&&const DeepCollectionEquality().equals(other._oauth1, _oauth1)&&const DeepCollectionEquality().equals(other._oauth2, _oauth2));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,type,const DeepCollectionEquality().hash(_bearer),const DeepCollectionEquality().hash(_basic),const DeepCollectionEquality().hash(_apikey),const DeepCollectionEquality().hash(_digest),const DeepCollectionEquality().hash(_oauth1),const DeepCollectionEquality().hash(_oauth2));
+
+@override
+String toString() {
+  return 'Auth(type: $type, bearer: $bearer, basic: $basic, apikey: $apikey, digest: $digest, oauth1: $oauth1, oauth2: $oauth2)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$AuthCopyWith<$Res> implements $AuthCopyWith<$Res> {
+  factory _$AuthCopyWith(_Auth value, $Res Function(_Auth) _then) = __$AuthCopyWithImpl;
+@override @useResult
+$Res call({
+ String? type, List<AuthKeyValue>? bearer, List<AuthKeyValue>? basic, List<AuthKeyValue>? apikey, List<AuthKeyValue>? digest, List<AuthKeyValue>? oauth1, List<AuthKeyValue>? oauth2
+});
+
+
+
+
+}
+/// @nodoc
+class __$AuthCopyWithImpl<$Res>
+    implements _$AuthCopyWith<$Res> {
+  __$AuthCopyWithImpl(this._self, this._then);
+
+  final _Auth _self;
+  final $Res Function(_Auth) _then;
+
+/// Create a copy of Auth
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? type = freezed,Object? bearer = freezed,Object? basic = freezed,Object? apikey = freezed,Object? digest = freezed,Object? oauth1 = freezed,Object? oauth2 = freezed,}) {
+  return _then(_Auth(
+type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String?,bearer: freezed == bearer ? _self._bearer : bearer // ignore: cast_nullable_to_non_nullable
+as List<AuthKeyValue>?,basic: freezed == basic ? _self._basic : basic // ignore: cast_nullable_to_non_nullable
+as List<AuthKeyValue>?,apikey: freezed == apikey ? _self._apikey : apikey // ignore: cast_nullable_to_non_nullable
+as List<AuthKeyValue>?,digest: freezed == digest ? _self._digest : digest // ignore: cast_nullable_to_non_nullable
+as List<AuthKeyValue>?,oauth1: freezed == oauth1 ? _self._oauth1 : oauth1 // ignore: cast_nullable_to_non_nullable
+as List<AuthKeyValue>?,oauth2: freezed == oauth2 ? _self._oauth2 : oauth2 // ignore: cast_nullable_to_non_nullable
+as List<AuthKeyValue>?,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$AuthKeyValue {
+
+ String? get key; String? get value; String? get type; bool? get disabled;
+/// Create a copy of AuthKeyValue
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$AuthKeyValueCopyWith<AuthKeyValue> get copyWith => _$AuthKeyValueCopyWithImpl<AuthKeyValue>(this as AuthKeyValue, _$identity);
+
+  /// Serializes this AuthKeyValue to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AuthKeyValue&&(identical(other.key, key) || other.key == key)&&(identical(other.value, value) || other.value == value)&&(identical(other.type, type) || other.type == type)&&(identical(other.disabled, disabled) || other.disabled == disabled));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,key,value,type,disabled);
+
+@override
+String toString() {
+  return 'AuthKeyValue(key: $key, value: $value, type: $type, disabled: $disabled)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $AuthKeyValueCopyWith<$Res>  {
+  factory $AuthKeyValueCopyWith(AuthKeyValue value, $Res Function(AuthKeyValue) _then) = _$AuthKeyValueCopyWithImpl;
+@useResult
+$Res call({
+ String? key, String? value, String? type, bool? disabled
+});
+
+
+
+
+}
+/// @nodoc
+class _$AuthKeyValueCopyWithImpl<$Res>
+    implements $AuthKeyValueCopyWith<$Res> {
+  _$AuthKeyValueCopyWithImpl(this._self, this._then);
+
+  final AuthKeyValue _self;
+  final $Res Function(AuthKeyValue) _then;
+
+/// Create a copy of AuthKeyValue
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? key = freezed,Object? value = freezed,Object? type = freezed,Object? disabled = freezed,}) {
+  return _then(_self.copyWith(
+key: freezed == key ? _self.key : key // ignore: cast_nullable_to_non_nullable
+as String?,value: freezed == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
+as String?,type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String?,disabled: freezed == disabled ? _self.disabled : disabled // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [AuthKeyValue].
+extension AuthKeyValuePatterns on AuthKeyValue {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _AuthKeyValue value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _AuthKeyValue() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _AuthKeyValue value)  $default,){
+final _that = this;
+switch (_that) {
+case _AuthKeyValue():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _AuthKeyValue value)?  $default,){
+final _that = this;
+switch (_that) {
+case _AuthKeyValue() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? key,  String? value,  String? type,  bool? disabled)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _AuthKeyValue() when $default != null:
+return $default(_that.key,_that.value,_that.type,_that.disabled);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? key,  String? value,  String? type,  bool? disabled)  $default,) {final _that = this;
+switch (_that) {
+case _AuthKeyValue():
+return $default(_that.key,_that.value,_that.type,_that.disabled);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? key,  String? value,  String? type,  bool? disabled)?  $default,) {final _that = this;
+switch (_that) {
+case _AuthKeyValue() when $default != null:
+return $default(_that.key,_that.value,_that.type,_that.disabled);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+@JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
+class _AuthKeyValue implements AuthKeyValue {
+  const _AuthKeyValue({this.key, this.value, this.type, this.disabled});
+  factory _AuthKeyValue.fromJson(Map<String, dynamic> json) => _$AuthKeyValueFromJson(json);
+
+@override final  String? key;
+@override final  String? value;
+@override final  String? type;
+@override final  bool? disabled;
+
+/// Create a copy of AuthKeyValue
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$AuthKeyValueCopyWith<_AuthKeyValue> get copyWith => __$AuthKeyValueCopyWithImpl<_AuthKeyValue>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$AuthKeyValueToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AuthKeyValue&&(identical(other.key, key) || other.key == key)&&(identical(other.value, value) || other.value == value)&&(identical(other.type, type) || other.type == type)&&(identical(other.disabled, disabled) || other.disabled == disabled));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,key,value,type,disabled);
+
+@override
+String toString() {
+  return 'AuthKeyValue(key: $key, value: $value, type: $type, disabled: $disabled)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$AuthKeyValueCopyWith<$Res> implements $AuthKeyValueCopyWith<$Res> {
+  factory _$AuthKeyValueCopyWith(_AuthKeyValue value, $Res Function(_AuthKeyValue) _then) = __$AuthKeyValueCopyWithImpl;
+@override @useResult
+$Res call({
+ String? key, String? value, String? type, bool? disabled
+});
+
+
+
+
+}
+/// @nodoc
+class __$AuthKeyValueCopyWithImpl<$Res>
+    implements _$AuthKeyValueCopyWith<$Res> {
+  __$AuthKeyValueCopyWithImpl(this._self, this._then);
+
+  final _AuthKeyValue _self;
+  final $Res Function(_AuthKeyValue) _then;
+
+/// Create a copy of AuthKeyValue
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? key = freezed,Object? value = freezed,Object? type = freezed,Object? disabled = freezed,}) {
+  return _then(_AuthKeyValue(
+key: freezed == key ? _self.key : key // ignore: cast_nullable_to_non_nullable
+as String?,value: freezed == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
+as String?,type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String?,disabled: freezed == disabled ? _self.disabled : disabled // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$Urlencoded {
+
+ String? get key; String? get value; String? get type; bool? get disabled;
+/// Create a copy of Urlencoded
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$UrlencodedCopyWith<Urlencoded> get copyWith => _$UrlencodedCopyWithImpl<Urlencoded>(this as Urlencoded, _$identity);
+
+  /// Serializes this Urlencoded to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Urlencoded&&(identical(other.key, key) || other.key == key)&&(identical(other.value, value) || other.value == value)&&(identical(other.type, type) || other.type == type)&&(identical(other.disabled, disabled) || other.disabled == disabled));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,key,value,type,disabled);
+
+@override
+String toString() {
+  return 'Urlencoded(key: $key, value: $value, type: $type, disabled: $disabled)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $UrlencodedCopyWith<$Res>  {
+  factory $UrlencodedCopyWith(Urlencoded value, $Res Function(Urlencoded) _then) = _$UrlencodedCopyWithImpl;
+@useResult
+$Res call({
+ String? key, String? value, String? type, bool? disabled
+});
+
+
+
+
+}
+/// @nodoc
+class _$UrlencodedCopyWithImpl<$Res>
+    implements $UrlencodedCopyWith<$Res> {
+  _$UrlencodedCopyWithImpl(this._self, this._then);
+
+  final Urlencoded _self;
+  final $Res Function(Urlencoded) _then;
+
+/// Create a copy of Urlencoded
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? key = freezed,Object? value = freezed,Object? type = freezed,Object? disabled = freezed,}) {
+  return _then(_self.copyWith(
+key: freezed == key ? _self.key : key // ignore: cast_nullable_to_non_nullable
+as String?,value: freezed == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
+as String?,type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String?,disabled: freezed == disabled ? _self.disabled : disabled // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [Urlencoded].
+extension UrlencodedPatterns on Urlencoded {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Urlencoded value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Urlencoded() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Urlencoded value)  $default,){
+final _that = this;
+switch (_that) {
+case _Urlencoded():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Urlencoded value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Urlencoded() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? key,  String? value,  String? type,  bool? disabled)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Urlencoded() when $default != null:
+return $default(_that.key,_that.value,_that.type,_that.disabled);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? key,  String? value,  String? type,  bool? disabled)  $default,) {final _that = this;
+switch (_that) {
+case _Urlencoded():
+return $default(_that.key,_that.value,_that.type,_that.disabled);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? key,  String? value,  String? type,  bool? disabled)?  $default,) {final _that = this;
+switch (_that) {
+case _Urlencoded() when $default != null:
+return $default(_that.key,_that.value,_that.type,_that.disabled);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+@JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
+class _Urlencoded implements Urlencoded {
+  const _Urlencoded({this.key, this.value, this.type, this.disabled});
+  factory _Urlencoded.fromJson(Map<String, dynamic> json) => _$UrlencodedFromJson(json);
+
+@override final  String? key;
+@override final  String? value;
+@override final  String? type;
+@override final  bool? disabled;
+
+/// Create a copy of Urlencoded
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$UrlencodedCopyWith<_Urlencoded> get copyWith => __$UrlencodedCopyWithImpl<_Urlencoded>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$UrlencodedToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Urlencoded&&(identical(other.key, key) || other.key == key)&&(identical(other.value, value) || other.value == value)&&(identical(other.type, type) || other.type == type)&&(identical(other.disabled, disabled) || other.disabled == disabled));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,key,value,type,disabled);
+
+@override
+String toString() {
+  return 'Urlencoded(key: $key, value: $value, type: $type, disabled: $disabled)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$UrlencodedCopyWith<$Res> implements $UrlencodedCopyWith<$Res> {
+  factory _$UrlencodedCopyWith(_Urlencoded value, $Res Function(_Urlencoded) _then) = __$UrlencodedCopyWithImpl;
+@override @useResult
+$Res call({
+ String? key, String? value, String? type, bool? disabled
+});
+
+
+
+
+}
+/// @nodoc
+class __$UrlencodedCopyWithImpl<$Res>
+    implements _$UrlencodedCopyWith<$Res> {
+  __$UrlencodedCopyWithImpl(this._self, this._then);
+
+  final _Urlencoded _self;
+  final $Res Function(_Urlencoded) _then;
+
+/// Create a copy of Urlencoded
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? key = freezed,Object? value = freezed,Object? type = freezed,Object? disabled = freezed,}) {
+  return _then(_Urlencoded(
+key: freezed == key ? _self.key : key // ignore: cast_nullable_to_non_nullable
+as String?,value: freezed == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
+as String?,type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String?,disabled: freezed == disabled ? _self.disabled : disabled // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$Variable {
+
+ String? get key; dynamic get value; String? get type; bool? get disabled;
+/// Create a copy of Variable
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$VariableCopyWith<Variable> get copyWith => _$VariableCopyWithImpl<Variable>(this as Variable, _$identity);
+
+  /// Serializes this Variable to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Variable&&(identical(other.key, key) || other.key == key)&&const DeepCollectionEquality().equals(other.value, value)&&(identical(other.type, type) || other.type == type)&&(identical(other.disabled, disabled) || other.disabled == disabled));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,key,const DeepCollectionEquality().hash(value),type,disabled);
+
+@override
+String toString() {
+  return 'Variable(key: $key, value: $value, type: $type, disabled: $disabled)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $VariableCopyWith<$Res>  {
+  factory $VariableCopyWith(Variable value, $Res Function(Variable) _then) = _$VariableCopyWithImpl;
+@useResult
+$Res call({
+ String? key, dynamic value, String? type, bool? disabled
+});
+
+
+
+
+}
+/// @nodoc
+class _$VariableCopyWithImpl<$Res>
+    implements $VariableCopyWith<$Res> {
+  _$VariableCopyWithImpl(this._self, this._then);
+
+  final Variable _self;
+  final $Res Function(Variable) _then;
+
+/// Create a copy of Variable
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? key = freezed,Object? value = freezed,Object? type = freezed,Object? disabled = freezed,}) {
+  return _then(_self.copyWith(
+key: freezed == key ? _self.key : key // ignore: cast_nullable_to_non_nullable
+as String?,value: freezed == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
+as dynamic,type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String?,disabled: freezed == disabled ? _self.disabled : disabled // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [Variable].
+extension VariablePatterns on Variable {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Variable value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Variable() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Variable value)  $default,){
+final _that = this;
+switch (_that) {
+case _Variable():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Variable value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Variable() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? key,  dynamic value,  String? type,  bool? disabled)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Variable() when $default != null:
+return $default(_that.key,_that.value,_that.type,_that.disabled);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? key,  dynamic value,  String? type,  bool? disabled)  $default,) {final _that = this;
+switch (_that) {
+case _Variable():
+return $default(_that.key,_that.value,_that.type,_that.disabled);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? key,  dynamic value,  String? type,  bool? disabled)?  $default,) {final _that = this;
+switch (_that) {
+case _Variable() when $default != null:
+return $default(_that.key,_that.value,_that.type,_that.disabled);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+@JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
+class _Variable implements Variable {
+  const _Variable({this.key, this.value, this.type, this.disabled});
+  factory _Variable.fromJson(Map<String, dynamic> json) => _$VariableFromJson(json);
+
+@override final  String? key;
+@override final  dynamic value;
+@override final  String? type;
+@override final  bool? disabled;
+
+/// Create a copy of Variable
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$VariableCopyWith<_Variable> get copyWith => __$VariableCopyWithImpl<_Variable>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$VariableToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Variable&&(identical(other.key, key) || other.key == key)&&const DeepCollectionEquality().equals(other.value, value)&&(identical(other.type, type) || other.type == type)&&(identical(other.disabled, disabled) || other.disabled == disabled));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,key,const DeepCollectionEquality().hash(value),type,disabled);
+
+@override
+String toString() {
+  return 'Variable(key: $key, value: $value, type: $type, disabled: $disabled)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$VariableCopyWith<$Res> implements $VariableCopyWith<$Res> {
+  factory _$VariableCopyWith(_Variable value, $Res Function(_Variable) _then) = __$VariableCopyWithImpl;
+@override @useResult
+$Res call({
+ String? key, dynamic value, String? type, bool? disabled
+});
+
+
+
+
+}
+/// @nodoc
+class __$VariableCopyWithImpl<$Res>
+    implements _$VariableCopyWith<$Res> {
+  __$VariableCopyWithImpl(this._self, this._then);
+
+  final _Variable _self;
+  final $Res Function(_Variable) _then;
+
+/// Create a copy of Variable
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? key = freezed,Object? value = freezed,Object? type = freezed,Object? disabled = freezed,}) {
+  return _then(_Variable(
+key: freezed == key ? _self.key : key // ignore: cast_nullable_to_non_nullable
+as String?,value: freezed == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
+as dynamic,type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String?,disabled: freezed == disabled ? _self.disabled : disabled // ignore: cast_nullable_to_non_nullable
+as bool?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/postman/lib/models/postman_collection.g.dart
+++ b/packages/postman/lib/models/postman_collection.g.dart
@@ -6,178 +6,256 @@ part of 'postman_collection.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$PostmanCollectionImpl _$$PostmanCollectionImplFromJson(Map json) =>
-    _$PostmanCollectionImpl(
-      info: json['info'] == null
-          ? null
-          : Info.fromJson(Map<String, dynamic>.from(json['info'] as Map)),
-      item: (json['item'] as List<dynamic>?)
-          ?.map((e) => Item.fromJson(Map<String, dynamic>.from(e as Map)))
-          .toList(),
-    );
+_PostmanCollection _$PostmanCollectionFromJson(Map json) => _PostmanCollection(
+  info: json['info'] == null
+      ? null
+      : Info.fromJson(Map<String, dynamic>.from(json['info'] as Map)),
+  item: (json['item'] as List<dynamic>?)
+      ?.map((e) => Item.fromJson(Map<String, dynamic>.from(e as Map)))
+      .toList(),
+  auth: json['auth'] == null
+      ? null
+      : Auth.fromJson(Map<String, dynamic>.from(json['auth'] as Map)),
+  variable: (json['variable'] as List<dynamic>?)
+      ?.map((e) => Variable.fromJson(Map<String, dynamic>.from(e as Map)))
+      .toList(),
+);
 
-Map<String, dynamic> _$$PostmanCollectionImplToJson(
-        _$PostmanCollectionImpl instance) =>
+Map<String, dynamic> _$PostmanCollectionToJson(_PostmanCollection instance) =>
     <String, dynamic>{
-      if (instance.info?.toJson() case final value?) 'info': value,
-      if (instance.item?.map((e) => e.toJson()).toList() case final value?)
-        'item': value,
+      'info': ?instance.info?.toJson(),
+      'item': ?instance.item?.map((e) => e.toJson()).toList(),
+      'auth': ?instance.auth?.toJson(),
+      'variable': ?instance.variable?.map((e) => e.toJson()).toList(),
     };
 
-_$InfoImpl _$$InfoImplFromJson(Map json) => _$InfoImpl(
-      postmanId: json['_postman_id'] as String?,
-      name: json['name'] as String?,
-      schema: json['schema'] as String?,
-      exporterId: json['_exporter_id'] as String?,
-    );
+_Info _$InfoFromJson(Map json) => _Info(
+  postmanId: json['_postman_id'] as String?,
+  name: json['name'] as String?,
+  schema: json['schema'] as String?,
+  exporterId: json['_exporter_id'] as String?,
+);
 
-Map<String, dynamic> _$$InfoImplToJson(_$InfoImpl instance) =>
+Map<String, dynamic> _$InfoToJson(_Info instance) => <String, dynamic>{
+  '_postman_id': ?instance.postmanId,
+  'name': ?instance.name,
+  'schema': ?instance.schema,
+  '_exporter_id': ?instance.exporterId,
+};
+
+_Item _$ItemFromJson(Map json) => _Item(
+  name: json['name'] as String?,
+  item: (json['item'] as List<dynamic>?)
+      ?.map((e) => Item.fromJson(Map<String, dynamic>.from(e as Map)))
+      .toList(),
+  request: json['request'] == null
+      ? null
+      : Request.fromJson(Map<String, dynamic>.from(json['request'] as Map)),
+  response: json['response'] as List<dynamic>?,
+);
+
+Map<String, dynamic> _$ItemToJson(_Item instance) => <String, dynamic>{
+  'name': ?instance.name,
+  'item': ?instance.item?.map((e) => e.toJson()).toList(),
+  'request': ?instance.request?.toJson(),
+  'response': ?instance.response,
+};
+
+_Request _$RequestFromJson(Map json) => _Request(
+  method: json['method'] as String?,
+  header: (json['header'] as List<dynamic>?)
+      ?.map((e) => Header.fromJson(Map<String, dynamic>.from(e as Map)))
+      .toList(),
+  body: json['body'] == null
+      ? null
+      : Body.fromJson(Map<String, dynamic>.from(json['body'] as Map)),
+  url: json['url'] == null
+      ? null
+      : Url.fromJson(Map<String, dynamic>.from(json['url'] as Map)),
+  auth: json['auth'] == null
+      ? null
+      : Auth.fromJson(Map<String, dynamic>.from(json['auth'] as Map)),
+);
+
+Map<String, dynamic> _$RequestToJson(_Request instance) => <String, dynamic>{
+  'method': ?instance.method,
+  'header': ?instance.header?.map((e) => e.toJson()).toList(),
+  'body': ?instance.body?.toJson(),
+  'url': ?instance.url?.toJson(),
+  'auth': ?instance.auth?.toJson(),
+};
+
+_Header _$HeaderFromJson(Map json) => _Header(
+  key: json['key'] as String?,
+  value: json['value'] as String?,
+  type: json['type'] as String?,
+  disabled: json['disabled'] as bool?,
+);
+
+Map<String, dynamic> _$HeaderToJson(_Header instance) => <String, dynamic>{
+  'key': ?instance.key,
+  'value': ?instance.value,
+  'type': ?instance.type,
+  'disabled': ?instance.disabled,
+};
+
+_Url _$UrlFromJson(Map json) => _Url(
+  raw: json['raw'] as String?,
+  protocol: json['protocol'] as String?,
+  host: (json['host'] as List<dynamic>?)?.map((e) => e as String).toList(),
+  path: (json['path'] as List<dynamic>?)?.map((e) => e as String).toList(),
+  query: (json['query'] as List<dynamic>?)
+      ?.map((e) => Query.fromJson(Map<String, dynamic>.from(e as Map)))
+      .toList(),
+);
+
+Map<String, dynamic> _$UrlToJson(_Url instance) => <String, dynamic>{
+  'raw': ?instance.raw,
+  'protocol': ?instance.protocol,
+  'host': ?instance.host,
+  'path': ?instance.path,
+  'query': ?instance.query?.map((e) => e.toJson()).toList(),
+};
+
+_Query _$QueryFromJson(Map json) => _Query(
+  key: json['key'] as String?,
+  value: json['value'] as String?,
+  disabled: json['disabled'] as bool?,
+);
+
+Map<String, dynamic> _$QueryToJson(_Query instance) => <String, dynamic>{
+  'key': ?instance.key,
+  'value': ?instance.value,
+  'disabled': ?instance.disabled,
+};
+
+_Body _$BodyFromJson(Map json) => _Body(
+  mode: json['mode'] as String?,
+  raw: json['raw'] as String?,
+  options: json['options'] == null
+      ? null
+      : Options.fromJson(Map<String, dynamic>.from(json['options'] as Map)),
+  formdata: (json['formdata'] as List<dynamic>?)
+      ?.map((e) => Formdatum.fromJson(Map<String, dynamic>.from(e as Map)))
+      .toList(),
+  urlencoded: (json['urlencoded'] as List<dynamic>?)
+      ?.map((e) => Urlencoded.fromJson(Map<String, dynamic>.from(e as Map)))
+      .toList(),
+);
+
+Map<String, dynamic> _$BodyToJson(_Body instance) => <String, dynamic>{
+  'mode': ?instance.mode,
+  'raw': ?instance.raw,
+  'options': ?instance.options?.toJson(),
+  'formdata': ?instance.formdata?.map((e) => e.toJson()).toList(),
+  'urlencoded': ?instance.urlencoded?.map((e) => e.toJson()).toList(),
+};
+
+_Options _$OptionsFromJson(Map json) => _Options(
+  raw: json['raw'] == null
+      ? null
+      : Raw.fromJson(Map<String, dynamic>.from(json['raw'] as Map)),
+);
+
+Map<String, dynamic> _$OptionsToJson(_Options instance) => <String, dynamic>{
+  'raw': ?instance.raw?.toJson(),
+};
+
+_Raw _$RawFromJson(Map json) => _Raw(language: json['language'] as String?);
+
+Map<String, dynamic> _$RawToJson(_Raw instance) => <String, dynamic>{
+  'language': ?instance.language,
+};
+
+_Formdatum _$FormdatumFromJson(Map json) => _Formdatum(
+  key: json['key'] as String?,
+  value: json['value'] as String?,
+  type: json['type'] as String?,
+  src: json['src'] as String?,
+  disabled: json['disabled'] as bool?,
+);
+
+Map<String, dynamic> _$FormdatumToJson(_Formdatum instance) =>
     <String, dynamic>{
-      if (instance.postmanId case final value?) '_postman_id': value,
-      if (instance.name case final value?) 'name': value,
-      if (instance.schema case final value?) 'schema': value,
-      if (instance.exporterId case final value?) '_exporter_id': value,
+      'key': ?instance.key,
+      'value': ?instance.value,
+      'type': ?instance.type,
+      'src': ?instance.src,
+      'disabled': ?instance.disabled,
     };
 
-_$ItemImpl _$$ItemImplFromJson(Map json) => _$ItemImpl(
-      name: json['name'] as String?,
-      item: (json['item'] as List<dynamic>?)
-          ?.map((e) => Item.fromJson(Map<String, dynamic>.from(e as Map)))
-          .toList(),
-      request: json['request'] == null
-          ? null
-          : Request.fromJson(Map<String, dynamic>.from(json['request'] as Map)),
-      response: json['response'] as List<dynamic>?,
-    );
+_Auth _$AuthFromJson(Map json) => _Auth(
+  type: json['type'] as String?,
+  bearer: (json['bearer'] as List<dynamic>?)
+      ?.map((e) => AuthKeyValue.fromJson(Map<String, dynamic>.from(e as Map)))
+      .toList(),
+  basic: (json['basic'] as List<dynamic>?)
+      ?.map((e) => AuthKeyValue.fromJson(Map<String, dynamic>.from(e as Map)))
+      .toList(),
+  apikey: (json['apikey'] as List<dynamic>?)
+      ?.map((e) => AuthKeyValue.fromJson(Map<String, dynamic>.from(e as Map)))
+      .toList(),
+  digest: (json['digest'] as List<dynamic>?)
+      ?.map((e) => AuthKeyValue.fromJson(Map<String, dynamic>.from(e as Map)))
+      .toList(),
+  oauth1: (json['oauth1'] as List<dynamic>?)
+      ?.map((e) => AuthKeyValue.fromJson(Map<String, dynamic>.from(e as Map)))
+      .toList(),
+  oauth2: (json['oauth2'] as List<dynamic>?)
+      ?.map((e) => AuthKeyValue.fromJson(Map<String, dynamic>.from(e as Map)))
+      .toList(),
+);
 
-Map<String, dynamic> _$$ItemImplToJson(_$ItemImpl instance) =>
+Map<String, dynamic> _$AuthToJson(_Auth instance) => <String, dynamic>{
+  'type': ?instance.type,
+  'bearer': ?instance.bearer?.map((e) => e.toJson()).toList(),
+  'basic': ?instance.basic?.map((e) => e.toJson()).toList(),
+  'apikey': ?instance.apikey?.map((e) => e.toJson()).toList(),
+  'digest': ?instance.digest?.map((e) => e.toJson()).toList(),
+  'oauth1': ?instance.oauth1?.map((e) => e.toJson()).toList(),
+  'oauth2': ?instance.oauth2?.map((e) => e.toJson()).toList(),
+};
+
+_AuthKeyValue _$AuthKeyValueFromJson(Map json) => _AuthKeyValue(
+  key: json['key'] as String?,
+  value: json['value'] as String?,
+  type: json['type'] as String?,
+  disabled: json['disabled'] as bool?,
+);
+
+Map<String, dynamic> _$AuthKeyValueToJson(_AuthKeyValue instance) =>
     <String, dynamic>{
-      if (instance.name case final value?) 'name': value,
-      if (instance.item?.map((e) => e.toJson()).toList() case final value?)
-        'item': value,
-      if (instance.request?.toJson() case final value?) 'request': value,
-      if (instance.response case final value?) 'response': value,
+      'key': ?instance.key,
+      'value': ?instance.value,
+      'type': ?instance.type,
+      'disabled': ?instance.disabled,
     };
 
-_$RequestImpl _$$RequestImplFromJson(Map json) => _$RequestImpl(
-      method: json['method'] as String?,
-      header: (json['header'] as List<dynamic>?)
-          ?.map((e) => Header.fromJson(Map<String, dynamic>.from(e as Map)))
-          .toList(),
-      body: json['body'] == null
-          ? null
-          : Body.fromJson(Map<String, dynamic>.from(json['body'] as Map)),
-      url: json['url'] == null
-          ? null
-          : Url.fromJson(Map<String, dynamic>.from(json['url'] as Map)),
-    );
+_Urlencoded _$UrlencodedFromJson(Map json) => _Urlencoded(
+  key: json['key'] as String?,
+  value: json['value'] as String?,
+  type: json['type'] as String?,
+  disabled: json['disabled'] as bool?,
+);
 
-Map<String, dynamic> _$$RequestImplToJson(_$RequestImpl instance) =>
+Map<String, dynamic> _$UrlencodedToJson(_Urlencoded instance) =>
     <String, dynamic>{
-      if (instance.method case final value?) 'method': value,
-      if (instance.header?.map((e) => e.toJson()).toList() case final value?)
-        'header': value,
-      if (instance.body?.toJson() case final value?) 'body': value,
-      if (instance.url?.toJson() case final value?) 'url': value,
+      'key': ?instance.key,
+      'value': ?instance.value,
+      'type': ?instance.type,
+      'disabled': ?instance.disabled,
     };
 
-_$HeaderImpl _$$HeaderImplFromJson(Map json) => _$HeaderImpl(
-      key: json['key'] as String?,
-      value: json['value'] as String?,
-      type: json['type'] as String?,
-      disabled: json['disabled'] as bool?,
-    );
+_Variable _$VariableFromJson(Map json) => _Variable(
+  key: json['key'] as String?,
+  value: json['value'],
+  type: json['type'] as String?,
+  disabled: json['disabled'] as bool?,
+);
 
-Map<String, dynamic> _$$HeaderImplToJson(_$HeaderImpl instance) =>
-    <String, dynamic>{
-      if (instance.key case final value?) 'key': value,
-      if (instance.value case final value?) 'value': value,
-      if (instance.type case final value?) 'type': value,
-      if (instance.disabled case final value?) 'disabled': value,
-    };
-
-_$UrlImpl _$$UrlImplFromJson(Map json) => _$UrlImpl(
-      raw: json['raw'] as String?,
-      protocol: json['protocol'] as String?,
-      host: (json['host'] as List<dynamic>?)?.map((e) => e as String).toList(),
-      path: (json['path'] as List<dynamic>?)?.map((e) => e as String).toList(),
-      query: (json['query'] as List<dynamic>?)
-          ?.map((e) => Query.fromJson(Map<String, dynamic>.from(e as Map)))
-          .toList(),
-    );
-
-Map<String, dynamic> _$$UrlImplToJson(_$UrlImpl instance) => <String, dynamic>{
-      if (instance.raw case final value?) 'raw': value,
-      if (instance.protocol case final value?) 'protocol': value,
-      if (instance.host case final value?) 'host': value,
-      if (instance.path case final value?) 'path': value,
-      if (instance.query?.map((e) => e.toJson()).toList() case final value?)
-        'query': value,
-    };
-
-_$QueryImpl _$$QueryImplFromJson(Map json) => _$QueryImpl(
-      key: json['key'] as String?,
-      value: json['value'] as String?,
-      disabled: json['disabled'] as bool?,
-    );
-
-Map<String, dynamic> _$$QueryImplToJson(_$QueryImpl instance) =>
-    <String, dynamic>{
-      if (instance.key case final value?) 'key': value,
-      if (instance.value case final value?) 'value': value,
-      if (instance.disabled case final value?) 'disabled': value,
-    };
-
-_$BodyImpl _$$BodyImplFromJson(Map json) => _$BodyImpl(
-      mode: json['mode'] as String?,
-      raw: json['raw'] as String?,
-      options: json['options'] == null
-          ? null
-          : Options.fromJson(Map<String, dynamic>.from(json['options'] as Map)),
-      formdata: (json['formdata'] as List<dynamic>?)
-          ?.map((e) => Formdatum.fromJson(Map<String, dynamic>.from(e as Map)))
-          .toList(),
-    );
-
-Map<String, dynamic> _$$BodyImplToJson(_$BodyImpl instance) =>
-    <String, dynamic>{
-      if (instance.mode case final value?) 'mode': value,
-      if (instance.raw case final value?) 'raw': value,
-      if (instance.options?.toJson() case final value?) 'options': value,
-      if (instance.formdata?.map((e) => e.toJson()).toList() case final value?)
-        'formdata': value,
-    };
-
-_$OptionsImpl _$$OptionsImplFromJson(Map json) => _$OptionsImpl(
-      raw: json['raw'] == null
-          ? null
-          : Raw.fromJson(Map<String, dynamic>.from(json['raw'] as Map)),
-    );
-
-Map<String, dynamic> _$$OptionsImplToJson(_$OptionsImpl instance) =>
-    <String, dynamic>{
-      if (instance.raw?.toJson() case final value?) 'raw': value,
-    };
-
-_$RawImpl _$$RawImplFromJson(Map json) => _$RawImpl(
-      language: json['language'] as String?,
-    );
-
-Map<String, dynamic> _$$RawImplToJson(_$RawImpl instance) => <String, dynamic>{
-      if (instance.language case final value?) 'language': value,
-    };
-
-_$FormdatumImpl _$$FormdatumImplFromJson(Map json) => _$FormdatumImpl(
-      key: json['key'] as String?,
-      value: json['value'] as String?,
-      type: json['type'] as String?,
-      src: json['src'] as String?,
-    );
-
-Map<String, dynamic> _$$FormdatumImplToJson(_$FormdatumImpl instance) =>
-    <String, dynamic>{
-      if (instance.key case final value?) 'key': value,
-      if (instance.value case final value?) 'value': value,
-      if (instance.type case final value?) 'type': value,
-      if (instance.src case final value?) 'src': value,
-    };
+Map<String, dynamic> _$VariableToJson(_Variable instance) => <String, dynamic>{
+  'key': ?instance.key,
+  'value': ?instance.value,
+  'type': ?instance.type,
+  'disabled': ?instance.disabled,
+};

--- a/packages/postman/pubspec.yaml
+++ b/packages/postman/pubspec.yaml
@@ -11,12 +11,13 @@ topics:
   - network
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 resolution: workspace
 
 dependencies:
   freezed_annotation: ^3.0.0
+  json_annotation: ^4.11.0
 
 dev_dependencies:
   build_runner: ^2.11.1


### PR DESCRIPTION
Fixes : #1330 

This PR fixes major Postman import gaps by preserving authentication, urlencoded body fields, and collection variable substitution during import.
I verified all test cases are passing.