### PR TITLE
feat: detect MIME type from magic bytes for application/octet-stream

### DIFF
--- a/lib/utils/magic_bytes_utils.dart
+++ b/lib/utils/magic_bytes_utils.dart
@@ -1,0 +1,48 @@
+import 'dart:typed_data';
+
+(String, String) detectMimeTypeFromBytes(Uint8List bytes) {
+  if (bytes.length < 4) return ('application', 'octet-stream');
+
+  // PNG: 89 50 4E 47
+  if (bytes[0] == 0x89 && bytes[1] == 0x50 &&
+      bytes[2] == 0x4E && bytes[3] == 0x47) return ('image', 'png');
+
+  // JPEG: FF D8 FF
+  if (bytes[0] == 0xFF && bytes[1] == 0xD8 && bytes[2] == 0xFF)
+    return ('image', 'jpeg');
+
+  // GIF: 47 49 46 38
+  if (bytes[0] == 0x47 && bytes[1] == 0x49 &&
+      bytes[2] == 0x46 && bytes[3] == 0x38) return ('image', 'gif');
+
+  // BMP: 42 4D
+  if (bytes[0] == 0x42 && bytes[1] == 0x4D) return ('image', 'bmp');
+
+  // WebP: RIFF....WEBP
+  if (bytes.length >= 12 &&
+      bytes[0] == 0x52 && bytes[1] == 0x49 && bytes[2] == 0x46 && bytes[3] == 0x46 &&
+      bytes[8] == 0x57 && bytes[9] == 0x45 && bytes[10] == 0x42 && bytes[11] == 0x50)
+    return ('image', 'webp');
+
+  // PDF: 25 50 44 46 (%PDF)
+  if (bytes[0] == 0x25 && bytes[1] == 0x50 &&
+      bytes[2] == 0x44 && bytes[3] == 0x46) return ('application', 'pdf');
+
+  // MP3: FF FB or ID3
+  if ((bytes[0] == 0xFF && (bytes[1] == 0xFB || bytes[1] == 0xF3)) ||
+      (bytes[0] == 0x49 && bytes[1] == 0x44 && bytes[2] == 0x33))
+    return ('audio', 'mpeg');
+
+  // WAV: RIFF....WAVE
+  if (bytes.length >= 12 &&
+      bytes[0] == 0x52 && bytes[1] == 0x49 && bytes[2] == 0x46 && bytes[3] == 0x46 &&
+      bytes[8] == 0x57 && bytes[9] == 0x41 && bytes[10] == 0x56 && bytes[11] == 0x45)
+    return ('audio', 'wav');
+
+  // MP4: ftyp at offset 4
+  if (bytes.length >= 8 &&
+      bytes[4] == 0x66 && bytes[5] == 0x74 &&
+      bytes[6] == 0x79 && bytes[7] == 0x70) return ('video', 'mp4');
+
+  return ('application', 'octet-stream');
+}

--- a/lib/widgets/previewer.dart
+++ b/lib/widgets/previewer.dart
@@ -13,6 +13,7 @@ import 'previewer_video.dart';
 import 'uint8_audio_player.dart';
 import '../consts.dart';
 import '../utils/file_utils.dart';
