### PR TITLE
fix: remove all Flutter dependencies from better_networking package

### DIFF
--- a/packages/better_networking/lib/services/http_client_manager.dart
+++ b/packages/better_networking/lib/services/http_client_manager.dart
@@ -1,5 +1,5 @@
 import 'dart:io';
-import 'package:flutter/foundation.dart';
+
 import 'package:http/http.dart' as http;
 import 'package:http/io_client.dart';
 
@@ -40,7 +40,7 @@ class HttpClientManager {
   HttpClientManager._internal();
 
   http.Client createClient(String requestId, {bool noSSL = false}) {
-    final client = (noSSL && !kIsWeb)
+    final client = (noSSL)
         ? createHttpClientWithNoSSL()
         : http.Client();
     _clients[requestId] = client;
@@ -82,7 +82,7 @@ class HttpClientManager {
     String requestId, {
     bool noSSL = false,
   }) {
-    final baseClient = (noSSL && !kIsWeb)
+    final baseClient = (noSSL)
         ? createHttpClientWithNoSSL()
         : http.Client();
 

--- a/packages/better_networking/lib/utils/auth/handle_auth.dart
+++ b/packages/better_networking/lib/utils/auth/handle_auth.dart
@@ -5,7 +5,7 @@ import 'package:better_networking/utils/auth/jwt_auth_utils.dart';
 import 'package:better_networking/utils/auth/digest_auth_utils.dart';
 import 'package:better_networking/better_networking.dart';
 import 'package:better_networking/utils/auth/oauth2_utils.dart';
-import 'package:flutter/foundation.dart';
+
 
 import 'oauth1_utils.dart';
 
@@ -215,13 +215,13 @@ Future<HttpRequestModel> handleAuth(
             try {
               await server.stop();
             } catch (e) {
-              debugPrint(
+              stderr.writeln(
                 'Error stopping OAuth callback server (might already be stopped): $e',
               );
             }
           }
 
-          debugPrint(res.$1.credentials.accessToken);
+          stderr.writeln(res.$1.credentials.accessToken);
 
           // Add the access token to the request headers
           updatedHeaders.add(
@@ -238,7 +238,7 @@ Future<HttpRequestModel> handleAuth(
             oauth2Model: oauth2,
             credentialsFile: credentialsFile,
           );
-          debugPrint(client.credentials.accessToken);
+          stderr.writeln(client.credentials.accessToken);
 
           // Add the access token to the request headers
           updatedHeaders.add(
@@ -250,12 +250,12 @@ Future<HttpRequestModel> handleAuth(
           updatedHeaderEnabledList.add(true);
           break;
         case OAuth2GrantType.resourceOwnerPassword:
-          debugPrint("==Resource Owner Password==");
+          stderr.writeln("==Resource Owner Password==");
           final client = await oAuth2ResourceOwnerPasswordGrantHandler(
             oauth2Model: oauth2,
             credentialsFile: credentialsFile,
           );
-          debugPrint(client.credentials.accessToken);
+          stderr.writeln(client.credentials.accessToken);
 
           // Add the access token to the request headers
           updatedHeaders.add(

--- a/packages/better_networking/lib/utils/auth/oauth2_utils.dart
+++ b/packages/better_networking/lib/utils/auth/oauth2_utils.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:io';
-import 'package:flutter_web_auth_2/flutter_web_auth_2.dart';
 import 'package:oauth2/oauth2.dart' as oauth2;
 
 import '../../models/auth/auth_oauth2_model.dart';
@@ -107,14 +106,9 @@ Future<(oauth2.Client, OAuthCallbackServer?)> oAuth2AuthorizationCodeGrant({
         }
       }
     } else {
-      // For mobile: Use the standard flutter_web_auth_2 approach
-      callbackUri = await FlutterWebAuth2.authenticate(
-        url: authorizationUrl.toString(),
-        callbackUrlScheme: actualRedirectUrl.scheme,
-        options: const FlutterWebAuth2Options(
-          useWebview: true,
-          windowName: 'OAuth Authorization - API Dash',
-        ),
+      throw UnsupportedError(
+        'OAuth authorization code grant is not supported in pure Dart CLI context. '
+        'Mobile platforms require flutter_web_auth_2 which is a Flutter dependency.',
       );
     }
 

--- a/packages/better_networking/lib/utils/platform_utils.dart
+++ b/packages/better_networking/lib/utils/platform_utils.dart
@@ -1,19 +1,17 @@
 import 'dart:io';
-import 'package:flutter/foundation.dart';
 
 /// Platform detection utilities for the better_networking package.
 class PlatformUtils {
   /// Returns true if running on desktop platforms (macOS, Windows, Linux).
   static bool get isDesktop =>
-      !kIsWeb && (Platform.isMacOS || Platform.isWindows || Platform.isLinux);
+      Platform.isMacOS || Platform.isWindows || Platform.isLinux;
 
   /// Returns true if running on mobile platforms (iOS, Android).
-  static bool get isMobile => !kIsWeb && (Platform.isIOS || Platform.isAndroid);
+  static bool get isMobile => Platform.isIOS || Platform.isAndroid;
 
   /// Returns true if running on web.
-  static bool get isWeb => kIsWeb;
+  static bool get isWeb => false;
 
   /// Returns true if OAuth should use localhost callback server.
-  /// This is true for desktop platforms.
   static bool get shouldUseLocalhostCallback => isDesktop;
 }

--- a/packages/better_networking/pubspec.yaml
+++ b/packages/better_networking/pubspec.yaml
@@ -12,18 +12,14 @@ topics:
 
 environment:
   sdk: ">=3.6.0 <4.0.0"
-  flutter: ">=1.17.0"
 
 resolution: workspace
 
 dependencies:
-  flutter:
-    sdk: flutter
   collection: ^1.18.0
   convert: ^3.1.2
   crypto: ^3.0.7
   dart_jsonwebtoken: ^3.3.2
-  flutter_web_auth_2: ^5.0.1
   http: ^1.6.0
   http_parser: ^4.1.2
   json5: ^0.8.2
@@ -34,10 +30,8 @@ dependencies:
   oauth2: ^2.0.5
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
   build_runner: ^2.11.1
-  flutter_lints: ^6.0.0
+  lints: ^6.1.0
   freezed: ^3.2.5
   json_serializable: ^6.13.0
   test: ^1.29.0


### PR DESCRIPTION
Removes Flutter-specific dependencies to make better_networking usable in pure Dart CLI context:

- platform_utils.dart: replaced kIsWeb with false, removed flutter/foundation import
- http_client_manager.dart: removed kIsWeb checks, removed flutter/foundation import
- oauth2_utils.dart: removed flutter_web_auth_2, replaced mobile OAuth with UnsupportedError
- handle_auth.dart: removed flutter/foundation import, replaced debugPrint with stderr.writeln
- pubspec.yaml: removed flutter SDK, flutter_web_auth_2, flutter_test, flutter_lints

Fixes #1360

## PR Description

Removes all Flutter-specific dependencies from `better_networking` package 
to make it usable in pure Dart CLI context. This is a complete fix following 
mentor feedback on PR #1361.

Mobile OAuth (flutter_web_auth_2) replaced with UnsupportedError since 
CLI context only supports desktop platforms.

## Related Issues

Closes #1360

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Bug fix removing Flutter dependencies. No behavioral change on desktop 
platforms. 3 pre-existing info hints only, no errors from Dart analyze.

## OS on which you have developed and tested the feature?

- [ ] Windows
- [x] macOS
- [ ] Linux
