### PR TITLE
Add confirmation dialog before deleting requests and environments

### DIFF
--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -542,6 +542,15 @@ const kMsgClearDataConfirmation =
     "This action will clear all the requests data from the disk and is irreversible. Do you want to proceed?";
 const kLabelYes = "Yes";
 const kLabelClear = "Clear";
+const kLabelDelete = "Delete";
+
+// Delete Confirmation Dialogs
+const kTitleDeleteRequest = "Delete Request";
+const kMsgDeleteRequest =
+    "Are you sure you want to delete this request? This action cannot be undone.";
+const kTitleDeleteEnvironment = "Delete Environment";
+const kMsgDeleteEnvironment =
+    "Are you sure you want to delete this environment? This action cannot be undone.";
 const kLabelAboutSubtitle =
     "Release Details, Support Channel, Report Bug / Request New Feature";
 const kMsgRequestsDataCleared = "Requests Data Cleared";

--- a/lib/screens/envvar/environment_editor.dart
+++ b/lib/screens/envvar/environment_editor.dart
@@ -56,11 +56,20 @@ class EnvironmentEditor extends ConsumerWidget {
                       onDeletePressed: id == kGlobalEnvironmentId
                           ? null
                           : () {
-                              ref
-                                  .read(
-                                    environmentsStateNotifierProvider.notifier,
-                                  )
-                                  .removeEnvironment(id!);
+                              showOkCancelDialog(
+                                context,
+                                dialogTitle: kTitleDeleteEnvironment,
+                                content: kMsgDeleteEnvironment,
+                                buttonLabelOk: kLabelDelete,
+                                onClickOk: () {
+                                  ref
+                                      .read(
+                                        environmentsStateNotifierProvider
+                                            .notifier,
+                                      )
+                                      .removeEnvironment(id!);
+                                },
+                              );
                             },
                     ),
                     kHSpacer4,

--- a/lib/screens/envvar/environments_pane.dart
+++ b/lib/screens/envvar/environments_pane.dart
@@ -212,9 +212,17 @@ class EnvironmentItem extends ConsumerWidget {
           );
         }
         if (item == ItemMenuOption.delete) {
-          ref
-              .read(environmentsStateNotifierProvider.notifier)
-              .removeEnvironment(id);
+          showOkCancelDialog(
+            context,
+            dialogTitle: kTitleDeleteEnvironment,
+            content: kMsgDeleteEnvironment,
+            buttonLabelOk: kLabelDelete,
+            onClickOk: () {
+              ref
+                  .read(environmentsStateNotifierProvider.notifier)
+                  .removeEnvironment(id);
+            },
+          );
         }
         if (item == ItemMenuOption.duplicate) {
           ref

--- a/lib/screens/home_page/collection_pane.dart
+++ b/lib/screens/home_page/collection_pane.dart
@@ -221,7 +221,17 @@ class RequestItem extends ConsumerWidget {
           );
         }
         if (item == ItemMenuOption.delete) {
-          ref.read(collectionStateNotifierProvider.notifier).remove(id: id);
+          showOkCancelDialog(
+            context,
+            dialogTitle: kTitleDeleteRequest,
+            content: kMsgDeleteRequest,
+            buttonLabelOk: kLabelDelete,
+            onClickOk: () {
+              ref
+                  .read(collectionStateNotifierProvider.notifier)
+                  .remove(id: id);
+            },
+          );
         }
         if (item == ItemMenuOption.duplicate) {
           ref.read(collectionStateNotifierProvider.notifier).duplicate(id: id);

--- a/lib/screens/home_page/editor_pane/request_editor_top_bar.dart
+++ b/lib/screens/home_page/editor_pane/request_editor_top_bar.dart
@@ -41,8 +41,14 @@ class RequestEditorTopBar extends ConsumerWidget {
             },
             onDuplicatePressed: () =>
                 ref.read(collectionStateNotifierProvider.notifier).duplicate(),
-            onDeletePressed: () =>
-                ref.read(collectionStateNotifierProvider.notifier).remove(),
+            onDeletePressed: () => showOkCancelDialog(
+              context,
+              dialogTitle: kTitleDeleteRequest,
+              content: kMsgDeleteRequest,
+              buttonLabelOk: kLabelDelete,
+              onClickOk: () =>
+                  ref.read(collectionStateNotifierProvider.notifier).remove(),
+            ),
           ),
           kHSpacer10,
           const EnvironmentDropdown(),

