### PR TITLE
Refined Proposal: [GSoC 2026] MCP Testing Suite — Standalone Electron + Python3 Backend

### DIFF
--- a/doc/proposals/2026/gsoc/application_souvik_ghosh_mcp_testing.md
+++ b/doc/proposals/2026/gsoc/application_souvik_ghosh_mcp_testing.md
@@ -1,4 +1,4 @@
-# GSoC 2026 Application: MCP Testing Suite for API Dash
+# GSoC 2026 Application: MCP Testing Suite — Standalone Electron App
 
 ### About
 
@@ -27,7 +27,7 @@
 
 **1. Have you worked on or contributed to a FOSS project before?**
 
-Yes — I have two active PRs against foss42/apidash:
+Yes — I have multiple active contributions to foss42/apidash:
 
 **PR #1349 — feat: add custom AI model support in selector**
 Real Flutter/Dart code contribution to the API Dash codebase.
@@ -37,36 +37,51 @@ widget architecture, and extended the AI model selector to support
 custom model names alongside built-in presets.
 → https://github.com/foss42/apidash/pull/1349
 
-**PR #1284 — MCP Testing Suite: interactive mockup v10 + working PoC**
-Includes a 5-page interactive HTML mockup and a self-contained
-Node.js PoC (`poc.js`) — real stdio JSON-RPC 2.0, 8 automated
-tests, 4-layer breakdown, zero external dependencies, ~7ms.
-The MCP Apps Preview page performs a real `ui/initialize`
-handshake in a sandboxed iframe via `postMessage`, built
-directly from @ashitaprasad's MCP Apps spec.
+**PR #1336 — Refined MCP Testing idea and PoC**
+Contains the interactive 5-page HTML mockup (v10) and the
+self-contained Node.js PoC (`poc.js`) demonstrating real stdio
+JSON-RPC 2.0 communication, 4-layer failure classification,
+and MCP Apps `_meta.ui.resourceUri` detection. The MCP Apps
+Preview page performs a working `ui/initialize` handshake in a
+sandboxed iframe via `postMessage`, built directly from
+@ashitaprasad's MCP Apps specification.
+→ https://github.com/foss42/apidash/pull/1336
+
+**PR #1284 — Initial idea submission for MCP Testing**
+The original prototype that started the conversation with
+maintainers. Led to feedback that shaped the refined version.
 → https://github.com/foss42/apidash/pull/1284
 
-Maintainers added the `gsoc-2026` label to #1284 and
-@ashitaprasad tagged me directly in `#gsoc-foss-apidash`
-to include MCP Apps testing — which was already done.
+Maintainers added the `gsoc-2026` label and @ashitaprasad
+tagged me directly in `#gsoc-foss-apidash` to incorporate
+MCP Apps testing — which was already addressed.
 
 **2. What is your one project/achievement you are most proud of?**
 
-The `poc.js` proof of concept I built for this proposal.
+The PoC I built for this proposal — now available in both
+Node.js (`poc.js`) and Python3 (`poc.py`), each with 12
+automated tests and zero external dependencies.
 
-In a single Node.js file with zero external dependencies, it:
-- Spawns a real MCP server as a child process
-- Connects via `child_process.spawn` + `stdin`/`stdout` pipe
-  (that is literally what stdio transport is)
-- Exchanges real JSON-RPC 2.0 messages over that pipe
-- Classifies results across all 4 layers: transport, protocol,
-  tool execution, and MCP Apps `_meta.ui.resourceUri` detection
+In a single file, each PoC:
+1. Spawns a real MCP server as a child process
+2. Connects via `child_process.spawn` (Node) or
+   `subprocess.Popen` (Python) + stdin/stdout pipe
+3. Exchanges real JSON-RPC 2.0 messages over that pipe
+4. Classifies every error to the correct layer using a
+   decision tree: `-32700` → transport, `-32601/-32602` →
+   protocol, `isError:true` → tool-exec, `ui/*` → ui-handshake
+5. Detects `_meta.ui.resourceUri` in tool responses
+6. Runs a snapshot diff engine for baseline regression detection
+
 ```bash
-node poc.js  # → 8/8 pass, ~7ms, zero dependencies
+node poc.js    # → 12/12 pass, ~230ms, zero deps
+python3 poc.py # → 12/12 pass, ~90ms,  zero deps
 ```
 
-Most proposals describe what they plan to build.
-This one already shows the core works at the protocol level.
+Both PoCs also support `--json` for structured output — the
+exact format the Electron main process will send to the React
+renderer via IPC. Most proposals describe what they plan to
+build. This one already runs at the protocol level.
 
 **3. What kind of problems motivate you most?**
 
@@ -77,45 +92,48 @@ hosts. But testing an MCP server today means hand-crafting
 JSON-RPC payloads in curl and guessing which layer broke from
 a generic error code.
 
-The same gap existed for REST APIs before Postman.
-I want to build the Postman moment for MCP, inside API Dash.
+Existing tools like **MCP Inspector** (Anthropic's official
+tool) are browser-based REPLs — good for manual poking, but
+they have no saved scenarios, no automation, no replay, no
+diff, and no MCP Apps hostContext injection testing.
+**MCPJam Inspector** adds an LLM playground but still lacks
+automated replayable testing and layer classification.
+
+The gap is clear: no tool does automated, replayable,
+layer-classified MCP testing today. I want to build that.
 
 **4. Will you be working on GSoC full-time?**
 
 Yes. I have no internship or coursework conflicts during the
-GSoC period and will dedicate 35–40 hours per week to this
-project.
+GSoC period and will dedicate 35–40 hours per week.
 
 **5. Do you mind regularly syncing up with mentors?**
 
 Not at all. I've been attending every weekly connect session
 and am active in `#gsoc-foss-apidash` on Discord daily.
-Regular sync is something I actively want, not just tolerate.
 
 **6. What interests you most about API Dash?**
 
-Two things. First, API Dash treats the developer as the user —
-it's fast, local-first, and doesn't require an account to get
-value. That philosophy is rare. Second, the timing: API Dash
-is at the exact inflection point where AI tooling (MCP, agents,
-model selectors) is being added on top of a solid REST/GraphQL
-foundation. Contributing now means shaping the architecture
-of a feature that will matter for years, not just fixing
-something that already works.
+API Dash treats the developer as the user — fast, local-first,
+no account required. The timing is perfect: MCP is the fastest-
+growing protocol in the AI ecosystem, and the API Dash org is
+building dedicated standalone tooling around it. Contributing
+now means shaping the architecture of a tool that will matter
+for years, not patching something already finished.
 
 **7. Areas where the project can be improved?**
 
-- **MCP testing tooling** — the biggest gap right now. No
-  dedicated way to test MCP servers, debug transport/protocol
-  failures, or validate MCP Apps `ui/initialize` handshakes.
-  This proposal addresses it directly.
-- **MCP Apps integration** — as Ashita's guide outlines, MCP
-  servers can now deliver rich HTML UI components to AI hosts.
-  API Dash is uniquely positioned to be the tool that tests
-  this entire visual layer, not just the JSON-RPC wire protocol.
-- **Regression testing for AI requests** — snapshot and replay
-  for AI/LLM API calls, similar to what this proposal builds
-  for MCP, would be a natural next step.
+- **MCP testing tooling** — the single biggest gap. No dedicated
+  way to test MCP servers, debug transport/protocol failures,
+  or validate MCP Apps `ui/initialize` handshakes. This proposal
+  builds it as a **standalone Electron desktop app**.
+- **MCP Apps validation** — as Ashita's guide outlines, MCP
+  servers can deliver rich HTML UI components. A standalone
+  tester can sandbox these with Electron's `<webview>` tag
+  (more secure than browser iframes) and test `hostContext`
+  CSS injection across different host themes.
+- **Regression testing** — snapshot and replay for MCP scenarios
+  with payload-level diffing, saved to the local filesystem.
 
 ---
 
@@ -123,151 +141,413 @@ something that already works.
 
 **1. Proposal Title**
 
-MCP Testing Suite — Full-Stack MCP & MCP Apps Testing Workflow
-for API Dash
+MCP Testing Suite — Standalone Electron Desktop App for
+Full-Stack MCP & MCP Apps Testing
 
 **2. Abstract**
 
-MCP (Model Context Protocol) is becoming the standard API layer
-of the AI world. But developers building and debugging MCP servers
-have no dedicated testing tooling. They craft JSON-RPC payloads
-manually, receive opaque error codes, and cannot tell whether a
-failure is in the transport, the protocol schema, or the tool
-execution layer.
+MCP (Model Context Protocol) is the standard API layer of
+the AI world. But developers building MCP servers have no
+dedicated testing tooling. They craft JSON-RPC payloads
+manually, receive opaque error codes, and cannot tell whether
+a failure is in the transport, the protocol schema, or the
+tool execution layer.
 
-With the new MCP Apps specification, the problem deepens: servers
-now deliver rich HTML UI components (`text/html;profile=mcp-app`)
-to AI hosts via sandboxed iframes, requiring a `ui/initialize`
-handshake and `hostContext` CSS injection. No existing tool
-handles this visual layer at all.
+With the new **MCP Apps** specification, the problem deepens:
+servers now deliver rich HTML UI components via sandboxed
+iframes, requiring a `ui/initialize` handshake and
+`hostContext` CSS injection. No existing tool handles this.
 
