### PR TITLE
Seed new blank requests with default headers

### DIFF
--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -185,6 +185,17 @@ const kAnswerRawBodyViewOptions = [
   ResponseBodyView.answer,
   ResponseBodyView.raw,
 ];
+const kDefaultNewRequestHeaders = <NameValueModel>[
+  NameValueModel(
+    name: 'User-Agent',
+    value: 'APIDash (https://apidash.dev)',
+  ),
+  NameValueModel(name: 'Accept', value: '*/*'),
+  NameValueModel(name: 'Accept-Language', value: 'en-US,en;q=0.9'),
+];
+
+List<NameValueModel> buildDefaultNewRequestHeaders() =>
+    List<NameValueModel>.from(kDefaultNewRequestHeaders);
 
 const Map<String, Map<String, List<ResponseBodyView>>>
 kResponseBodyViewOptions = {

--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -80,7 +80,9 @@ class CollectionStateNotifier
     final id = getNewUuid();
     final newRequestModel = RequestModel(
       id: id,
-      httpRequestModel: const HttpRequestModel(),
+      httpRequestModel: HttpRequestModel(
+        headers: buildDefaultNewRequestHeaders(),
+      ),
     );
     var map = {...state!};
     map[id] = newRequestModel;
@@ -600,7 +602,9 @@ class CollectionStateNotifier
       state = {
         newId: RequestModel(
           id: newId,
-          httpRequestModel: const HttpRequestModel(),
+          httpRequestModel: HttpRequestModel(
+            headers: buildDefaultNewRequestHeaders(),
+          ),
         ),
       };
       return true;

--- a/test/providers/collection_providers_test.dart
+++ b/test/providers/collection_providers_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:apidash/screens/home_page/editor_pane/details_card/request_pane/request_body.dart';
 import 'package:apidash/widgets/editor.dart';
 import 'package:apidash/widgets/response_body.dart';
+import 'package:apidash/consts.dart';
 import 'package:apidash_core/apidash_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -13,6 +14,73 @@ void main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
   setUp(() async {
     await testSetUpTempDirForHive();
+  });
+
+  group('CollectionStateNotifier Default Header Tests', () {
+    late ProviderContainer container;
+    late CollectionStateNotifier notifier;
+
+    setUp(() {
+      container = createContainer();
+      notifier = container.read(collectionStateNotifierProvider.notifier);
+    });
+
+    test('should seed default headers for the initial blank request', () {
+      final request = notifier.state!.values.first.httpRequestModel;
+
+      expect(request?.headers, orderedEquals(kDefaultNewRequestHeaders));
+    });
+
+    test('should seed default headers when adding a blank request', () {
+      notifier.add();
+
+      final newId = container.read(selectedIdStateProvider);
+      final request = notifier.getRequestModel(newId!)?.httpRequestModel;
+
+      expect(request?.headers, orderedEquals(kDefaultNewRequestHeaders));
+    });
+
+    test('should not seed default headers for imported requests', () {
+      const importedModel = HttpRequestModel(
+        url: 'https://api.apidash.dev/country/data',
+        headers: [
+          NameValueModel(name: 'X-Test', value: '1'),
+        ],
+      );
+
+      notifier.addRequestModel(importedModel, name: 'imported');
+
+      final importedId = container.read(selectedIdStateProvider);
+      final request = notifier.getRequestModel(importedId!)?.httpRequestModel;
+
+      expect(
+        request?.headers,
+        orderedEquals([
+          const NameValueModel(name: 'X-Test', value: '1'),
+        ]),
+      );
+    });
+
+    test('should allow overriding seeded default headers', () {
+      notifier.add();
+
+      final newId = container.read(selectedIdStateProvider)!;
+      notifier.update(
+        id: newId,
+        headers: const [
+          NameValueModel(name: 'User-Agent', value: 'Custom Agent'),
+        ],
+      );
+
+      final request = notifier.getRequestModel(newId)?.httpRequestModel;
+
+      expect(
+        request?.headers,
+        orderedEquals([
+          const NameValueModel(name: 'User-Agent', value: 'Custom Agent'),
+        ]),
+      );
+    });
   });
 
   testWidgets(


### PR DESCRIPTION
Closes #1109

## Summary
This PR seeds browser-like default headers when API Dash creates a brand-new blank REST request.

The change applies to the initial empty-state request and to requests created through the normal "new request" flow. Imported requests and already-saved requests are left unchanged.

## Root Cause
Some protected endpoints return 403 responses when requests are sent without the common client headers that other API tools send by default. At the same time, seeding headers globally at the transport layer would silently affect imported requests and existing saved requests.

## Fix
I added a small default-header helper in app constants and used it only in the two blank-request creation paths inside `CollectionStateNotifier`.

This keeps the behavior aligned with the issue discussion:
- new blank requests start with default headers
- imported requests keep their own headers
- users can still edit or replace the seeded headers normally

## Validation
Passed locally:
- `flutter test test/providers/collection_providers_test.dart`

## AI Usage
AI assistance was used for exploration and drafting, and the final code was reviewed manually before submission.