--- a/test/widgets/dialog_delete_confirmation_test.dart
+++ b/test/widgets/dialog_delete_confirmation_test.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:apidash/consts.dart';
+import 'package:apidash/widgets/dialog_ok_cancel.dart';
+
+void main() {
+  group('Delete Confirmation Dialog Tests', () {
+    // Helper to build a simple app that shows the dialog on button tap
+    Widget buildTestApp({
+      required String dialogTitle,
+      required String content,
+      String buttonLabelOk = kLabelDelete,
+      VoidCallback? onClickOk,
+    }) {
+      return MaterialApp(
+        home: Builder(
+          builder: (context) {
+            return ElevatedButton(
+              onPressed: () {
+                showOkCancelDialog(
+                  context,
+                  dialogTitle: dialogTitle,
+                  content: content,
+                  buttonLabelOk: buttonLabelOk,
+                  onClickOk: onClickOk,
+                );
+              },
+              child: const Text('Show Dialog'),
+            );
+          },
+        ),
+      );
+    }
+
+    // ─── Request Delete ──────────────────────────────────────────────────
+
+    testWidgets('Request delete dialog renders title and message',
+        (tester) async {
+      await tester.pumpWidget(
+        buildTestApp(
+          dialogTitle: kTitleDeleteRequest,
+          content: kMsgDeleteRequest,
+        ),
+      );
+
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      expect(find.text(kTitleDeleteRequest), findsOneWidget);
+      expect(find.text(kMsgDeleteRequest), findsOneWidget);
+      expect(find.text(kLabelDelete), findsOneWidget);
+      expect(find.text(kLabelCancel), findsOneWidget);
+    });
+
+    testWidgets('Request delete — Cancel closes dialog without calling callback',
+        (tester) async {
+      bool deleted = false;
+
+      await tester.pumpWidget(
+        buildTestApp(
+          dialogTitle: kTitleDeleteRequest,
+          content: kMsgDeleteRequest,
+          onClickOk: () => deleted = true,
+        ),
+      );
+
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(kLabelCancel));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlertDialog), findsNothing);
+      expect(deleted, isFalse);
+    });
+
+    testWidgets(
+        'Request delete — Delete button calls callback and closes dialog',
+        (tester) async {
+      bool deleted = false;
+
+      await tester.pumpWidget(
+        buildTestApp(
+          dialogTitle: kTitleDeleteRequest,
+          content: kMsgDeleteRequest,
+          onClickOk: () => deleted = true,
+        ),
+      );
+
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(kLabelDelete));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlertDialog), findsNothing);
+      expect(deleted, isTrue);
+    });
+
+    // ─── Environment Delete ──────────────────────────────────────────────
+
+    testWidgets('Environment delete dialog renders title and message',
+        (tester) async {
+      await tester.pumpWidget(
+        buildTestApp(
+          dialogTitle: kTitleDeleteEnvironment,
+          content: kMsgDeleteEnvironment,
+        ),
+      );
+
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      expect(find.text(kTitleDeleteEnvironment), findsOneWidget);
+      expect(find.text(kMsgDeleteEnvironment), findsOneWidget);
+      expect(find.text(kLabelDelete), findsOneWidget);
+      expect(find.text(kLabelCancel), findsOneWidget);
+    });
+
+    testWidgets(
+        'Environment delete — Cancel closes dialog without calling callback',
+        (tester) async {
+      bool deleted = false;
+
+      await tester.pumpWidget(
+        buildTestApp(
+          dialogTitle: kTitleDeleteEnvironment,
+          content: kMsgDeleteEnvironment,
+          onClickOk: () => deleted = true,
+        ),
+      );
+
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(kLabelCancel));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlertDialog), findsNothing);
+      expect(deleted, isFalse);
+    });
+
+    testWidgets(
+        'Environment delete — Delete button calls callback and closes dialog',
+        (tester) async {
+      bool deleted = false;
+
+      await tester.pumpWidget(
+        buildTestApp(
+          dialogTitle: kTitleDeleteEnvironment,
+          content: kMsgDeleteEnvironment,
+          onClickOk: () => deleted = true,
+        ),
+      );
+
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(kLabelDelete));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlertDialog), findsNothing);
+      expect(deleted, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## PR Description

This PR adds a confirmation dialog before deleting requests and environments in API Dash, preventing accidental data loss from unintended clicks.

---

### Changes Made

#### Confirmation Dialog for Delete Actions
- Added confirmation dialog before deleting:
  - Requests (Collection Pane sidebar & editor top bar)
  - Environments (Environments Pane sidebar & editor)
- Deletion occurs only after explicit user confirmation
- Reuses the existing `showOkCancelDialog` pattern for consistency across the application

---

### Testing

Added widget tests for delete confirmation dialogs covering:

- Dialog renders correctly with title, message, and buttons
- Cancel closes the dialog without deleting the item
- Delete confirms and deletes the item

All tests pass successfully.

---

## Related Issues

- Closes #1363

---

### Checklist

- [x] I have gone through the contributing guide  
- [x] I have updated my branch and synced it with project `main` branch before making this PR  
- [x] I am using the latest Flutter stable branch (`flutter upgrade`)  
- [x] I have run the tests (`flutter test`) and all tests are passing  

---

## Added/updated tests?

- [x] Yes

---

## OS on which you have developed and tested the feature?

- [x] Windows  
- [ ] macOS  
- [ ] Linux  