-This project builds the MCP Testing Suite inside API Dash — a
-full-stack, collection-oriented testing workflow covering every
-layer of MCP communication: transport, protocol, tool execution,
-and the MCP Apps visual layer. The same way API Dash already
-covers REST and GraphQL.
+This project builds the **MCP Testing Suite** as a
+**standalone Electron desktop application** in the API Dash
+ecosystem. It is a self-contained app — not a tab or plugin
+inside the existing API Dash Flutter app. It uses React +
+TypeScript in the Electron renderer process for the UI, and
+Node.js in the Electron main process for stdio transport,
+file system access, and MCP server lifecycle management.
 
 **3. Detailed Description**
 
-**The Problem**
+### Why Standalone Electron?
 
-| Pain today | After this project |
+Stdio transport **requires** `child_process.spawn` — this
+cannot run in a browser. An Electron app provides:
+
+- **Main process (Node.js):** spawns MCP servers as child
+  processes, reads stdin/stdout via `readline`, manages
+  snapshots on the local filesystem, handles timeout guards
+- **Renderer process (React):** all UI — Session Setup,
+  Scenario Runner, Trace Inspection, Replay & Compare,
+  MCP Apps Preview
+- **IPC bridge (preload.ts):** secure communication between
+  main and renderer via `ipcMain.handle` / `ipcRenderer.invoke`
+- **`<webview>` tag:** Electron's secure alternative to
+  `<iframe>` for sandboxing MCP Apps — native `postMessage`
+  support, isolated process, content security policy enforced
+
+This is the same architectural pattern used by VS Code,
+Postman, and MCP Inspector.
+
+### The Problem
+
+| Pain today | After this tool |
 |---|---|
-| Hand-craft JSON-RPC payloads in curl | Configure MCP targets like API Dash collections |
-| Generic error — which layer broke? | 4-layer trace: transport / protocol / tool-exec / ui-handshake |
-| No replay after a server change | Baseline snapshots + one-click replay + payload diff |
-| `ui/initialize` handshake — test how? | Sandboxed iframe + live `postMessage` message log |
-| `hostContext` CSS injection — validate how? | Host context sandbox with theme presets |
-| `_meta.ui.resourceUri` — auto-detect? | Detection banner in Scenario Runner |
+| Hand-craft JSON-RPC payloads in curl | Configure MCP targets, save as reusable sessions |
+| Generic error — which layer broke? | 4-layer trace: transport · protocol · tool-exec · ui-handshake |
+| No replay after a server change | Baseline snapshots + one-click replay + field-level diff |
+| `ui/initialize` handshake — test how? | Electron `<webview>` sandbox + live `postMessage` log |
+| `hostContext` CSS — validate how? | Theme preset switcher with live re-render |
+| `_meta.ui.resourceUri` — undetectable | Auto-detection banner in Scenario Runner |
 
-**Architecture**
+### Architecture
+
 ```
-src/
-  mcp/
-    client/
-      StdioTransport.ts      # child_process spawn + stdin/stdout
-      HttpTransport.ts       # fetch-based HTTP transport
-      MCPClient.ts           # JSON-RPC 2.0 layer, pending map
-    testing/
-      ScenarioRunner.ts      # step-by-step execution engine
-      TraceInspector.ts      # 4-layer event classifier
-      SnapshotStore.ts       # baseline capture + diff engine
-    apps/
-      AppPreview.tsx         # sandboxed iframe + postMessage host
-      HostContextSandbox.ts  # CSS variable injection + presets
-  ui/
-    SessionSetup/
-    ScenarioRunner/
-    TraceInspection/
-    ReplayCompare/
-    MCPAppsPreview/
+mcp-testing-suite/                  # standalone Electron app
+├── package.json
+├── electron/
+│   ├── main.ts                     # Electron main process entry
+│   ├── preload.ts                  # IPC bridge (contextBridge)
+│   └── ipc/
+│       ├── transport-handlers.ts   # mcp:connect, mcp:send, mcp:disconnect
+│       └── snapshot-handlers.ts    # snapshot:save, snapshot:load, snapshot:diff
+├── src/
+│   ├── client/
+│   │   ├── StdioTransport.ts       # child_process.spawn + readline
+│   │   ├── HttpTransport.ts        # fetch-based HTTP/SSE transport
+│   │   └── MCPClient.ts            # JSON-RPC 2.0 pending map + error types
+│   ├── testing/
+│   │   ├── ScenarioRunner.ts       # step-by-step execution engine
+│   │   ├── TraceInspector.ts       # 4-layer event classifier
+│   │   └── SnapshotStore.ts        # baseline capture + diff engine
+│   ├── apps/
+│   │   ├── AppPreview.tsx          # <webview> for MCP Apps sandbox
+│   │   └── HostContextSandbox.ts   # CSS variable injection + presets
+│   ├── ui/
+│   │   ├── pages/
+│   │   │   ├── SessionSetup.tsx
+│   │   │   ├── ScenarioRunner.tsx
+│   │   │   ├── TraceInspection.tsx
+│   │   │   ├── ReplayCompare.tsx
+│   │   │   └── MCPAppsPreview.tsx
+│   │   ├── components/             # shared React components
+│   │   └── store/                  # Zustand for state management
+│   ├── App.tsx
+│   └── main.tsx                    # React entry point
+├── poc/
+│   ├── poc.js                      # Node.js PoC (12 tests)
+│   └── poc.py                      # Python3 PoC (12 tests)
+└── tests/
+    ├── unit/
+    └── integration/
 ```
 
-**Proof of Work**
+### How Each Module Works (Implementation Detail)
 
-Both artifacts are in PR #1284 and runnable today:
+**StdioTransport.ts** (runs in Electron main process)
 
-*Mockup* — open `gsoc/mcp-testing/mockup/index.html` in any
-browser. MCP Apps Preview page performs a real `ui/initialize`
-handshake and re-themes when you inject a different `hostContext`.
-
-*PoC* — `node gsoc/mcp-testing/poc/poc.js`
+This is the exact code pattern proven by `poc.js`:
 ```
-✓ All 8 tests passed  (~7ms total)
+constructor(command, args, env):
+  this.process = child_process.spawn(command, args, {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, ...env }
+  })
+  this.readline = readline.createInterface(this.process.stdout)
+  this.readline.on('line', msg => this.handleResponse(msg))
+
+send(method, params) → Promise<result>:
+  id = this.nextId++
+  this.pending.set(id, { resolve, reject, timer })
+  this.process.stdin.write(JSON.stringify({
+    jsonrpc: '2.0', id, method, params
+  }) + '\n')
+
+handleResponse(line):
+  msg = JSON.parse(line)
+  entry = this.pending.get(msg.id)
+  clearTimeout(entry.timer)
+  if msg.error → entry.reject(msg.error)
+  else → entry.resolve(msg.result)
+```
+
+The renderer never touches `child_process` directly. Instead:
+```
+// renderer (React)
+const result = await window.mcpBridge.send('initialize', params)
+
+// preload.ts (contextBridge)
+mcpBridge: {
+  send: (method, params) => ipcRenderer.invoke('mcp:send', method, params)
+}
+
+// main.ts (ipcMain)
+ipcMain.handle('mcp:send', (_, method, params) => {
+  return transport.send(method, params)
+})
+```
+
+**TraceInspector.ts** — 4-Layer Classifier
+
+The classifier uses a decision tree proven in both PoCs:
+```
+classifyError(error, context):
+  // Layer 1 — Transport
+  if context.spawnFailed or context.pipeBroken → TRANSPORT
+  if error.code == -32700 → TRANSPORT  // malformed JSON on wire
+
+  // Layer 2 — Protocol
+  if error.code == -32600 → PROTOCOL   // invalid request
+  if error.code == -32601 → PROTOCOL   // method not found
+  if error.code == -32602 → PROTOCOL   // invalid params
+  if context.missingField → PROTOCOL   // e.g. no serverInfo
+
+  // Layer 4 — UI Handshake
+  if context.method.startsWith('ui/') → UI_HANDSHAKE
+  if context.hostContextRejected → UI_HANDSHAKE
+
+  // Layer 3 — Tool Execution (default)
+  → TOOL_EXEC
+```
+
+This is not theoretical — it's the exact `classifyError()`
+function exported from both `poc.js` and `poc.py`, tested
+against real JSON-RPC error codes.
+
+**SnapshotStore.ts** — Diff Engine
+
+```
+captureSnapshot(label, data):
+  return { label, timestamp, data: deepClone(data) }
+  // saved to filesystem via ipcMain.handle('snapshot:save')
+
+diffSnapshots(baseline, current):
+  recursively compare objects field by field
+  emit { path, type, from, to } for each difference
+  types: 'value-change' | 'added' | 'removed' | 'type-change'
+```
+
+The diff engine in `poc.js` already detects version changes,
+tool count changes, and validation state regressions. The
+GSoC implementation adds filesystem persistence via Electron's
+main process and a React diff viewer in the renderer.
+
+**AppPreview.tsx** — MCP Apps Sandbox
+
+In Electron, MCP Apps run inside a `<webview>` tag (not an
+`<iframe>`). The `<webview>` is an isolated Chromium process
+with its own security context:
+
+```tsx
+<webview
+  src={resourceUri}
+  partition="mcp-app-sandbox"
+  nodeintegration={false}
+  preload="./app-preload.js"
+/>
+```
+
+The host (our Electron app) listens for `postMessage` from
+the webview, responds with `hostContext` CSS variables, and
+logs every message bidirectionally:
+
+```
+App → Host:  ui/initialize { clientInfo }
+Host → App:  result { hostContext: { css: { --host-bg, --host-fg, ... } } }
+App → Host:  ui/notifications/initialized
+```
+
+The theme preset switcher lets developers test their MCP App
+against different host themes (VS Code Dark, VS Code Light,
+custom) — a real pain point called out in Ashita's blog.
+
+### Proof of Work
+
+Three artifacts demonstrate feasibility:
+
+**1. Interactive Mockup v11** (`mockup/index.html`)
+Updated to show standalone Electron UI with custom title bar,
+IPC architecture diagrams, `<webview>` references, and
+explicit "this is NOT inside API Dash" callout.
+
+**2. Node.js PoC** (`poc/poc.js`) — 12 tests
+```bash
+node poc/poc.js
+```
+```
+✓ All 12 tests passed  (~230ms total)
 
 Layer Breakdown:
-■ Transport   ── OK       stdio spawn + stdin/stdout
-■ Protocol    ── OK       JSON-RPC initialize · serverInfo
-■ Tool Exec   ── OK       tools/call · contentType assert
-■ MCP Apps    ── DETECTED _meta.ui.resourceUri
+■ Transport      ── OK       stdio spawn + stdin/stdout pipe
+■ Protocol       ── OK       JSON-RPC initialize · error codes
+■ Tool Exec      ── OK       tools/call · schema · _meta.ui
+■ UI Handshake   ── OK       ui/initialize · hostContext CSS
 ```
 