+import '../utils/magic_bytes_utils.dart';
 
 class Previewer extends StatefulWidget {
   const Previewer({
@@ -38,7 +39,17 @@ class _PreviewerState extends State<Previewer> {
   @override
   Widget build(BuildContext context) {
     var errorTemplate = jj.Template(kMimeTypeRaiseIssue);
-    if (widget.type == kTypeApplication && widget.subtype == kSubTypeJson) {
+    var resolvedType = widget.type;
+    var resolvedSubtype = widget.subtype;
+    if (resolvedType == kTypeApplication &&
+        resolvedSubtype == kSubTypeOctetStream) {
+      final (detectedType, detectedSubtype) = detectMimeTypeFromBytes(widget.bytes);
+      if (detectedType != kTypeApplication || detectedSubtype != kSubTypeOctetStream) {
+        resolvedType = detectedType;
+        resolvedSubtype = detectedSubtype;
+      }
+    }
+    if (resolvedType == kTypeApplication && resolvedSubtype == kSubTypeJson) {
       try {
         var preview = JsonPreviewer(code: jsonDecode(widget.body));
         return preview;
@@ -46,7 +57,7 @@ class _PreviewerState extends State<Previewer> {
         // pass
       }
     }
-    if (widget.type == kTypeImage && widget.subtype == kSubTypeSvg) {
+    if (resolvedType == kTypeImage && resolvedSubtype == kSubTypeSvg) {
       final String rawSvg = widget.body;
       try {
         parseWithoutOptimizers(rawSvg);
@@ -62,7 +73,7 @@ class _PreviewerState extends State<Previewer> {
         );
       }
     }
-    if (widget.type == kTypeImage) {
+    if (resolvedType == kTypeImage) {
       return Image.memory(
         widget.bytes,
         errorBuilder: (context, _, stackTrace) {
@@ -76,7 +87,7 @@ class _PreviewerState extends State<Previewer> {
         },
       );
     }
-    if (widget.type == kTypeApplication && widget.subtype == kSubTypePdf) {
+    if (resolvedType == kTypeApplication && resolvedSubtype == kSubTypePdf) {
       return PdfPreview(
         build: (_) => widget.bytes,
         useActions: false,
@@ -91,11 +102,11 @@ class _PreviewerState extends State<Previewer> {
         },
       );
     }
-    if (widget.type == kTypeAudio) {
+    if (resolvedType == kTypeAudio) {
       return Uint8AudioPlayer(
         bytes: widget.bytes,
-        type: widget.type!,
-        subtype: widget.subtype!,
+        type: resolvedType!,
+        subtype: resolvedSubtype!,
         errorBuilder: (context, error, stacktrace) {
           return ErrorMessage(
             message: errorTemplate.render({
@@ -107,7 +118,7 @@ class _PreviewerState extends State<Previewer> {
         },
       );
     }
-    if (widget.type == kTypeText && widget.subtype == kSubTypeCsv) {
+    if (resolvedType == kTypeText && resolvedSubtype == kSubTypeCsv) {
       return CsvPreviewer(
         body: widget.body,
         errorWidget: ErrorMessage(
@@ -119,12 +130,12 @@ class _PreviewerState extends State<Previewer> {
         ),
       );
     }
-    if (widget.type == kTypeVideo) {
+    if (resolvedType == kTypeVideo) {
       try {
         var preview = VideoPreviewer(
           videoBytes: widget.bytes,
           videoFileExtension: getFileExtension(
-            '${widget.type}/${widget.subtype}',
+            '$resolvedType/$resolvedSubtype',
           ),
         );
         return preview;
@@ -141,7 +152,7 @@ class _PreviewerState extends State<Previewer> {
     var errorText = errorTemplate.render({
       "showRaw": widget.hasRaw,
       "showContentType": true,
-      "type": "${widget.type}/${widget.subtype}",
+      "type": "$resolvedType/$resolvedSubtype",
     });
     return ErrorMessage(message: errorText);
   }

--- a/lib/widgets/response_body.dart
+++ b/lib/widgets/response_body.dart
@@ -3,6 +3,7 @@ import 'package:apidash_core/apidash_core.dart';
 import 'package:apidash/models/models.dart';
 import 'package:apidash/utils/utils.dart';
 import 'package:apidash/consts.dart';
+import '../utils/magic_bytes_utils.dart';
 import 'error_message.dart';
 import 'response_body_success.dart';
 
@@ -38,8 +39,19 @@ class ResponseBody extends StatelessWidget {
       );
     }
 
-    final mediaType =
-        responseModel.mediaType ?? MediaType(kTypeText, kSubTypePlain);
+    final bodyBytes = responseModel.bodyBytes!;
+
+    var mediaType = responseModel.mediaType ?? MediaType(kTypeText, kSubTypePlain);
+    if (mediaType.type == kTypeApplication &&
+        mediaType.subtype == kSubTypeOctetStream &&
+        bodyBytes.isNotEmpty) {
+      final (detectedType, detectedSubtype) = detectMimeTypeFromBytes(bodyBytes);
+      if (detectedType != kTypeApplication ||
+          detectedSubtype != kSubTypeOctetStream) {
+        mediaType = MediaType(detectedType, detectedSubtype);
+      }
+    }
+
     // Fix #415: Treat null Content-type as plain text instead of Error message
     // if (mediaType == null) {
     //   return ErrorMessage(
@@ -67,7 +79,7 @@ class ResponseBody extends StatelessWidget {
       key: Key("${selectedRequestModel!.id}-response"),
       mediaType: mediaType,
       options: options,
-      bytes: responseModel.bodyBytes!,
+      bytes: bodyBytes,
       body: body,
       formattedBody: formattedBody,
       highlightLanguage: highlightLanguage,

--- a/test/widgets/previewer_test.dart
+++ b/test/widgets/previewer_test.dart
@@ -154,6 +154,28 @@ void main() {
     expect(find.byType(Image), findsOneWidget);
   });
 
+  testWidgets(
+      'Testing when type/subtype is application/octet-stream with jpeg bytes',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        title: 'Previewer',
+        home: Scaffold(
+          body: Previewer(
+            type: kTypeApplication,
+            subtype: kSubTypeOctetStream,
+            bytes: kBodyBytesJpeg,
+            body: '',
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Image), findsOneWidget);
+  });
+
   testWidgets('Testing when type/subtype is image/jpeg corrupted', (
     tester,
   ) async {

--- a/test/widgets/response_widgets_test.dart
+++ b/test/widgets/response_widgets_test.dart
@@ -269,6 +269,37 @@ void main() {
     expect(find.byIcon(Icons.download), findsOneWidget);
   });
 
+  testWidgets(
+      'Testing Response Body for octet-stream with recognizable bytes',
+      (tester) async {
+    var responseModelOctetRecognized = responseModel.copyWith(
+      headers: const {"content-type": "application/octet-stream"},
+      bodyBytes: kBodyBytesJpeg,
+      formattedBody: null,
+    );
+    var requestModelWithRecognizedOctet =
+        testRequestModel.copyWith(httpResponseModel: responseModelOctetRecognized);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        title: 'Response Body',
+        theme: kThemeDataLight,
+        home: Scaffold(
+          body:
+              ResponseBody(selectedRequestModel: requestModelWithRecognizedOctet),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Image), findsOneWidget);
+    expect(
+      find.textContaining('application/octet-stream', findRichText: true),
+      findsNothing,
+    );
+  });
+
   testWidgets('Testing Response Body for no formatted body', (tester) async {
     var responseModelNoFormattedBody = responseModel.copyWith(
       formattedBody: null,


### PR DESCRIPTION
Fixes #1382 
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>feat: detect MIME type from magic bytes for <code>application/octet-stream</code> responses</h1>
<h2>Problem</h2>
<p>When a server responds with <code>Content-Type: application/octet-stream</code>, API Dash cannot determine the actual file format, so the Preview tab either fails or shows a fallback error instead of rendering the file correctly.</p>
<h2>Solution</h2>
<p>Sniff the first few bytes of the response body (magic bytes) to detect the true MIME type and route it to the correct previewer.</p>
<h2>Changes</h2>

File | What
-- | --
lib/utils/magic_bytes_utils.dart | New utility — detects MIME from magic bytes (PNG, JPEG, GIF, BMP, WebP, PDF, MP3, WAV, MP4)
lib/widgets/previewer.dart | Uses resolved MIME type for preview routing instead of raw header
lib/widgets/response_body.dart | Derives effective MediaType from sniffing so correct UI tabs appear
test/utils/magic_bytes_utils_test.dart | Unit tests for all supported formats
test/widgets/previewer_test.dart | Sniffing test — octet-stream + JPEG bytes → image preview
test/widgets/response_widgets_test.dart | UI test — Preview tab appears for recognizable binary content


<h2>Testing</h2>
<p>Send a GET request to any URL that returns a binary file with <code>Content-Type: application/octet-stream</code> and confirm the Preview tab renders correctly.</p>
<pre><code>https://raw.githubusercontent.com/mozilla/pdf.js/master/web/compressed.tracemonkey-pldi-09.pdf
</code></pre></body></html><!--EndFragment-->
</body>

https://github.com/user-attachments/assets/52582eaa-7db9-4855-b31a-af57ae029d38
<p>In this sample test I just send a request and imported a pdf of Content-Type: application/octet-stream, previously users were encountring a error message. </p>
</html>