### PR TITLE
Add markdown rendering toggle to AI answers

### DIFF
--- a/lib/widgets/response_body_success.dart
+++ b/lib/widgets/response_body_success.dart
@@ -38,6 +38,7 @@ class ResponseBodySuccess extends StatefulWidget {
 
 class _ResponseBodySuccessState extends State<ResponseBodySuccess> {
   int segmentIdx = 0;
+  bool renderAnswerAsMarkdown = false;
 
   @override
   Widget build(BuildContext context) {
@@ -45,6 +46,8 @@ class _ResponseBodySuccessState extends State<ResponseBodySuccess> {
     var codeTheme = Theme.of(context).brightness == Brightness.light
         ? kLightCodeTheme
         : kDarkCodeTheme;
+    final showMarkdownToggle =
+        widget.isAIResponse && currentSeg == ResponseBodyView.answer;
     final textContainerdecoration = BoxDecoration(
       color: Theme.of(context).colorScheme.surfaceContainerLow,
       border: Border.all(
@@ -93,6 +96,21 @@ class _ResponseBodySuccessState extends State<ResponseBodySuccess> {
                             });
                           },
                         ),
+                  if (showMarkdownToggle) ...[
+                    kHSpacer10,
+                    Text(
+                      'Markdown',
+                      style: Theme.of(context).textTheme.labelMedium,
+                    ),
+                    Switch.adaptive(
+                      value: renderAnswerAsMarkdown,
+                      onChanged: (value) {
+                        setState(() {
+                          renderAnswerAsMarkdown = value;
+                        });
+                      },
+                    ),
+                  ],
                   const Spacer(),
                   ((widget.options == kPreviewRawBodyViewOptions) ||
                           kCodeRawBodyViewOptions.contains(currentSeg))
@@ -147,12 +165,17 @@ class _ResponseBodySuccessState extends State<ResponseBodySuccess> {
                       width: double.maxFinite,
                       padding: kP8,
                       decoration: textContainerdecoration,
-                      child: SingleChildScrollView(
-                        child: SelectableText(
-                          widget.formattedBody ?? widget.body,
-                          style: kCodeStyle,
-                        ),
-                      ),
+                      child: renderAnswerAsMarkdown
+                          ? CustomMarkdown(
+                              data: widget.formattedBody ?? widget.body,
+                              padding: EdgeInsets.zero,
+                            )
+                          : SingleChildScrollView(
+                              child: SelectableText(
+                                widget.formattedBody ?? widget.body,
+                                style: kCodeStyle,
+                              ),
+                            ),
                     ),
                   ),
                 ResponseBodyView.raw => Expanded(

--- a/test/widgets/response_widgets_test.dart
+++ b/test/widgets/response_widgets_test.dart
@@ -1,6 +1,7 @@
 import 'package:apidash/widgets/response_body.dart';
 import 'package:apidash/widgets/response_body_success.dart';
 import 'package:apidash/widgets/response_headers.dart';
+import 'package:apidash/widgets/markdown.dart';
 import 'package:apidash/widgets/response_pane_header.dart';
 import 'package:apidash/widgets/response_tab_view.dart';
 import 'package:apidash/widgets/widget_not_sent.dart';
@@ -465,5 +466,40 @@ void main() async {
     await tester.tap(find.text('Raw'));
     await tester.pumpAndSettle();
     expect(find.text('Raw Hello from API Dash'), findsOneWidget);
+  });
+
+  testWidgets('Testing AI answer markdown toggle', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        title: 'Body Success',
+        theme: kThemeDataLight,
+        home: Scaffold(
+          body: ResponseBodySuccess(
+            body: '# Hello World\nThis is some *markdown* text.',
+            mediaType: MediaType('text', 'plain'),
+            options: const [
+              ResponseBodyView.answer,
+              ResponseBodyView.raw,
+            ],
+            bytes: Uint8List.fromList([20, 8]),
+            isAIResponse: true,
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Markdown'), findsOneWidget);
+    expect(find.byType(CustomMarkdown), findsNothing);
+    expect(find.text('# Hello World\nThis is some *markdown* text.'),
+        findsOneWidget);
+
+    await tester.tap(find.byType(Switch));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(CustomMarkdown), findsOneWidget);
+    expect(find.text('Hello World'), findsOneWidget);
+    expect(find.text('This is some markdown text.'), findsOneWidget);
   });
 }


### PR DESCRIPTION
Closes #955

## Summary
This PR adds a local markdown-rendering toggle to the AI Answer tab in the response body.

The default behavior is unchanged: AI answers still open in the existing raw/plain selectable text view. When the toggle is enabled, the Answer tab reuses the existing `CustomMarkdown` widget to render markdown formatting without changing any stored response data.

## Root Cause
AI answers were always rendered as plain selectable text inside `ResponseBodySuccess`, even when the answer body contained markdown that users wanted to read in a formatted view.

## Fix
I added a widget-local `renderAnswerAsMarkdown` toggle in `ResponseBodySuccess` and only show the switch when the current segment is `Answer` for an AI response.

When the switch is off, the widget keeps the current `SelectableText` rendering. When the switch is on, it renders the same response body through the existing markdown widget with zero extra persistence or model changes.

## Validation
Passed locally:
- `flutter test test/widgets/response_widgets_test.dart test/widgets/markdown_test.dart`

## AI Usage
AI assistance was used for exploration and drafting, and the final code was reviewed manually before submission.
