### PR TITLE
feat: add OpenAPI import support to importer

### DIFF
--- a/lib/importer/importer.dart
+++ b/lib/importer/importer.dart
@@ -14,6 +14,7 @@ class Importer {
       ImportFormat.postman => PostmanIO().getHttpRequestModelList(content),
       ImportFormat.insomnia => InsomniaIO().getHttpRequestModelList(content),
       ImportFormat.har => HarParserIO().getHttpRequestModelList(content),
+      ImportFormat.openapi => OpenApiIO().getHttpRequestModelList(content),
     };
   }
 }


### PR DESCRIPTION
## 🚀 Feature: OpenAPI Import Support

This PR adds initial support for importing OpenAPI specifications into API Dash.

### ✨ Changes
- Added `openapi` option in `ImportFormat`
- Integrated OpenAPI handling in `importer.dart`
- Introduced `OpenApiIO` parser for processing OpenAPI JSON

### 🧠 Details
The importer now routes OpenAPI input to the new `OpenApiIO` parser, which extracts endpoints and converts them into `HttpRequestModel` objects.

### 📌 Motivation
API Dash currently supports curl, Postman, Insomnia, and HAR imports. This PR extends functionality by enabling OpenAPI-based API ingestion.

### ⚠️ Note
This is an initial implementation and can be extended further.