-Demo video: https://youtu.be/GAZrTelq_M0
+Supports `--json` flag for structured output matching
+the IPC format the Electron main process will emit.
+
+**3. Python3 PoC** (`poc/poc.py`) — 12 tests
+```bash
+python3 poc/poc.py
+```
+```
+✓ All 12 tests passed  (~90ms total)
+```
+
+Same 4-layer classifier, same snapshot diff engine,
+zero external dependencies. Serves as evaluation harness.
+
+**Demo video:** https://youtu.be/GAZrTelq_M0
+
+### Comparison with Existing Tools
+
+| Feature | MCP Inspector | MCPJam Inspector | **This project** |
+|---|---|---|---|
+| Manual testing | ✓ | ✓ | ✓ |
+| Saved scenarios | ✗ | ✗ | **✓** |
+| Automated replay | ✗ | ✗ | **✓** |
+| Layer classification | ✗ | ✗ | **✓ (4 layers)** |
+| Baseline + diff | ✗ | ✗ | **✓** |
+| MCP Apps preview | ✗ | Partial | **✓ (webview)** |
+| hostContext testing | ✗ | ✗ | **✓ (theme presets)** |
+| `_meta.ui.resourceUri` | ✗ | ✗ | **✓ (auto-detect)** |
+| Standalone desktop app | ✗ (browser) | ✗ (browser) | **✓ (Electron)** |
 
 **4. Weekly Timeline**
 
 **Community Bonding (May)**
-- Deep-dive into API Dash codebase: collection model, state
-  management (Riverpod), request lifecycle
-- Finalise module structure and file organisation with mentors
-- Confirm testing strategy
+- Deep-dive into project structure and confirm Electron
+  scaffolding approach with mentors (electron-forge or
+  electron-vite for build tooling)
+- Set up monorepo structure, CI pipeline, linting
+- Agree on IPC contract between main and renderer process
+- Review React state management approach (Zustand preferred
+  for simplicity; confirm with mentors)
 
-**Week 1–2 · Transport Layer**
-- `StdioTransport.ts`: spawn, readline, timeout guard
-- `MCPClient.ts`: JSON-RPC 2.0 pending map, error types
-- Unit tests for transport layer
-- ✅ Milestone: `client.initialize()` works against a real
-  MCP server over stdio
+**Week 1–2 · Electron Shell + Transport Layer**
+- Scaffold Electron app: main process, preload bridge,
+  React renderer with Vite
+- Implement `StdioTransport.ts` in main process:
+  `child_process.spawn`, `readline`, timeout guard,
+  event tracing
+- Implement `MCPClient.ts`: JSON-RPC 2.0 pending map,
+  `send()` / `notify()` / `disconnect()`
+- Wire IPC handlers: `mcp:connect`, `mcp:send`,
+  `mcp:disconnect`
+- Unit tests for transport and client modules
+- ✅ Milestone: `ipcRenderer.invoke('mcp:send', 'initialize', params)` works against a real MCP server
 
 **Week 3–4 · Session Setup UI**
-- Session Setup page wired to real `MCPClient`
-- Save/load MCP targets as API Dash collection entries
-- Validation panel: transport reachable, capabilities
-  discovered, env vars resolved
-- ✅ Milestone: user can configure, validate and save
-  an MCP target
+- `SessionSetup.tsx`: form for transport type, server
+  command, working directory, environment variables
+- On "Validate & Save": renderer calls `mcp:connect`
+  via IPC, main process spawns server, runs initialize
+  handshake, returns validation result
+- Validation panel shows 4 pills: process spawned,
+  pipe open, handshake OK, serverInfo received
+- Sessions saved to local JSON file via `snapshot:save` IPC
+- ✅ Milestone: user configures, validates, and saves an MCP target
 
 **Week 5–6 · Scenario Runner**
-- `ScenarioRunner.ts`: step execution engine
-- Scenario Runner UI: live step status, JSON-RPC output panel
-- `_meta.ui.resourceUri` auto-detection banner
-- Artifact save after each run
-- ✅ Milestone: user can run a multi-step scenario and
-  see live JSON-RPC output
+- `ScenarioRunner.ts`: ordered step execution engine —
+  each step is a `{ method, params, assertions }` object
+- `ScenarioRunner.tsx`: live step status badges
+  (PENDING → RUNNING → PASS/FAIL), JSON-RPC output panel
+  showing raw request/response for each step
+- `_meta.ui.resourceUri` auto-detection: after each
+  `tools/call` response, check `result._meta?.ui?.resourceUri`
+  — if present, show pink banner linking to MCP Apps page
+- Artifact save: after each run, serialize the full
+  step results + trace log to a timestamped JSON file
+- ✅ Milestone: user runs a multi-step scenario with live output and `_meta` detection
 
 **Week 7 · Midterm Buffer**
-- Fix issues from midterm evaluation
-- Developer documentation for M1–M3
-- Integration tests
+- Address midterm evaluation feedback
+- Developer documentation for transport + runner modules
+- Integration tests: spawn real MCP server, run scenario,
+  verify trace output programmatically
 
 **Week 8–9 · Trace Inspection**
-- `TraceInspector.ts`: event stream parser, 4-layer
-  classifier (transport / protocol / tool-exec / ui-handshake)
-- Trace Inspection UI: event timeline, layer breakdown grid,
-  raw request/response viewer, reclassify action
-- ✅ Milestone: any MCP failure classified to the correct
-  layer with clear error context
+- `TraceInspector.ts`: consumes the event array from
+  `StdioTransport.getTrace()`, applies `classifyError()`
+  decision tree to every error event, produces a
+  per-layer summary
+- `TraceInspection.tsx`:
+  - Event timeline: vertical connected line with colored
+    dots (green = pass, red = fail), timestamps, expandable
+    raw request/response
+  - Layer breakdown grid: 4 cards showing OK/FAIL per layer
+  - Classifier decision tree: visual display of which error
+    codes map to which layers (educational + debuggable)
+  - Reclassify action: user can override if they believe
+    the automatic classification is wrong
+- ✅ Milestone: any MCP failure classified to the correct layer
 
 **Week 10 · Replay & Compare**
-- `SnapshotStore.ts`: capture baseline, field-level diff
-- Replay & Compare UI: run history, diff view
-  (summary + payload diff tabs)
-- ✅ Milestone: regression detected and shown as a
-  clear readable diff
+- `SnapshotStore.ts`: save/load baselines to filesystem
+  via IPC, `diffSnapshots()` field-level comparison
+- `ReplayCompare.tsx`:
+  - Run history list with timestamps, pass/fail counts
+  - "Pin as Baseline" action on any run
+  - Diff view: summary tab (field-level changes) +
+    payload diff tab (git-style +/- syntax highlighting)
+  - "Replay Baseline" button: re-runs the saved scenario
+    and auto-diffs against the pinned baseline
+- ✅ Milestone: regression detected and displayed as readable diff
 
