### PR TITLE
fix: remove Flutter-specific dependencies from handle_auth.dart

### DIFF
--- a/packages/better_networking/lib/utils/auth/handle_auth.dart
+++ b/packages/better_networking/lib/utils/auth/handle_auth.dart
@@ -5,7 +5,7 @@ import 'package:better_networking/utils/auth/jwt_auth_utils.dart';
 import 'package:better_networking/utils/auth/digest_auth_utils.dart';
 import 'package:better_networking/better_networking.dart';
 import 'package:better_networking/utils/auth/oauth2_utils.dart';
-import 'package:flutter/foundation.dart';
+
 
 import 'oauth1_utils.dart';
 
@@ -215,13 +215,13 @@ Future<HttpRequestModel> handleAuth(
             try {
               await server.stop();
             } catch (e) {
-              debugPrint(
+              stderr.writeln(
                 'Error stopping OAuth callback server (might already be stopped): $e',
               );
             }
           }
 
-          debugPrint(res.$1.credentials.accessToken);
+          stderr.writeln(res.$1.credentials.accessToken);
 
           // Add the access token to the request headers
           updatedHeaders.add(
@@ -238,7 +238,7 @@ Future<HttpRequestModel> handleAuth(
             oauth2Model: oauth2,
             credentialsFile: credentialsFile,
           );
-          debugPrint(client.credentials.accessToken);
+          stderr.writeln(client.credentials.accessToken);
 
           // Add the access token to the request headers
           updatedHeaders.add(
@@ -250,12 +250,12 @@ Future<HttpRequestModel> handleAuth(
           updatedHeaderEnabledList.add(true);
           break;
         case OAuth2GrantType.resourceOwnerPassword:
-          debugPrint("==Resource Owner Password==");
+          stderr.writeln("==Resource Owner Password==");
           final client = await oAuth2ResourceOwnerPasswordGrantHandler(
             oauth2Model: oauth2,
             credentialsFile: credentialsFile,
           );
-          debugPrint(client.credentials.accessToken);
+          stderr.writeln(client.credentials.accessToken);
 
           // Add the access token to the request headers
           updatedHeaders.add(


### PR DESCRIPTION
Removes Flutter dependency (package:flutter/foundation.dart) from better_networking package by replacing debugPrint with stderr.writeln. dart:io was already imported so no new dependencies needed.

This is part of making better_networking usable in pure Dart CLI context.

## PR Description

Removes `import 'package:flutter/foundation.dart'` from `handle_auth.dart` 
in the `better_networking` package and replaces 5 occurrences of `debugPrint` 
with `stderr.writeln`. `dart:io` was already imported so no new dependencies 
were needed.

This is part of making `better_networking` usable in pure Dart CLI context.

## Related Issues

- Closes #1360

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
This is a bug fix with no behavioral change. debugPrint and stderr.writeln 
produce identical output in debug mode. No new logic was introduced.

- [] Yes
- [x] No, and this is why: This is a bug fix with no behavioral change. debugPrint and stderr.writeln produce identical output. No new logic was introduced. 339 tests passed, 1 pre-existing network timeout failure unrelated to this change.

## OS on which you have developed and tested the feature?

- [ ] Windows
- [x] macOS
- [ ] Linux
