### PR TITLE
fix: detect magic bytes for application/octet-stream previewer #1382

### DIFF
--- a/lib/widgets/previewer.dart
+++ b/lib/widgets/previewer.dart
@@ -138,11 +138,91 @@ class _PreviewerState extends State<Previewer> {
         );
       }
     }
-    var errorText = errorTemplate.render({
-      "showRaw": widget.hasRaw,
-      "showContentType": true,
-      "type": "${widget.type}/${widget.subtype}",
-    });
-    return ErrorMessage(message: errorText);
+    // var errorText = errorTemplate.render({
+    //   "showRaw": widget.hasRaw,
+    //   "showContentType": true,
+    //   "type": "${widget.type}/${widget.subtype}",
+    // });
+    // return ErrorMessage(message: errorText);
+    
+    //Adding magic bytes fallback feature
+    
+    if (widget.type ==kTypeApplication && widget.subtype ==kSubTypeOctetStream ||
+        widget.type == null || widget.subtype==null){
+
+      final b = widget.bytes;
+      if (b.length>=4){
+
+        //PNG 89 50 4E 47
+        if (b[0]==0x89 && b[1]==0x50 && b[2]==0x4E && b[3]==0x47){
+          return Image.memory(b);
+        }
+        // JPEG FF D8 FF 
+        if(b[0]==0xFF && b[1]==0xD8 && b[2]==0xFF){
+          return Image.memory(b);
+        }
+
+        //GIF 47 49 46 38 
+
+        if (b[0]==0x47 && b[1]==0x49 && b[2]==0x46 && b[3]==0x38){
+          return Image.memory(b);
+        }
+        // BMP 42 40 BMP
+        if (b[0]==0x42 && b[1]==0x4D){
+          return Image.memory(b);
+        }
+
+        // WebP 52 49 46 46 57 45 42 50
+        
+        if (b.length>= 12 &&
+        b[0] == 0x52 && b[1] == 0x49 && b[2] == 0x46 && b[3] == 0x46 &&
+        b[8] == 0x57 && b[9] == 0x45 && b[10] == 0x42 && b[11] == 0x50){
+          return Image.memory(b);
+        }
+
+    //PDF 25 50 44 46 
+    if(b[0]==0x25 && b[1]==0x50 && b[2]==0x44 && b[3]==0x46){
+      return PdfPreview(build:(_) =>b, useActions: false);
+    }
+
+    // MP3 49 44 33
+    if(b.length >= 3 && b[0]==0x49 && b[1]==0x44 && b[2]==0x33){
+      return Uint8AudioPlayer(
+        bytes: b,
+        type: kTypeAudio,
+        subtype: 'mpeg',
+        errorBuilder: (context, error, stacktrace)=> ErrorMessage(message:errorTemplate.render({
+          "showRaw": false,
+          "showContentType": false,
+          "type": kTypeAudio,
+        }),
+        ),
+      );
+    }
+
+    //video 66 74 99 70
+    if (b.length >= 8 &&
+          b[4] == 0x66 && b[5] == 0x74 && b[6] == 0x79 && b[7] == 0x70){
+      return VideoPreviewer(videoBytes: b, videoFileExtension: 'mp4'); 
+    }
+
+    if (b[0] == 0x1A && b[1] == 0x45 && b[2] == 0xDF && b[3] == 0xA3){
+      return VideoPreviewer(videoBytes: b, videoFileExtension: 'webm'); 
+    }
+
+    // SVG
+    final prefix = String.fromCharCodes(b.take(200));
+    if (prefix.contains('<svg') || prefix.contains('<?xml')){
+      return SvgPicture.string(widget.body);
+    }
+      }
+    }
+    return ErrorMessage(
+      message: errorTemplate.render({
+        "showRaw": widget.hasRaw,
+        "showContentType": true,
+        "type": "${widget.type}/${widget.subtype}",
+      }),
+    );
   }
 }

--- a/test/widgets/previewer_test.dart
+++ b/test/widgets/previewer_test.dart
@@ -309,4 +309,83 @@ void main() {
     expect(find.text('John Doe'), findsOneWidget);
     expect(find.text('41'), findsOneWidget);
   });
+    testWidgets(
+    'renders JPEG for application/octet-stream when magic bytes match image',
+    (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Previewer(
+              type: kTypeApplication,
+              subtype: kSubTypeOctetStream,
+              bytes: kBodyBytesJpeg,
+              body: "",
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('encountered an error'), findsNothing);
+      expect(find.byType(Image), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'renders PdfPreview for application/octet-stream when magic bytes match PDF',
+    (tester) async {
+      final pdfBytes = Uint8List.fromList(<int>[
+        0x25, 0x50, 0x44, 0x46, 0x2D,
+        0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+      ]);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Previewer(
+              type: kTypeApplication,
+              subtype: kSubTypeOctetStream,
+              bytes: pdfBytes,
+              body: "",
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.byType(PdfPreview), findsOneWidget);
+      expect(find.textContaining('encountered an error'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'shows error for application/octet-stream when magic bytes are unknown',
+    (tester) async {
+      final unknownBytes = Uint8List.fromList(<int>[
+        0x00, 0x01, 0x02, 0x03,
+        0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0A, 0x0B,
+      ]);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Previewer(
+              type: kTypeApplication,
+              subtype: kSubTypeOctetStream,
+              bytes: unknownBytes,
+              body: "",
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('encountered an error'), findsOneWidget);
+    },
+  );
 }


### PR DESCRIPTION
## PR Description

When a file is served with the generic application/octet-stream MIME type, it indicates an unknown binary file. Magic bytes - a unique sequence of bytes at the beginning of the file to identify its true format and select an appropriate previewer.
_Now any `application/octet-stream` MIME type can be previewed by identifying the first sequence of the binary file type._

**Video before the feature-**

https://github.com/user-attachments/assets/26a43aee-17a1-4e1a-998d-f5b46129ed07

**Video after adding the feature-**

https://github.com/user-attachments/assets/2ecce19e-2452-42fb-80a7-d77d506a45f8


@animator Please look into this pr and merge it.
thank you!

## Related Issues

- Closes #1382

### Checklist
- [X] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [X] I have updated my branch and synced it with project `main` branch before making this PR
- [X] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [X] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_

## OS on which you have developed and tested the feature?

- [ ] Windows
- [ ] macOS
- [X] Linux
