### PR TITLE
Route URL-field cURL paste through DashBot import

### DIFF
--- a/lib/screens/common_widgets/env_trigger_field.dart
+++ b/lib/screens/common_widgets/env_trigger_field.dart
@@ -1,4 +1,6 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:multi_trigger_autocomplete_plus/multi_trigger_autocomplete_plus.dart';
 import 'package:extended_text_field/extended_text_field.dart';
 import 'env_regexp_span_builder.dart';
@@ -13,6 +15,7 @@ class EnvironmentTriggerField extends StatefulWidget {
     this.focusNode,
     this.onChanged,
     this.onFieldSubmitted,
+    this.onPastedText,
     this.style,
     this.decoration,
     this.optionsWidthFactor,
@@ -30,6 +33,7 @@ class EnvironmentTriggerField extends StatefulWidget {
   final FocusNode? focusNode;
   final void Function(String)? onChanged;
   final void Function(String)? onFieldSubmitted;
+  final Future<bool> Function(String)? onPastedText;
   final TextStyle? style;
   final InputDecoration? decoration;
   final double? optionsWidthFactor;
@@ -45,43 +49,48 @@ class EnvironmentTriggerField extends StatefulWidget {
 class EnvironmentTriggerFieldState extends State<EnvironmentTriggerField> {
   late TextEditingController controller;
   late FocusNode _focusNode;
+  late String _lastText;
+  late bool _ownsController;
+  late bool _ownsFocusNode;
+  int _pendingChangeId = 0;
 
   @override
   void initState() {
     super.initState();
     final initialText = widget.initialValue ?? '';
-    controller =
-        widget.controller ??
-        TextEditingController.fromValue(
-          TextEditingValue(
-            text: initialText,
-            selection: TextSelection.collapsed(offset: initialText.length),
-          ),
-        );
+    _ownsController = widget.controller == null;
+    controller = widget.controller ?? _buildController(initialText);
+    _ownsFocusNode = widget.focusNode == null;
     _focusNode = widget.focusNode ?? FocusNode();
+    _lastText = controller.text;
   }
 
   @override
   void dispose() {
-    if (widget.controller == null) controller.dispose();
-    if (widget.focusNode == null) _focusNode.dispose();
+    if (_ownsController) controller.dispose();
+    if (_ownsFocusNode) _focusNode.dispose();
     super.dispose();
   }
 
   @override
   void didUpdateWidget(EnvironmentTriggerField oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (oldWidget.focusNode != widget.focusNode) {
+      if (_ownsFocusNode) {
+        _focusNode.dispose();
+      }
+      _ownsFocusNode = widget.focusNode == null;
+      _focusNode = widget.focusNode ?? FocusNode();
+    }
+
     if (oldWidget.keyId != widget.keyId) {
-      controller =
-          widget.controller ??
-          TextEditingController.fromValue(
-            TextEditingValue(
-              text: widget.initialValue!,
-              selection: TextSelection.collapsed(
-                offset: widget.initialValue!.length,
-              ),
-            ),
-          );
+      final initialText = widget.initialValue ?? '';
+      if (_ownsController) {
+        controller.dispose();
+      }
+      _ownsController = widget.controller == null;
+      controller = widget.controller ?? _buildController(initialText);
+      _lastText = controller.text;
     } else if (widget.controller == null &&
         oldWidget.initialValue != widget.initialValue &&
         widget.initialValue != null &&
@@ -93,6 +102,88 @@ class EnvironmentTriggerFieldState extends State<EnvironmentTriggerField> {
       // Restore the selection if it's still valid
       if (currentSelection.baseOffset <= controller.text.length) {
         controller.selection = currentSelection;
+      }
+      _lastText = controller.text;
+    }
+  }
+
+  TextEditingController _buildController(String text) =>
+      TextEditingController.fromValue(
+        TextEditingValue(
+          text: text,
+          selection: TextSelection.collapsed(offset: text.length),
+        ),
+      );
+
+  bool _shouldCheckForPaste(String previousText, String nextText) {
+    final trimmedNextText = nextText.trim();
+    return widget.onPastedText != null &&
+        trimmedNextText != previousText.trim() &&
+        trimmedNextText.startsWith('curl ') &&
+        nextText.length > previousText.length + 1;
+  }
+
+  bool _isCurrentPendingChange(int changeId, String expectedText) =>
+      mounted &&
+      _pendingChangeId == changeId &&
+      controller.text == expectedText;
+
+  void _commitTextChange(String value) {
+    _lastText = value;
+    widget.onChanged?.call(value);
+  }
+
+  void _restorePreviousText(String previousText) {
+    controller.value = TextEditingValue(
+      text: previousText,
+      selection: TextSelection.collapsed(offset: previousText.length),
+    );
+    _lastText = previousText;
+    widget.onChanged?.call(previousText);
+  }
+
+  void _handleChanged(String value) {
+    final previousText = _lastText;
+    final changeId = ++_pendingChangeId;
+    if (!_shouldCheckForPaste(previousText, value)) {
+      _commitTextChange(value);
+      return;
+    }
+    unawaited(
+      _handlePotentialPaste(
+        changeId: changeId,
+        previousText: previousText,
+        nextText: value,
+      ),
+    );
+  }
+
+  Future<void> _handlePotentialPaste({
+    required int changeId,
+    required String previousText,
+    required String nextText,
+  }) async {
+    try {
+      final clipboardData = await Clipboard.getData(Clipboard.kTextPlain);
+      if (!_isCurrentPendingChange(changeId, nextText)) return;
+
+      final clipboardText = clipboardData?.text;
+      if (clipboardText == null || clipboardText.trim() != nextText.trim()) {
+        _commitTextChange(nextText);
+        return;
+      }
+
+      final handled = await widget.onPastedText!.call(clipboardText);
+      if (!_isCurrentPendingChange(changeId, nextText)) return;
+      if (!handled) {
+        _commitTextChange(nextText);
+        return;
+      }
+
+      _restorePreviousText(previousText);
+    } catch (_) {
+      if (_isCurrentPendingChange(changeId, nextText)) {
+        _commitTextChange(nextText);
       }
     }
   }
@@ -145,7 +236,7 @@ class EnvironmentTriggerFieldState extends State<EnvironmentTriggerField> {
           focusNode: focusnode,
           decoration: widget.decoration,
           style: widget.style,
-          onChanged: widget.onChanged,
+          onChanged: _handleChanged,
           onSubmitted: widget.onFieldSubmitted,
           specialTextSpanBuilder: EnvRegExpSpanBuilder(),
           onTapOutside: (event) {

--- a/lib/screens/common_widgets/envfield_url.dart
+++ b/lib/screens/common_widgets/envfield_url.dart
@@ -10,6 +10,7 @@ class EnvURLField extends StatelessWidget {
     this.initialValue,
     this.onChanged,
     this.onFieldSubmitted,
+    this.onPastedText,
     this.focusNode,
   });
 
@@ -17,6 +18,7 @@ class EnvURLField extends StatelessWidget {
   final String? initialValue;
   final void Function(String)? onChanged;
   final void Function(String)? onFieldSubmitted;
+  final Future<bool> Function(String)? onPastedText;
   final FocusNode? focusNode;
 
   @override
@@ -35,6 +37,7 @@ class EnvURLField extends StatelessWidget {
       ),
       onChanged: onChanged,
       onFieldSubmitted: onFieldSubmitted,
+      onPastedText: onPastedText,
       optionsWidthFactor: 1,
     );
   }

--- a/lib/screens/home_page/editor_pane/url_card.dart
+++ b/lib/screens/home_page/editor_pane/url_card.dart
@@ -1,5 +1,8 @@
 import 'package:apidash_core/apidash_core.dart';
 import 'package:apidash_design_system/apidash_design_system.dart';
+import 'package:apidash/dashbot/constants.dart';
+import 'package:apidash/dashbot/providers/providers.dart';
+import 'package:apidash/dashbot/utils/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:apidash/providers/providers.dart';
@@ -127,6 +130,20 @@ class URLTextField extends ConsumerWidget {
       onFieldSubmitted: (value) {
         ref.read(collectionStateNotifierProvider.notifier).sendRequest();
       },
+      onPastedText: requestModel.apiType == APIType.rest
+          ? (pastedText) async {
+              showDashbotWindow(context, ref);
+              ref.read(dashbotActiveRouteProvider.notifier).goToChat();
+              final chatViewmodel =
+                  ref.read(chatViewmodelProvider.notifier);
+              await chatViewmodel.sendTaskMessage(ChatMessageType.importCurl);
+              await chatViewmodel.sendMessage(
+                text: pastedText,
+                type: ChatMessageType.importCurl,
+              );
+              return true;
+            }
+          : null,
     );
   }
 }

--- a/lib/widgets/field_url.dart
+++ b/lib/widgets/field_url.dart
@@ -1,26 +1,150 @@
+import 'dart:async';
 import 'package:apidash_design_system/apidash_design_system.dart';
 import 'package:flutter/material.dart';
 import 'package:apidash/consts.dart';
+import 'package:flutter/services.dart';
 
-class URLField extends StatelessWidget {
+class URLField extends StatefulWidget {
   const URLField({
     super.key,
     required this.selectedId,
     this.initialValue,
     this.onChanged,
     this.onFieldSubmitted,
+    this.onPastedText,
   });
 
   final String selectedId;
   final String? initialValue;
   final void Function(String)? onChanged;
   final void Function(String)? onFieldSubmitted;
+  final Future<bool> Function(String)? onPastedText;
+
+  @override
+  State<URLField> createState() => _URLFieldState();
+}
+
+class _URLFieldState extends State<URLField> {
+  late final TextEditingController _controller;
+  late String _lastText;
+  int _pendingChangeId = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialValue ?? '');
+    _lastText = _controller.text;
+  }
+
+  @override
+  void didUpdateWidget(covariant URLField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final nextInitialValue = widget.initialValue ?? '';
+    if (oldWidget.selectedId != widget.selectedId &&
+        _controller.text != nextInitialValue) {
+      _controller.value = TextEditingValue(
+        text: nextInitialValue,
+        selection: TextSelection.collapsed(offset: nextInitialValue.length),
+      );
+      _lastText = nextInitialValue;
+      return;
+    }
+
+    if (oldWidget.initialValue != widget.initialValue &&
+        _controller.text != nextInitialValue) {
+      final currentSelection = _controller.selection;
+      _controller.text = nextInitialValue;
+      if (currentSelection.baseOffset <= _controller.text.length) {
+        _controller.selection = currentSelection;
+      }
+      _lastText = _controller.text;
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _handleChanged(String value) {
+    final previousText = _lastText;
+    final changeId = ++_pendingChangeId;
+    if (!_shouldCheckForPaste(previousText, value)) {
+      _commitTextChange(value);
+      return;
+    }
+    unawaited(
+      _handlePotentialPaste(
+        changeId: changeId,
+        previousText: previousText,
+        nextText: value,
+      ),
+    );
+  }
+
+  bool _shouldCheckForPaste(String previousText, String nextText) {
+    final trimmedNextText = nextText.trim();
+    return widget.onPastedText != null &&
+        trimmedNextText != previousText.trim() &&
+        trimmedNextText.startsWith('curl ') &&
+        nextText.length > previousText.length + 1;
+  }
+
+  bool _isCurrentPendingChange(int changeId, String expectedText) =>
+      mounted &&
+      _pendingChangeId == changeId &&
+      _controller.text == expectedText;
+
+  void _commitTextChange(String value) {
+    _lastText = value;
+    widget.onChanged?.call(value);
+  }
+
+  void _restorePreviousText(String previousText) {
+    _controller.value = TextEditingValue(
+      text: previousText,
+      selection: TextSelection.collapsed(offset: previousText.length),
+    );
+    _lastText = previousText;
+    widget.onChanged?.call(previousText);
+  }
+
+  Future<void> _handlePotentialPaste({
+    required int changeId,
+    required String previousText,
+    required String nextText,
+  }) async {
+    try {
+      final clipboardData = await Clipboard.getData(Clipboard.kTextPlain);
+      if (!_isCurrentPendingChange(changeId, nextText)) return;
+
+      final clipboardText = clipboardData?.text;
+      if (clipboardText == null || clipboardText.trim() != nextText.trim()) {
+        _commitTextChange(nextText);
+        return;
+      }
+
+      final handled = await widget.onPastedText!.call(clipboardText);
+      if (!_isCurrentPendingChange(changeId, nextText)) return;
+      if (!handled) {
+        _commitTextChange(nextText);
+        return;
+      }
+
+      _restorePreviousText(previousText);
+    } catch (_) {
+      if (_isCurrentPendingChange(changeId, nextText)) {
+        _commitTextChange(nextText);
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return TextFormField(
-      key: Key("url-$selectedId"),
-      initialValue: initialValue,
+      key: Key("url-${widget.selectedId}"),
+      controller: _controller,
       style: kCodeStyle,
       decoration: InputDecoration(
         hintText: kHintTextUrlCard,
@@ -29,8 +153,8 @@ class URLField extends StatelessWidget {
         ),
         border: InputBorder.none,
       ),
-      onChanged: onChanged,
-      onFieldSubmitted: onFieldSubmitted,
+      onChanged: _handleChanged,
+      onFieldSubmitted: widget.onFieldSubmitted,
       onTapOutside: (PointerDownEvent event) {
         FocusManager.instance.primaryFocus?.unfocus();
       },

--- a/test/dashbot/features/chat/viewmodel/chat_viewmodel_test.dart
+++ b/test/dashbot/features/chat/viewmodel/chat_viewmodel_test.dart
@@ -583,6 +583,27 @@ info:
       expect(viewmodel.currentMessages.length, greaterThan(1));
     });
 
+    test('sendMessage should keep non-curl text in the curl import flow',
+        () async {
+      final viewmodel = container.read(chatViewmodelProvider.notifier);
+
+      await viewmodel.sendMessage(
+        text: 'not a curl command',
+        type: ChatMessageType.importCurl,
+      );
+
+      expect(viewmodel.currentMessages, hasLength(2));
+      expect(viewmodel.currentMessages.first.role, equals(MessageRole.user));
+      expect(
+        viewmodel.currentMessages.first.content,
+        equals('not a curl command'),
+      );
+      expect(
+        viewmodel.currentMessages.last.messageType,
+        equals(ChatMessageType.importCurl),
+      );
+    });
+
     test('sendMessage should detect OpenAPI paste in import flow', () async {
       final viewmodel = container.read(chatViewmodelProvider.notifier);
 

--- a/test/screens/common_widgets/env_trigger_field_test.dart
+++ b/test/screens/common_widgets/env_trigger_field_test.dart
@@ -1,10 +1,40 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_portal/flutter_portal.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:extended_text_field/extended_text_field.dart';
 import 'package:apidash/screens/common_widgets/env_trigger_field.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  String? clipboardText;
+
+  setUp(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform,
+            (MethodCall methodCall) async {
+      switch (methodCall.method) {
+        case 'Clipboard.getData':
+          return <String, dynamic>{'text': clipboardText};
+        case 'Clipboard.setData':
+          clipboardText =
+              (methodCall.arguments as Map<Object?, Object?>?)?['text']
+                  as String?;
+          return null;
+        default:
+          return null;
+      }
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+    clipboardText = null;
+  });
+
   testWidgets('Testing EnvironmentTriggerField updates the controller text',
       (WidgetTester tester) async {
     final fieldKey = GlobalKey<EnvironmentTriggerFieldState>();
@@ -223,5 +253,168 @@ void main() {
     expect(fieldKey.currentState!.controller.selection.baseOffset,
         newValue.length);
     expect(fieldKey.currentState!.controller.text, newValue);
+  });
+
+  testWidgets(
+      'Testing EnvironmentTriggerField clears text when keyId changes with null initialValue',
+      (WidgetTester tester) async {
+    final fieldKey = GlobalKey<EnvironmentTriggerFieldState>();
+
+    await tester.pumpWidget(
+      Portal(
+        child: MaterialApp(
+          home: Scaffold(
+            body: EnvironmentTriggerField(
+              key: fieldKey,
+              keyId: 'testKey1',
+              initialValue: 'hello world',
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(
+      Portal(
+        child: MaterialApp(
+          home: Scaffold(
+            body: EnvironmentTriggerField(
+              key: fieldKey,
+              keyId: 'testKey2',
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(fieldKey.currentState!.controller.text, isEmpty);
+    expect(fieldKey.currentState!.controller.selection.baseOffset, 0);
+  });
+
+  testWidgets(
+      'Testing EnvironmentTriggerField detects pasted curl text and restores previous value',
+      (WidgetTester tester) async {
+    final fieldKey = GlobalKey<EnvironmentTriggerFieldState>();
+    String? interceptedText;
+    final changes = <String>[];
+
+    await tester.pumpWidget(
+      Portal(
+        child: MaterialApp(
+          home: Scaffold(
+            body: EnvironmentTriggerField(
+              key: fieldKey,
+              keyId: 'testKey',
+              initialValue: 'https://api.apidash.dev',
+              onChanged: changes.add,
+              onPastedText: (text) async {
+                interceptedText = text;
+                return true;
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    const curlCommand = 'curl -X GET https://api.apidash.dev/users';
+    await Clipboard.setData(const ClipboardData(text: curlCommand));
+    final field = tester.widget<ExtendedTextField>(find.byType(ExtendedTextField));
+    fieldKey.currentState!.controller.value = const TextEditingValue(
+      text: curlCommand,
+      selection: TextSelection.collapsed(offset: curlCommand.length),
+    );
+    field.onChanged!(curlCommand);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(interceptedText, curlCommand);
+    expect(changes, ['https://api.apidash.dev']);
+    expect(fieldKey.currentState!.controller.text, 'https://api.apidash.dev');
+  });
+
+  testWidgets(
+      'Testing EnvironmentTriggerField does not treat normal typing as pasted curl text',
+      (WidgetTester tester) async {
+    final fieldKey = GlobalKey<EnvironmentTriggerFieldState>();
+    String? interceptedText;
+
+    await tester.pumpWidget(
+      Portal(
+        child: MaterialApp(
+          home: Scaffold(
+            body: EnvironmentTriggerField(
+              key: fieldKey,
+              keyId: 'testKey',
+              onPastedText: (text) async {
+                interceptedText = text;
+                return true;
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    const typedValue = 'https://api.apidash.dev/users';
+    await Clipboard.setData(const ClipboardData(text: 'different clipboard'));
+    final field = tester.widget<ExtendedTextField>(find.byType(ExtendedTextField));
+    fieldKey.currentState!.controller.value = const TextEditingValue(
+      text: typedValue,
+      selection: TextSelection.collapsed(offset: typedValue.length),
+    );
+    field.onChanged!(typedValue);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(interceptedText, isNull);
+    expect(fieldKey.currentState!.controller.text, typedValue);
+  });
+
+  testWidgets(
+      'Testing EnvironmentTriggerField ignores stale async paste results after a newer edit',
+      (WidgetTester tester) async {
+    final fieldKey = GlobalKey<EnvironmentTriggerFieldState>();
+    final completer = Completer<bool>();
+    final changes = <String>[];
+
+    await tester.pumpWidget(
+      Portal(
+        child: MaterialApp(
+          home: Scaffold(
+            body: EnvironmentTriggerField(
+              key: fieldKey,
+              keyId: 'testKey',
+              initialValue: 'https://api.apidash.dev',
+              onChanged: changes.add,
+              onPastedText: (_) => completer.future,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    const curlCommand = 'curl -X GET https://api.apidash.dev/users';
+    await Clipboard.setData(const ClipboardData(text: curlCommand));
+    final field = tester.widget<ExtendedTextField>(find.byType(ExtendedTextField));
+    fieldKey.currentState!.controller.value = const TextEditingValue(
+      text: curlCommand,
+      selection: TextSelection.collapsed(offset: curlCommand.length),
+    );
+    field.onChanged!(curlCommand);
+
+    const newerValue = 'https://api.apidash.dev/profile';
+    fieldKey.currentState!.controller.value = const TextEditingValue(
+      text: newerValue,
+      selection: TextSelection.collapsed(offset: newerValue.length),
+    );
+    field.onChanged!(newerValue);
+
+    completer.complete(true);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(changes, [newerValue]);
+    expect(fieldKey.currentState!.controller.text, newerValue);
   });
 }

--- a/test/widgets/textfields_test.dart
+++ b/test/widgets/textfields_test.dart
@@ -1,10 +1,37 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:apidash/widgets/widgets.dart';
 import 'package:apidash/consts.dart';
 import '../test_consts.dart';
 
 void main() {
+  String? clipboardText;
+
+  setUp(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform,
+            (MethodCall methodCall) async {
+      switch (methodCall.method) {
+        case 'Clipboard.getData':
+          return <String, dynamic>{'text': clipboardText};
+        case 'Clipboard.setData':
+          clipboardText =
+              (methodCall.arguments as Map<Object?, Object?>?)?['text']
+                  as String?;
+          return null;
+        default:
+          return null;
+      }
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+    clipboardText = null;
+  });
+
   testWidgets('Testing URL Field', (tester) async {
     await tester.pumpWidget(
       MaterialApp(
@@ -141,5 +168,52 @@ void main() {
 
     // check if value was updated
     expect(wasSubmitCalled, true);
+  });
+
+  testWidgets('URL Field handles pasted curl text without emitting raw value',
+      (tester) async {
+    final changes = <String>[];
+    String? interceptedText;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        title: 'URL Field',
+        theme: kThemeDataDark,
+        home: Scaffold(
+          body: Column(
+            children: [
+              URLField(
+                selectedId: '2',
+                initialValue: 'https://api.apidash.dev',
+                onChanged: changes.add,
+                onPastedText: (text) async {
+                  interceptedText = text;
+                  return true;
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    const curlCommand = 'curl -X GET https://api.apidash.dev/users';
+    await Clipboard.setData(const ClipboardData(text: curlCommand));
+    final formField = tester.widget<TextFormField>(find.byType(TextFormField));
+    final editableText = tester.widget<EditableText>(find.byType(EditableText));
+    editableText.controller.value = const TextEditingValue(
+      text: curlCommand,
+      selection: TextSelection.collapsed(offset: curlCommand.length),
+    );
+    formField.onChanged!(curlCommand);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(interceptedText, curlCommand);
+    expect(changes, ['https://api.apidash.dev']);
+    expect(
+      tester.widget<EditableText>(find.byType(EditableText)).controller.text,
+      'https://api.apidash.dev',
+    );
   });
 }


### PR DESCRIPTION
Closes #953

## Summary
This PR routes pasted cURL commands from the REST URL field into the existing DashBot import-cURL workflow.

Instead of leaving a pasted `curl ...` command in the URL field, API Dash now opens DashBot, pins the chat route, starts the import-cURL task, and forwards the pasted command through the current DashBot parsing path.

## Root Cause
The editor URL field accepted pasted cURL commands as plain text, but the actual parsing and request-conversion flow already exists in DashBot. That left users with a broken editor value and duplicated the work needed to import a request correctly.

## Fix
I added a paste-aware interception hook to the URL field path and used it only for the REST request editor.

The interception is clipboard-checked so normal typing is not rerouted. When the pasted text starts with `curl `, the field now:
- opens DashBot if needed
- pins DashBot to chat
- triggers the existing import-cURL task prompt
- forwards the pasted cURL text into the current DashBot import flow
- restores the URL field to its previous value instead of leaving raw cURL there

## Validation
Passed locally:
- `flutter test test/screens/common_widgets/env_trigger_field_test.dart`
- `flutter test test/widgets/textfields_test.dart`
- `flutter test test/dashbot/features/chat/viewmodel/chat_viewmodel_test.dart`

## AI Usage
AI assistance was used for exploration and drafting, and the final code was reviewed manually before submission.