-**Week 11 · MCP Apps Layer**
-- `AppPreview.tsx`: sandboxed iframe, `postMessage` host
-- `HostContextSandbox.ts`: theme presets, CSS injection
-- MCP Apps Preview UI: handshake state panel, live
-  message log, 3-theme preset switcher
-- HTTP transport support
-- ✅ Milestone: full MCP Apps testing workflow
-  functional end-to-end
+**Week 11 · MCP Apps Layer + HTTP Transport**
+- `AppPreview.tsx`: Electron `<webview>` tag loading the
+  MCP App HTML from the server's resource URI
+- `HostContextSandbox.ts`: 3 theme presets (VS Code Dark,
+  VS Code Light, Custom) — each injects a different set
+  of CSS variables via `postMessage`
+- `MCPAppsPreview.tsx`:
+  - Webview frame showing the live MCP App
+  - Handshake state panel: READY → SENT → INJECTED → COMPLETE
+  - Live postMessage log: every JSON-RPC message between
+    host and app, timestamped, color-coded (in/out)
+  - Theme switcher: click preset, app re-renders live
+- `HttpTransport.ts`: fetch-based HTTP/SSE transport for
+  servers that don't use stdio
+- ✅ Milestone: full MCP Apps testing + HTTP transport end-to-end
 
 **Week 12 · Polish + Final Submission**
-- Full test coverage (unit + integration)
-- User guide + developer guide for the new feature
+- Full test coverage (unit + integration + E2E with Playwright)
+- User guide: how to configure, run, inspect, compare
+- Developer guide: architecture, IPC contract, adding new layers
 - Final PR, updated demo video, GSoC final report
+
+### Deliverables Summary
+
+| # | Deliverable | Week |
+|---|------------|------|
+| M1 | Electron shell + `StdioTransport` + `MCPClient` + IPC | 1–2 |
+| M2 | Session Setup UI (wired to real transport via IPC) | 3–4 |
+| M3 | Scenario Runner with live output + `_meta` detection | 5–6 |
+| M4 | Trace Inspection — 4-layer classifier + timeline UI | 8–9 |
+| M5 | Replay & Compare — snapshots + diff engine + UI | 10 |
+| M6 | MCP Apps layer (`<webview>` + hostContext) + HTTP transport | 11 |
+| M7 | Full tests + documentation + final report | 12 |
+
+### Why I Will Complete This
+
+The three hardest questions in any GSoC project are already
+answered:
+
+- **"Will the transport layer actually work?"** — `poc.js`
+  already does it. 12 tests, real stdio, real JSON-RPC.
+  The Electron main process code is a typed version of
+  what already runs.
+
+- **"Does the contributor understand the architecture?"** —
+  The mockup shows the Electron IPC flow. PR #1349 proves
+  I can read and extend real production code. The Python3
+  PoC proves the concept is language-agnostic.
+
+- **"Will they stay engaged?"** — I've attended every weekly
+  connect, posted in Discord daily, and shipped 3 PRs before
+  the proposal deadline. I have zero competing commitments
+  during GSoC.
 
 ---
 
@@ -278,6 +558,7 @@ Demo video: https://youtu.be/GAZrTelq_M0
 | MCP Testing discussion | https://github.com/foss42/apidash/discussions/1225 |
 | Application guide | https://github.com/foss42/apidash/discussions/1048 |
 | Flutter contribution PR | https://github.com/foss42/apidash/pull/1349 |
-| Mockup + PoC PR | https://github.com/foss42/apidash/pull/1284 |
+| Refined idea + PoC PR | https://github.com/foss42/apidash/pull/1336 |
+| Initial idea PR | https://github.com/foss42/apidash/pull/1284 |
 | MCP Apps spec (mentor) | https://dev.to/ashita/a-practical-guide-to-building-mcp-apps-1bfm |
 | Demo video | https://youtu.be/GAZrTelq_M0 |

--- a/doc/proposals/2026/gsoc/application_souvik_ghosh_mcp_testing.md
+++ b/doc/proposals/2026/gsoc/application_souvik_ghosh_mcp_testing.md
@@ -1,4 +1,4 @@
-# GSoC 2026 Application: MCP Testing Suite — Standalone Electron App
+# GSoC 2026 Application: MCP Testing Suite — Standalone Desktop App
 
 ### About
 
@@ -27,113 +27,96 @@
 
 **1. Have you worked on or contributed to a FOSS project before?**
 
-Yes — I have multiple active contributions to foss42/apidash:
+Yes — I have contributed to foss42/apidash with real code:
 
 **PR #1349 — feat: add custom AI model support in selector**
-Real Flutter/Dart code contribution to the API Dash codebase.
-Addresses issue #1315 (part of meta-issue #1269 — revamping the
-Model Selector dialog). I cloned the repo, understood the existing
-widget architecture, and extended the AI model selector to support
-custom model names alongside built-in presets.
+Flutter/Dart contribution to the API Dash codebase. Addresses
+issue #1315 (part of meta-issue #1269 — revamping the Model
+Selector dialog). I cloned the repo, studied the existing
+widget architecture, and extended the AI model selector to
+support custom model names alongside the built-in presets.
+This involved understanding provider patterns, widget
+composition, and the existing test structure.
 → https://github.com/foss42/apidash/pull/1349
 
-**PR #1336 — Refined MCP Testing idea and PoC**
-Contains the interactive 5-page HTML mockup (v10) and the
-self-contained Node.js PoC (`poc.js`) demonstrating real stdio
-JSON-RPC 2.0 communication, 4-layer failure classification,
-and MCP Apps `_meta.ui.resourceUri` detection. The MCP Apps
-Preview page performs a working `ui/initialize` handshake in a
-sandboxed iframe via `postMessage`, built directly from
-@ashitaprasad's MCP Apps specification.
-→ https://github.com/foss42/apidash/pull/1336
-
-**PR #1284 — Initial idea submission for MCP Testing**
-The original prototype that started the conversation with
-maintainers. Led to feedback that shaped the refined version.
-→ https://github.com/foss42/apidash/pull/1284
-
-Maintainers added the `gsoc-2026` label and @ashitaprasad
-tagged me directly in `#gsoc-foss-apidash` to incorporate
-MCP Apps testing — which was already addressed.
+I've also been actively participating in the project through
+Discussion #1225 (MCP Testing), Discussion #1048 (Application
+Guide), every weekly connect session, and the `#gsoc-foss-apidash`
+Discord channel daily since early March.
 
 **2. What is your one project/achievement you are most proud of?**
 
-The PoC I built for this proposal — now available in both
-Node.js (`poc.js`) and Python3 (`poc.py`), each with 12
-automated tests and zero external dependencies.
+A pair of PoCs I built for this proposal — one in Python3
+(`poc.py`) and one in Node.js (`poc.js`), each running 12
+automated tests with zero external dependencies.
 
-In a single file, each PoC:
-1. Spawns a real MCP server as a child process
-2. Connects via `child_process.spawn` (Node) or
-   `subprocess.Popen` (Python) + stdin/stdout pipe
-3. Exchanges real JSON-RPC 2.0 messages over that pipe
-4. Classifies every error to the correct layer using a
-   decision tree: `-32700` → transport, `-32601/-32602` →
-   protocol, `isError:true` → tool-exec, `ui/*` → ui-handshake
-5. Detects `_meta.ui.resourceUri` in tool responses
-6. Runs a snapshot diff engine for baseline regression detection
+Each PoC spawns a real MCP server as a child process, connects
+via stdin/stdout pipes, exchanges real JSON-RPC 2.0 messages,
+and classifies every error to the correct layer using a
+decision tree I designed:
+
+- `-32700` on the wire → transport layer (malformed JSON)
+- `-32601` or `-32602` → protocol layer (bad method or params)
+- `isError: true` in response → tool execution layer
+- `ui/*` method failure → UI handshake layer
+
+They also detect `_meta.ui.resourceUri` in tool responses and
+run a snapshot diff engine for baseline regression detection.
+Both support `--json` for structured output matching the format
+the app's backend will emit.
 
 ```bash
-node poc.js    # → 12/12 pass, ~230ms, zero deps
-python3 poc.py # → 12/12 pass, ~90ms,  zero deps
+python3 poc.py  # → 12/12 pass, ~90ms
+node poc.js     # → 12/12 pass, ~230ms
 ```
-
-Both PoCs also support `--json` for structured output — the
-exact format the Electron main process will send to the React
-renderer via IPC. Most proposals describe what they plan to
-build. This one already runs at the protocol level.
 
 **3. What kind of problems motivate you most?**
 
-Developer tooling gaps where the ecosystem has outpaced the
-tooling. MCP is now the standard way AI agents discover and
-invoke tools — adopted by VS Code, Claude, and dozens of AI
-hosts. But testing an MCP server today means hand-crafting
-JSON-RPC payloads in curl and guessing which layer broke from
-a generic error code.
+Developer tooling gaps. MCP is now the standard way AI agents
+discover and invoke tools — VS Code, Claude, and dozens of
+hosts use it. But testing an MCP server today means opening a
+terminal, hand-writing a JSON-RPC payload in curl, getting
+back an error code, and then guessing: was that a transport
+problem? A schema mismatch? A bug in the tool itself?
 
