### PR TITLE
fix: resolve dashbot header overflow and prevent model name wrapping

### DIFF
--- a/lib/dashbot/dashbot_dashboard.dart
+++ b/lib/dashbot/dashbot_dashboard.dart
@@ -96,48 +96,51 @@ class DashbotWindow extends ConsumerWidget {
                             child: Row(
                               mainAxisAlignment: MainAxisAlignment.spaceBetween,
                               children: [
-                                Row(
-                                  children: [
-                                    kHSpacer20,
-                                    DashbotIcons.getDashbotIcon1(width: 38),
-                                    kHSpacer12,
-                                    Text(
-                                      'DashBot',
-                                      style: TextStyle(
-                                        fontSize: 16,
-                                        fontWeight: FontWeight.bold,
-                                        color: Theme.of(context)
-                                            .colorScheme
-                                            .surface,
+                                Expanded(
+                                  child: Row(
+                                    children: [
+                                      kHSpacer20,
+                                      DashbotIcons.getDashbotIcon1(width: 38),
+                                      kHSpacer12,
+                                      Text(
+                                        'DashBot',
+                                        style: TextStyle(
+                                          fontSize: 16,
+                                          fontWeight: FontWeight.bold,
+                                          color: Theme.of(context)
+                                              .colorScheme
+                                              .surface,
+                                        ),
                                       ),
-                                    ),
-                                    kHSpacer4,
-                                    AIModelSelectorButton(
-                                      aiRequestModel: AIRequestModel.fromJson(
-                                          settings.defaultAIModel ?? {}),
-                                      useRootNavigator: true,
-                                      onDialogOpen: () => ref
-                                          .read(dashbotWindowNotifierProvider
-                                              .notifier)
-                                          .hide(),
-                                      onDialogClose: () => ref
-                                          .read(dashbotWindowNotifierProvider
-                                              .notifier)
-                                          .show(),
-                                      onModelUpdated: (d) {
-                                        ref
-                                            .read(settingsProvider.notifier)
-                                            .update(
-                                                defaultAIModel: d.copyWith(
-                                                    modelConfigs: [],
-                                                    stream: null,
-                                                    systemPrompt: '',
-                                                    userPrompt: '').toJson());
-                                      },
-                                    ),
-                                  ],
+                                      kHSpacer4,
+                                      Flexible(
+                                        child: AIModelSelectorButton(
+                                          aiRequestModel: AIRequestModel.fromJson(
+                                              settings.defaultAIModel ?? {}),
+                                          useRootNavigator: true,
+                                          onDialogOpen: () => ref
+                                              .read(dashbotWindowNotifierProvider
+                                                  .notifier)
+                                              .hide(),
+                                          onDialogClose: () => ref
+                                              .read(dashbotWindowNotifierProvider
+                                                  .notifier)
+                                              .show(),
+                                          onModelUpdated: (d) {
+                                            ref
+                                                .read(settingsProvider.notifier)
+                                                .update(
+                                                    defaultAIModel: d.copyWith(
+                                                        modelConfigs: [],
+                                                        stream: null,
+                                                        systemPrompt: '',
+                                                        userPrompt: '').toJson());
+                                          },
+                                        ),
+                                      ),
+                                    ],
+                                  ),
                                 ),
-                                Spacer(),
                                 IconButton(
                                   icon: Icon(
                                     Icons.open_in_new,

--- a/lib/screens/common_widgets/ai/ai_model_selector_button.dart
+++ b/lib/screens/common_widgets/ai/ai_model_selector_button.dart
@@ -46,7 +46,11 @@ class AIModelSelectorButton extends StatelessWidget {
               if (newAIRequestModel == null) return;
               onModelUpdated?.call(newAIRequestModel);
             },
-      child: Text(aiRequestModel?.model ?? kLabelSelectModel),
+      child: Text(
+        aiRequestModel?.model ?? kLabelSelectModel,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
     );
   }
 }


### PR DESCRIPTION
## PR Description

This PR resolves a RenderFlex overflow issue in the Dashbot header that occurs when an AI model with a long name (e.g., `gemini-3.1-pro-preview`) is selected. Previously, long names would push the trailing window controls off the screen or wrap the text awkwardly, breaking the header layout.

**Changes made:**
* Wrapped the inner `Row` in `lib/dashbot/dashbot_dashboard.dart` with an `Expanded` widget to properly constrain its maximum width.
* Removed the unnecessary `Spacer()` widget, relying on the new `Expanded` layout.
* Wrapped the `AIModelSelectorButton` in a `Flexible` widget so it can safely shrink.
* Added `maxLines: 1` and `overflow: TextOverflow.ellipsis` to the model name `Text` widget inside `lib/screens/common_widgets/ai/ai_model_selector_button.dart` so long names gracefully truncate with an ellipsis (e.g., `gemini-3.1-pro...`).

## Visual Proof
<img width="2559" height="1529" alt="Screenshot 2026-03-18 104917" src="https://github.com/user-attachments/assets/ed881bf9-56bd-47b1-b86c-70deeb9d5d5a" />
<img width="300" height="400" alt="image" src="https://github.com/user-attachments/assets/b6bede88-1b5d-45ab-896a-3e41aef88641" />

## Related Issues

- Closes #1365 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: This is purely a UI layout fix to resolve a RenderFlex overflow and text wrapping behavior. No core business logic or functional state management was altered.

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux