### PR TITLE
Improve API error messages for better user understanding

### DIFF
--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -22,6 +22,7 @@ final selectedRequestModelProvider = StateProvider<RequestModel?>((ref) {
   }
 });
 
+
 final selectedSubstitutedHttpRequestModelProvider =
     StateProvider<HttpRequestModel?>((ref) {
       final selectedRequestModel = ref.watch(selectedRequestModelProvider);
@@ -489,7 +490,7 @@ class CollectionStateNotifier
     if (response == null) {
       newRequestModel = newRequestModel.copyWith(
         responseStatus: -1,
-        message: errorMessage,
+        message: getReadableError(errorMessage),
         isWorking: false,
         isStreaming: false,
       );
@@ -514,7 +515,7 @@ class CollectionStateNotifier
 
       newRequestModel = newRequestModel.copyWith(
         responseStatus: statusCode,
-        message: kResponseCodeReasons[statusCode],
+        message: kResponseCodeReasons[statusCode] ?? "Request completed",
         httpResponseModel: httpResponseModel,
         isWorking: false,
       );
@@ -659,4 +660,22 @@ class CollectionStateNotifier
 
     return substituteHttpRequestModel(httpRequestModel, envMap, activeEnvId);
   }
+}
+
+String getReadableError(String? error) {
+  if (error == null) return "Something went wrong";
+
+  final msg = error.toString().toLowerCase();
+
+  if (msg.contains("socketexception") || msg.contains("failed host lookup")) {
+    return "Unable to connect to server. Please check your internet or API URL.";
+  } else if (msg.contains("timeout")) {
+    return "Request timed out. Please try again.";
+  } else if (msg.contains("handshakeexception")) {
+    return "Secure connection failed (SSL issue).";
+  } else if (msg.contains("clientexception")) {
+    return "Request failed. Please check the API endpoint.";
+  }
+
+  return "Something went wrong. Please try again.";
 }


### PR DESCRIPTION
## Overview
Improved error messages shown to users when API requests fail.

## Problem
Previously, raw technical errors like "SocketException" were displayed, which are not easy for users to understand.

## Solution
Added user-friendly error messages for common failure scenarios such as:
- Network issues
- Invalid API URLs
- Connection failures

Now users see clear messages like:
"Unable to connect to server. Please check your internet or API URL."

## Testing
Tested with:
- Invalid API URL
- No internet connection
- Valid API request

All scenarios now display meaningful messages.

## Screenshots

### Before
<img width="1920" height="1020" alt="before" src="https://github.com/user-attachments/assets/cfc894ed-cc09-4209-9a37-82d78f95d145" />

### After
<img width="1920" height="1020" alt="after" src="https://github.com/user-attachments/assets/62c8d0a7-0993-4ddd-87d5-b5b78d28e62a" />


Fixes #1412