-Existing tools like **MCP Inspector** (Anthropic's official
-tool) are browser-based REPLs — good for manual poking, but
-they have no saved scenarios, no automation, no replay, no
-diff, and no MCP Apps hostContext injection testing.
-**MCPJam Inspector** adds an LLM playground but still lacks
-automated replayable testing and layer classification.
+I looked at the existing tools. Anthropic's MCP Inspector is
+a browser-based REPL — useful for manual poking, but you
+can't save a scenario, replay it after a server change, or
+figure out which layer broke. MCPJam's Inspector adds an LLM
+playground and some OAuth debugging, which is nice, but it
+still doesn't do automated replay, baseline diffing, or
+layer classification. Neither of them can test the MCP Apps
+`hostContext` injection at all — you'd have to build a custom
+iframe setup yourself.
 
-The gap is clear: no tool does automated, replayable,
-layer-classified MCP testing today. I want to build that.
+That gap is what this project fills. Not another REPL, but
+an automated, replayable, layer-classified testing tool with
+MCP Apps sandbox support built in.
 
 **4. Will you be working on GSoC full-time?**
 
-Yes. I have no internship or coursework conflicts during the
-GSoC period and will dedicate 35–40 hours per week.
+Yes. No internship or coursework conflicts. 35–40 hours/week.
 
 **5. Do you mind regularly syncing up with mentors?**
 
-Not at all. I've been attending every weekly connect session
-and am active in `#gsoc-foss-apidash` on Discord daily.
+Not at all. I've been at every weekly connect and on Discord
+daily. I actively want regular sync, not just tolerate it.
 
 **6. What interests you most about API Dash?**
 
-API Dash treats the developer as the user — fast, local-first,
-no account required. The timing is perfect: MCP is the fastest-
-growing protocol in the AI ecosystem, and the API Dash org is
-building dedicated standalone tooling around it. Contributing
-now means shaping the architecture of a tool that will matter
-for years, not patching something already finished.
+It's developer-first — fast, local, no account needed. And
+the timing is perfect: the org is building standalone tooling
+around MCP, the fastest-growing protocol in the AI ecosystem.
+Contributing now means shaping something from the ground up.
 
 **7. Areas where the project can be improved?**
 
-- **MCP testing tooling** — the single biggest gap. No dedicated
-  way to test MCP servers, debug transport/protocol failures,
-  or validate MCP Apps `ui/initialize` handshakes. This proposal
-  builds it as a **standalone Electron desktop app**.
-- **MCP Apps validation** — as Ashita's guide outlines, MCP
-  servers can deliver rich HTML UI components. A standalone
-  tester can sandbox these with Electron's `<webview>` tag
-  (more secure than browser iframes) and test `hostContext`
-  CSS injection across different host themes.
-- **Regression testing** — snapshot and replay for MCP scenarios
-  with payload-level diffing, saved to the local filesystem.
+MCP testing is the biggest gap. There's no dedicated tool
+to test MCP servers, classify transport vs protocol vs tool
+failures, or validate the MCP Apps `ui/initialize` handshake.
+This proposal builds that as a standalone desktop app with a
+Python3 backend. Beyond this project, snapshot-and-replay for
+AI/LLM API calls would be a natural extension.
 
 ---
 
@@ -141,413 +124,443 @@ for years, not patching something already finished.
 
 **1. Proposal Title**
 
-MCP Testing Suite — Standalone Electron Desktop App for
-Full-Stack MCP & MCP Apps Testing
+MCP Testing Suite — Standalone Desktop App for Full-Stack
+MCP & MCP Apps Testing
 
 **2. Abstract**
 
-MCP (Model Context Protocol) is the standard API layer of
-the AI world. But developers building MCP servers have no
-dedicated testing tooling. They craft JSON-RPC payloads
-manually, receive opaque error codes, and cannot tell whether
-a failure is in the transport, the protocol schema, or the
-tool execution layer.
+MCP is the standard API layer of the AI world. But developers
+building MCP servers have no dedicated testing tool. They
+craft JSON-RPC payloads by hand, get opaque error codes, and
+can't tell whether a failure is in the transport, the protocol,
+or the tool itself.
 
-With the new **MCP Apps** specification, the problem deepens:
-servers now deliver rich HTML UI components via sandboxed
-iframes, requiring a `ui/initialize` handshake and
-`hostContext` CSS injection. No existing tool handles this.
+The new MCP Apps spec makes it worse — servers now serve rich
+HTML UI components via sandboxed iframes, requiring a
+`ui/initialize` handshake and `hostContext` CSS injection.
+No existing tool handles any of this.
 
 This project builds the **MCP Testing Suite** as a
-**standalone Electron desktop application** in the API Dash
-ecosystem. It is a self-contained app — not a tab or plugin
-inside the existing API Dash Flutter app. It uses React +
-TypeScript in the Electron renderer process for the UI, and
-Node.js in the Electron main process for stdio transport,
-file system access, and MCP server lifecycle management.
+**standalone Electron desktop application** with a **Python3
+backend** and a **React/TypeScript frontend**. It is a
+self-contained app in the API Dash ecosystem — not a tab or
+plugin inside the existing API Dash Flutter app.
+
+- **Python3 backend** (runs in Electron main process via
+  child process): handles MCP server lifecycle, stdio/HTTP
+  transport, JSON-RPC communication, trace classification,
+  snapshot storage, and diff computation
+- **React/TypeScript frontend** (Electron renderer): all UI
+  pages — Session Setup, Scenario Runner, Trace Inspection,
+  Replay & Compare, MCP Apps Preview
+- **Electron shell**: provides desktop app experience, native
+  filesystem access, `<webview>` tag for secure MCP Apps
+  sandboxing, and bridges frontend ↔ backend via IPC
 
 **3. Detailed Description**
 
-### Why Standalone Electron?
+### Why Standalone? Why Electron? Why Python3 Backend?
 
-Stdio transport **requires** `child_process.spawn` — this
-cannot run in a browser. An Electron app provides:
+Stdio transport requires spawning MCP servers as child
+processes and reading their stdin/stdout — this can't run
+in a browser. Electron provides the desktop shell.
 
-- **Main process (Node.js):** spawns MCP servers as child
-  processes, reads stdin/stdout via `readline`, manages
-  snapshots on the local filesystem, handles timeout guards
-- **Renderer process (React):** all UI — Session Setup,
-  Scenario Runner, Trace Inspection, Replay & Compare,
-  MCP Apps Preview
-- **IPC bridge (preload.ts):** secure communication between
-  main and renderer via `ipcMain.handle` / `ipcRenderer.invoke`
-- **`<webview>` tag:** Electron's secure alternative to
-  `<iframe>` for sandboxing MCP Apps — native `postMessage`
-  support, isolated process, content security policy enforced
+Python3 is the backend language because:
+- The MCP Python SDK (`mcp` package) is mature and
+  well-maintained — first-class `stdio` and `sse` client support
+- `subprocess.Popen` + `threading` handles stdio transport
+  cleanly (proven in `poc.py`)
+- `asyncio` enables concurrent scenario execution
+- The evaluation harness is naturally Python3
+- Aligns with the project's Python skill requirement
 
-This is the same architectural pattern used by VS Code,
-Postman, and MCP Inspector.
+The architecture: Electron's main process spawns a Python3
+backend process on app startup. The React renderer
+communicates with it via local WebSocket or HTTP. The Python
+backend owns all MCP logic — transport, client, testing
+engine, trace classification, snapshots. The React frontend
+is purely the UI layer.
 
 ### The Problem
 
-| Pain today | After this tool |
-|---|---|
-| Hand-craft JSON-RPC payloads in curl | Configure MCP targets, save as reusable sessions |
-| Generic error — which layer broke? | 4-layer trace: transport · protocol · tool-exec · ui-handshake |
-| No replay after a server change | Baseline snapshots + one-click replay + field-level diff |
-| `ui/initialize` handshake — test how? | Electron `<webview>` sandbox + live `postMessage` log |
-| `hostContext` CSS — validate how? | Theme preset switcher with live re-render |
-| `_meta.ui.resourceUri` — undetectable | Auto-detection banner in Scenario Runner |
+Today, testing an MCP server means opening curl and typing
+something like `echo '{"jsonrpc":"2.0","id":1,"method":
+"initialize",...}' | npx server-weather`. You get back either
+a JSON blob or an error code. If it's `-32602`, is that
+because your params were wrong, or because the server
+crashed during validation? There's no way to know without
+reading the server source code.
+
+After a server update, you re-type the same curl command and
+eyeball whether the response changed. There's no saved
+baseline, no diff, no regression detection.
+
+If the server delivers an MCP App (a rich HTML component),
+you have no way to test the `ui/initialize` handshake or
+verify that the app renders correctly under different host
+themes without building a custom iframe setup from scratch.
+
+This tool solves each of these:
+
+- **Session Setup** replaces curl with a persistent config —
+  transport type, server command, env vars, working directory.
+  One click validates the connection end-to-end.
+- **Scenario Runner** replaces manual typing with saved,
+  ordered test steps. Each step has assertions. Run them all
+  at once, see live pass/fail per step.
+- **Trace Inspection** replaces guessing with a 4-layer
+  classifier that reads the error code and tells you exactly
+  which layer broke: transport, protocol, tool execution, or
+  UI handshake.
+- **Replay & Compare** replaces eyeballing with a snapshot
+  diff engine. Pin a baseline, replay after a server change,
+  see exactly what fields changed.
+- **MCP Apps Preview** replaces building a custom iframe with
+  a secure `<webview>` sandbox that runs the full
+  `ui/initialize → hostContext → initialized` handshake and
+  logs every `postMessage` in real time.
 
 ### Architecture
 
 ```
-mcp-testing-suite/                  # standalone Electron app
+mcp-testing-suite/                    # standalone Electron app
 ├── package.json
 ├── electron/
-│   ├── main.ts                     # Electron main process entry
-│   ├── preload.ts                  # IPC bridge (contextBridge)
-│   └── ipc/
-│       ├── transport-handlers.ts   # mcp:connect, mcp:send, mcp:disconnect
-│       └── snapshot-handlers.ts    # snapshot:save, snapshot:load, snapshot:diff
-├── src/
+│   ├── main.ts                       # spawns Python backend on startup
+│   ├── preload.ts                    # contextBridge for renderer
+│   └── backend-bridge.ts            # manages Python child process
+├── backend/                          # Python3 — all MCP logic
+│   ├── requirements.txt              # mcp, websockets, uvicorn
+│   ├── main.py                       # entry point, starts WS server
+│   ├── transport/
+│   │   ├── stdio_transport.py        # subprocess.Popen + readline
+│   │   └── http_transport.py         # httpx-based HTTP/SSE client
 │   ├── client/
-│   │   ├── StdioTransport.ts       # child_process.spawn + readline
-│   │   ├── HttpTransport.ts        # fetch-based HTTP/SSE transport
-│   │   └── MCPClient.ts            # JSON-RPC 2.0 pending map + error types
+│   │   └── mcp_client.py            # JSON-RPC 2.0 pending map
 │   ├── testing/
-│   │   ├── ScenarioRunner.ts       # step-by-step execution engine
-│   │   ├── TraceInspector.ts       # 4-layer event classifier
-│   │   └── SnapshotStore.ts        # baseline capture + diff engine
+│   │   ├── scenario_runner.py        # step-by-step execution
+│   │   ├── trace_inspector.py        # 4-layer classifier
+│   │   └── snapshot_store.py         # baseline capture + diff
 │   ├── apps/
-│   │   ├── AppPreview.tsx          # <webview> for MCP Apps sandbox
-│   │   └── HostContextSandbox.ts   # CSS variable injection + presets
-│   ├── ui/
-│   │   ├── pages/
-│   │   │   ├── SessionSetup.tsx
-│   │   │   ├── ScenarioRunner.tsx
-│   │   │   ├── TraceInspection.tsx
-│   │   │   ├── ReplayCompare.tsx
-│   │   │   └── MCPAppsPreview.tsx
-│   │   ├── components/             # shared React components
-│   │   └── store/                  # Zustand for state management
+│   │   └── host_context.py           # CSS variable presets
+│   └── api/
+│       └── ws_handler.py            # WebSocket API for frontend
+├── src/                              # React/TypeScript frontend
+│   ├── pages/
+│   │   ├── SessionSetup.tsx
+│   │   ├── ScenarioRunner.tsx
+│   │   ├── TraceInspection.tsx
+│   │   ├── ReplayCompare.tsx
+│   │   └── MCPAppsPreview.tsx
+│   ├── components/
+│   ├── hooks/
+│   │   └── useBackend.ts            # WebSocket hook to Python API
+│   ├── store/                        # Zustand state management
 │   ├── App.tsx
-│   └── main.tsx                    # React entry point
+│   └── main.tsx
 ├── poc/
-│   ├── poc.js                      # Node.js PoC (12 tests)
-│   └── poc.py                      # Python3 PoC (12 tests)
+│   ├── poc.py                        # Python3 PoC (12 tests)
+│   └── poc.js                        # Node.js PoC (12 tests)
 └── tests/
-    ├── unit/
-    └── integration/
+    ├── test_transport.py
+    ├── test_classifier.py
+    ├── test_snapshot.py
+    └── test_scenario.py
 ```
 
-### How Each Module Works (Implementation Detail)
+### How Each Module Works
 
-**StdioTransport.ts** (runs in Electron main process)
+**stdio_transport.py** (Python3 backend)
 
-This is the exact code pattern proven by `poc.js`:
-```
-constructor(command, args, env):
-  this.process = child_process.spawn(command, args, {
-    stdio: ['pipe', 'pipe', 'pipe'],
-    env: { ...process.env, ...env }
-  })
-  this.readline = readline.createInterface(this.process.stdout)
-  this.readline.on('line', msg => this.handleResponse(msg))
+This is the exact pattern proven by `poc.py`:
+```python
+class StdioTransport:
+    def connect(self, command, args, env):
+        self.proc = subprocess.Popen(
+            [command] + args,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True, bufsize=1,
+            env={**os.environ, **env}
+        )
+        self._reader = threading.Thread(
+            target=self._read_loop, daemon=True
+        )
+        self._reader.start()
 
-send(method, params) → Promise<result>:
-  id = this.nextId++
-  this.pending.set(id, { resolve, reject, timer })
-  this.process.stdin.write(JSON.stringify({
-    jsonrpc: '2.0', id, method, params
-  }) + '\n')
-
-handleResponse(line):
-  msg = JSON.parse(line)
-  entry = this.pending.get(msg.id)
-  clearTimeout(entry.timer)
-  if msg.error → entry.reject(msg.error)
-  else → entry.resolve(msg.result)
-```
-
-The renderer never touches `child_process` directly. Instead:
-```
-// renderer (React)
-const result = await window.mcpBridge.send('initialize', params)
-
-// preload.ts (contextBridge)
-mcpBridge: {
-  send: (method, params) => ipcRenderer.invoke('mcp:send', method, params)
-}
-
-// main.ts (ipcMain)
-ipcMain.handle('mcp:send', (_, method, params) => {
-  return transport.send(method, params)
-})
+    def send(self, method, params) -> dict:
+        id = self._next_id()
+        request = {
+            "jsonrpc": "2.0", "id": id,
+            "method": method, "params": params
+        }
+        self.proc.stdin.write(json.dumps(request) + "\n")
+        self.proc.stdin.flush()
+        return self._wait_for(id, timeout=5.0)
 ```
 
-**TraceInspector.ts** — 4-Layer Classifier
-
-The classifier uses a decision tree proven in both PoCs:
+The React frontend never touches subprocess directly. Instead:
 ```
-classifyError(error, context):
-  // Layer 1 — Transport
-  if context.spawnFailed or context.pipeBroken → TRANSPORT
-  if error.code == -32700 → TRANSPORT  // malformed JSON on wire
-
-  // Layer 2 — Protocol
-  if error.code == -32600 → PROTOCOL   // invalid request
-  if error.code == -32601 → PROTOCOL   // method not found
-  if error.code == -32602 → PROTOCOL   // invalid params
-  if context.missingField → PROTOCOL   // e.g. no serverInfo
-
-  // Layer 4 — UI Handshake
-  if context.method.startsWith('ui/') → UI_HANDSHAKE
-  if context.hostContextRejected → UI_HANDSHAKE
-
-  // Layer 3 — Tool Execution (default)
-  → TOOL_EXEC
+React UI
+  → useBackend() hook sends WebSocket message
+  → Python ws_handler.py receives it
+  → calls stdio_transport.send(method, params)
+  → returns result back over WebSocket
+  → React updates UI
 ```
 
-This is not theoretical — it's the exact `classifyError()`
-function exported from both `poc.js` and `poc.py`, tested
-against real JSON-RPC error codes.
+**trace_inspector.py** — 4-Layer Classifier
 
-**SnapshotStore.ts** — Diff Engine
+```python
+def classify_error(error, context=None):
+    code = error.get("code")
 
+    # Layer 1 — Transport
+    if context.get("spawn_failed") or context.get("pipe_broken"):
+        return "transport"
+    if code == -32700:       # parse error = bad JSON on wire
+        return "transport"
+
+    # Layer 2 — Protocol
+    if code == -32600:       # invalid request structure
+        return "protocol"
+    if code == -32601:       # method not found
+        return "protocol"
+    if code == -32602:       # missing/invalid params
+        return "protocol"
+
+    # Layer 4 — UI Handshake
+    if context.get("method", "").startswith("ui/"):
+        return "ui-handshake"
+
+    # Layer 3 — Tool Execution (default)
+    return "tool-exec"
 ```
-captureSnapshot(label, data):
-  return { label, timestamp, data: deepClone(data) }
-  // saved to filesystem via ipcMain.handle('snapshot:save')
 
-diffSnapshots(baseline, current):
-  recursively compare objects field by field
-  emit { path, type, from, to } for each difference
-  types: 'value-change' | 'added' | 'removed' | 'type-change'
+This isn't pseudocode — it's the actual function from `poc.py`,
+tested against real JSON-RPC error codes across 12 tests.
+
+**snapshot_store.py** — Diff Engine
+
+```python
+def diff_snapshots(baseline, current, path="$"):
+    diffs = []
+    if type(baseline) != type(current):
+        diffs.append({"path": path, "type": "type-change"})
+        return diffs
+    if isinstance(baseline, dict):
+        all_keys = set(baseline) | set(current)
+        for k in all_keys:
+            if k not in baseline:
+                diffs.append({"path": f"{path}.{k}", "type": "added"})
+            elif k not in current:
+                diffs.append({"path": f"{path}.{k}", "type": "removed"})
+            else:
+                diffs.extend(diff_snapshots(baseline[k], current[k], f"{path}.{k}"))
+    elif baseline != current:
+        diffs.append({"path": path, "type": "value-change",
+                       "from": baseline, "to": current})
+    return diffs
 ```
 
-The diff engine in `poc.js` already detects version changes,
-tool count changes, and validation state regressions. The
-GSoC implementation adds filesystem persistence via Electron's
-main process and a React diff viewer in the renderer.
+Snapshots are saved as JSON files on the local filesystem.
+The Python backend handles all file I/O; the React frontend
+just displays the diff.
 
-**AppPreview.tsx** — MCP Apps Sandbox
+**MCP Apps Preview** — Electron `<webview>` Sandbox
 
-In Electron, MCP Apps run inside a `<webview>` tag (not an
-`<iframe>`). The `<webview>` is an isolated Chromium process
-with its own security context:
+MCP Apps run inside Electron's `<webview>` tag, which is more
+secure than a browser iframe — it runs in an isolated Chromium
+process with its own security context:
 
-```tsx
+```html
 <webview
-  src={resourceUri}
+  src="ui://mcp-server/dashboard"
   partition="mcp-app-sandbox"
-  nodeintegration={false}
-  preload="./app-preload.js"
+  nodeintegration="false"
 />
 ```
 
-The host (our Electron app) listens for `postMessage` from
-the webview, responds with `hostContext` CSS variables, and
-logs every message bidirectionally:
-
+The handshake flow:
 ```
-App → Host:  ui/initialize { clientInfo }
-Host → App:  result { hostContext: { css: { --host-bg, --host-fg, ... } } }
-App → Host:  ui/notifications/initialized
+App → Host:   ui/initialize { clientInfo }
+Host → App:   result { hostContext: { css: { --host-bg, ... } } }
+App → Host:   ui/notifications/initialized
 ```
 
-The theme preset switcher lets developers test their MCP App
-against different host themes (VS Code Dark, VS Code Light,
-custom) — a real pain point called out in Ashita's blog.
+The Python backend generates the hostContext CSS variable sets.
+The React frontend renders the webview and logs every
+postMessage bidirectionally. The theme preset switcher (VS Code
+Dark, VS Code Light, Custom) lets developers verify their MCP
+App renders correctly across different host environments.
+
+### What Exists Today vs What This Builds
+
+The two main tools available right now are Anthropic's MCP
+Inspector and MCPJam's Inspector. MCP Inspector is the
+official one — you run `npx @modelcontextprotocol/inspector`
+and get a browser REPL where you can manually send requests
+and see responses. It's good for quick checks, but everything
+is manual and ephemeral. You can't save a test, replay it
+tomorrow, or figure out which layer of the protocol broke.
+
+MCPJam's version adds some useful features — an LLM playground
+where you can chat with a model that uses your MCP tools, and
+an OAuth configuration debugger. But the core testing workflow
+is still manual. There's no concept of "run these 5 steps in
+order and tell me if step 3 regressed since last Tuesday."
+
+Neither tool touches the MCP Apps layer. If your server exposes
+a `text/html;profile=mcp-app` resource and you want to verify
+the `ui/initialize` handshake works or that your dashboard
+re-themes correctly when a host sends different CSS variables,
+you're on your own.
+
+This project fills those gaps: saved scenarios that run
+automatically, a classifier that maps every error to its
+protocol layer, a baseline-and-diff engine for catching
+regressions, and a secure webview sandbox for MCP Apps with
+live theme switching and postMessage logging.
 
 ### Proof of Work
 
-Three artifacts demonstrate feasibility:
-
 **1. Interactive Mockup v11** (`mockup/index.html`)
-Updated to show standalone Electron UI with custom title bar,
-IPC architecture diagrams, `<webview>` references, and
-explicit "this is NOT inside API Dash" callout.
+Standalone Electron-framed UI with custom title bar, IPC
+architecture diagrams, `<webview>` references for MCP Apps,
+and explicit "this is NOT inside API Dash" callout. Open in
+any browser, no build step.
 
-**2. Node.js PoC** (`poc/poc.js`) — 12 tests
-```bash
-node poc/poc.js
-```
-```
-✓ All 12 tests passed  (~230ms total)
-
-Layer Breakdown:
-■ Transport      ── OK       stdio spawn + stdin/stdout pipe
-■ Protocol       ── OK       JSON-RPC initialize · error codes
-■ Tool Exec      ── OK       tools/call · schema · _meta.ui
-■ UI Handshake   ── OK       ui/initialize · hostContext CSS
-```
-
-Supports `--json` flag for structured output matching
-the IPC format the Electron main process will emit.
-
-**3. Python3 PoC** (`poc/poc.py`) — 12 tests
+**2. Python3 PoC** (`poc/poc.py`) — 12 tests, zero deps
 ```bash
 python3 poc/poc.py
 ```
 ```
 ✓ All 12 tests passed  (~90ms total)
+
+Layer Breakdown:
+■ Transport      ── OK       subprocess spawn + stdin/stdout
+■ Protocol       ── OK       JSON-RPC initialize · error codes
+■ Tool Exec      ── OK       tools/call · schema · _meta.ui
+■ UI Handshake   ── OK       ui/initialize · hostContext CSS
 ```
 
-Same 4-layer classifier, same snapshot diff engine,
-zero external dependencies. Serves as evaluation harness.
+**3. Node.js PoC** (`poc/poc.js`) — 12 tests, zero deps
+```bash
+node poc/poc.js
+```
+Same 12 tests, same 4-layer classifier, same snapshot diff.
+Supports `--json` for structured output.
 
 **Demo video:** https://youtu.be/GAZrTelq_M0
-
-### Comparison with Existing Tools
-
-| Feature | MCP Inspector | MCPJam Inspector | **This project** |
-|---|---|---|---|
-| Manual testing | ✓ | ✓ | ✓ |
-| Saved scenarios | ✗ | ✗ | **✓** |
-| Automated replay | ✗ | ✗ | **✓** |
-| Layer classification | ✗ | ✗ | **✓ (4 layers)** |
-| Baseline + diff | ✗ | ✗ | **✓** |
-| MCP Apps preview | ✗ | Partial | **✓ (webview)** |
-| hostContext testing | ✗ | ✗ | **✓ (theme presets)** |
-| `_meta.ui.resourceUri` | ✗ | ✗ | **✓ (auto-detect)** |
-| Standalone desktop app | ✗ (browser) | ✗ (browser) | **✓ (Electron)** |
 
 **4. Weekly Timeline**
 
 **Community Bonding (May)**
-- Deep-dive into project structure and confirm Electron
-  scaffolding approach with mentors (electron-forge or
-  electron-vite for build tooling)
-- Set up monorepo structure, CI pipeline, linting
-- Agree on IPC contract between main and renderer process
-- Review React state management approach (Zustand preferred
-  for simplicity; confirm with mentors)
+- Confirm Electron + Python3 architecture with mentors
+- Set up project scaffold: Electron shell, Python backend
+  process, React frontend with Vite, WebSocket bridge
+- Agree on WebSocket API contract between frontend and backend
+- Set up CI pipeline, linting (ruff for Python, eslint for TS)
 
-**Week 1–2 · Electron Shell + Transport Layer**
-- Scaffold Electron app: main process, preload bridge,
-  React renderer with Vite
-- Implement `StdioTransport.ts` in main process:
-  `child_process.spawn`, `readline`, timeout guard,
-  event tracing
-- Implement `MCPClient.ts`: JSON-RPC 2.0 pending map,
-  `send()` / `notify()` / `disconnect()`
-- Wire IPC handlers: `mcp:connect`, `mcp:send`,
-  `mcp:disconnect`
-- Unit tests for transport and client modules
-- ✅ Milestone: `ipcRenderer.invoke('mcp:send', 'initialize', params)` works against a real MCP server
+**Week 1–2 · Python Backend + Transport Layer**
+- Scaffold Electron app: main process spawns Python backend
+  on startup, preload bridge exposes WebSocket connection
+- `stdio_transport.py`: `subprocess.Popen`, readline thread,
+  timeout guard, event trace buffer
+- `mcp_client.py`: JSON-RPC 2.0 pending map, `send()`,
+  `notify()`, `disconnect()`, error type wrappers
+- `ws_handler.py`: WebSocket server exposing `connect`,
+  `send`, `disconnect` commands to the frontend
+- Unit tests: `test_transport.py`, `test_client.py`
+- ✅ Milestone: React UI calls `ws.send({cmd: "mcp:send", method: "initialize"})` and gets a real response from a live MCP server
 
 **Week 3–4 · Session Setup UI**
-- `SessionSetup.tsx`: form for transport type, server
-  command, working directory, environment variables
-- On "Validate & Save": renderer calls `mcp:connect`
-  via IPC, main process spawns server, runs initialize
-  handshake, returns validation result
-- Validation panel shows 4 pills: process spawned,
-  pipe open, handshake OK, serverInfo received
-- Sessions saved to local JSON file via `snapshot:save` IPC
+- `SessionSetup.tsx`: form for transport type, server command,
+  working directory, environment variables
+- On "Validate & Save": frontend sends `connect` command over
+  WebSocket → Python backend spawns server → runs initialize
+  → returns validation result
+- Validation panel: 4 pills (process spawned, pipe open,
+  handshake OK, serverInfo received)
+- Sessions saved to local JSON file by Python backend
 - ✅ Milestone: user configures, validates, and saves an MCP target
 
 **Week 5–6 · Scenario Runner**
-- `ScenarioRunner.ts`: ordered step execution engine —
-  each step is a `{ method, params, assertions }` object
-- `ScenarioRunner.tsx`: live step status badges
-  (PENDING → RUNNING → PASS/FAIL), JSON-RPC output panel
-  showing raw request/response for each step
-- `_meta.ui.resourceUri` auto-detection: after each
-  `tools/call` response, check `result._meta?.ui?.resourceUri`
-  — if present, show pink banner linking to MCP Apps page
-- Artifact save: after each run, serialize the full
-  step results + trace log to a timestamped JSON file
-- ✅ Milestone: user runs a multi-step scenario with live output and `_meta` detection
+- `scenario_runner.py`: ordered step execution — each step
+  is `{ method, params, assertions }`, run sequentially,
+  stream results to frontend via WebSocket
+- `ScenarioRunner.tsx`: live step badges (PENDING → PASS/FAIL),
+  JSON-RPC output panel, `_meta.ui.resourceUri` auto-detection
+  banner
+- After each run: serialize full results + trace to a
+  timestamped JSON file on disk
+- ✅ Milestone: user runs a multi-step scenario with live output
 
 **Week 7 · Midterm Buffer**
-- Address midterm evaluation feedback
-- Developer documentation for transport + runner modules
+- Address midterm feedback
+- Developer docs for backend API + transport module
 - Integration tests: spawn real MCP server, run scenario,
-  verify trace output programmatically
+  verify trace programmatically
 
 **Week 8–9 · Trace Inspection**
-- `TraceInspector.ts`: consumes the event array from
-  `StdioTransport.getTrace()`, applies `classifyError()`
-  decision tree to every error event, produces a
+- `trace_inspector.py`: consumes event array from transport,
+  applies `classify_error()` to every error, produces
   per-layer summary
-- `TraceInspection.tsx`:
-  - Event timeline: vertical connected line with colored
-    dots (green = pass, red = fail), timestamps, expandable
-    raw request/response
-  - Layer breakdown grid: 4 cards showing OK/FAIL per layer
-  - Classifier decision tree: visual display of which error
-    codes map to which layers (educational + debuggable)
-  - Reclassify action: user can override if they believe
-    the automatic classification is wrong
+- `TraceInspection.tsx`: event timeline with connected line
+  and colored dots, layer breakdown grid (4 cards),
+  classifier decision tree display, reclassify override action
 - ✅ Milestone: any MCP failure classified to the correct layer
 
 **Week 10 · Replay & Compare**
-- `SnapshotStore.ts`: save/load baselines to filesystem
-  via IPC, `diffSnapshots()` field-level comparison
-- `ReplayCompare.tsx`:
-  - Run history list with timestamps, pass/fail counts
-  - "Pin as Baseline" action on any run
-  - Diff view: summary tab (field-level changes) +
-    payload diff tab (git-style +/- syntax highlighting)
-  - "Replay Baseline" button: re-runs the saved scenario
-    and auto-diffs against the pinned baseline
+- `snapshot_store.py`: save/load baselines to filesystem,
+  `diff_snapshots()` recursive field comparison
+- `ReplayCompare.tsx`: run history list, "Pin as Baseline"
+  action, diff view (summary + payload tabs with +/- syntax
+  highlighting), "Replay Baseline" button
 - ✅ Milestone: regression detected and displayed as readable diff
 
 **Week 11 · MCP Apps Layer + HTTP Transport**
-- `AppPreview.tsx`: Electron `<webview>` tag loading the
-  MCP App HTML from the server's resource URI
-- `HostContextSandbox.ts`: 3 theme presets (VS Code Dark,
-  VS Code Light, Custom) — each injects a different set
-  of CSS variables via `postMessage`
-- `MCPAppsPreview.tsx`:
-  - Webview frame showing the live MCP App
-  - Handshake state panel: READY → SENT → INJECTED → COMPLETE
-  - Live postMessage log: every JSON-RPC message between
-    host and app, timestamped, color-coded (in/out)
-  - Theme switcher: click preset, app re-renders live
-- `HttpTransport.ts`: fetch-based HTTP/SSE transport for
+- `host_context.py`: theme presets (VS Code Dark, Light, Custom),
+  CSS variable generation
+- `MCPAppsPreview.tsx`: Electron `<webview>` loading MCP App,
+  handshake state panel (READY → SENT → INJECTED → COMPLETE),
+  live postMessage log, theme switcher
+- `http_transport.py`: `httpx`-based HTTP/SSE transport for
   servers that don't use stdio
-- ✅ Milestone: full MCP Apps testing + HTTP transport end-to-end
+- ✅ Milestone: full MCP Apps testing + HTTP transport working
 
 **Week 12 · Polish + Final Submission**
-- Full test coverage (unit + integration + E2E with Playwright)
-- User guide: how to configure, run, inspect, compare
-- Developer guide: architecture, IPC contract, adding new layers
+- Test coverage: pytest for backend, Vitest for frontend
+- User guide + developer guide
 - Final PR, updated demo video, GSoC final report
 
 ### Deliverables Summary
 
 | # | Deliverable | Week |
 |---|------------|------|
-| M1 | Electron shell + `StdioTransport` + `MCPClient` + IPC | 1–2 |
-| M2 | Session Setup UI (wired to real transport via IPC) | 3–4 |
+| M1 | Electron shell + Python backend + `stdio_transport` + WebSocket bridge | 1–2 |
+| M2 | Session Setup UI wired to real transport | 3–4 |
 | M3 | Scenario Runner with live output + `_meta` detection | 5–6 |
 | M4 | Trace Inspection — 4-layer classifier + timeline UI | 8–9 |
 | M5 | Replay & Compare — snapshots + diff engine + UI | 10 |
-| M6 | MCP Apps layer (`<webview>` + hostContext) + HTTP transport | 11 |
-| M7 | Full tests + documentation + final report | 12 |
+| M6 | MCP Apps (`<webview>` + hostContext) + HTTP transport | 11 |
+| M7 | Tests + documentation + final report | 12 |
 
 ### Why I Will Complete This
 
-The three hardest questions in any GSoC project are already
-answered:
+- **"Will the core engine work?"** — `poc.py` already does it.
+  12 tests, real subprocess, real JSON-RPC, real classifier.
+  The backend code is a structured version of what already runs.
 
-- **"Will the transport layer actually work?"** — `poc.js`
-  already does it. 12 tests, real stdio, real JSON-RPC.
-  The Electron main process code is a typed version of
-  what already runs.
+- **"Can this person actually write code for this project?"** —
+  PR #1349 proves I can read and extend production code.
+  The Python PoC proves I can build the backend. The mockup
+  proves I've thought through the UX.
 
-- **"Does the contributor understand the architecture?"** —
-  The mockup shows the Electron IPC flow. PR #1349 proves
-  I can read and extend real production code. The Python3
-  PoC proves the concept is language-agnostic.
-
-- **"Will they stay engaged?"** — I've attended every weekly
-  connect, posted in Discord daily, and shipped 3 PRs before
-  the proposal deadline. I have zero competing commitments
-  during GSoC.
+- **"Will they stay engaged?"** — Every weekly connect attended,
+  Discord active daily, 3 PRs shipped before the deadline,
+  zero competing commitments during GSoC.
 
 ---
 


### PR DESCRIPTION
## 🎬 Demo Video

https://github.com/user-attachments/assets/1d4788eb-4dd7-40e7-81ea-f83c9fdc789a



## PR Description

Refined proposal for GSoC 2026 Idea #1 — MCP Testing Suite.

**What changed from v1 (PR #1371):**
- Reframed as a **standalone Electron desktop app** (not inside API Dash)
- **Python3 backend** for all MCP logic (transport, classifier, snapshots)
- React/TypeScript frontend communicates with Python via WebSocket
- Detailed implementation: `stdio_transport.py`, `trace_inspector.py` classifier decision tree, `snapshot_store.py` diff engine — all with actual code
- Natural comparison with existing tools (MCP Inspector, MCPJam) — explains gaps clearly
- Updated weekly timeline reflecting Electron + Python3 architecture

**File:**
- `doc/proposals/2026/gsoc/application_souvik_ghosh_mcp_testing.md` — full refined proposal



## Related Issues

- Addresses Discussion #1225
- References #1048
- Previous proposal: #1371
- Refined idea + PoC: #1336
- Flutter contribution: #1349

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [ ] I am using the latest Flutter stable branch
- [ ] I have run the tests (`flutter test`) and all tests are passing


## Added/updated tests?
- [x] Yes — PoCs with 12 tests each (Python3 + Node.js) are in PR #1336

## OS on which you have developed and tested the feature?
- [x] Windows
- [ ] macOS
- [x] Linux