### PR TITLE
Resolve #591: Add env variable support for text request body

### DIFF
--- a/lib/screens/common_widgets/envfield_editor.dart
+++ b/lib/screens/common_widgets/envfield_editor.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:apidash/screens/common_widgets/env_trigger_field.dart';
+
+class EnvTextFieldEditor extends StatefulWidget {
+  const EnvTextFieldEditor({
+    super.key,
+    required this.fieldKey,
+    this.onChanged,
+    this.initialValue,
+    this.readOnly = false,
+    this.hintText,
+  });
+
+  final String fieldKey;
+  final ValueChanged<String>? onChanged;
+  final String? initialValue;
+  final bool readOnly;
+  final String? hintText;
+
+  @override
+  State<EnvTextFieldEditor> createState() => _EnvTextFieldEditorState();
+}
+
+class _EnvTextFieldEditorState extends State<EnvTextFieldEditor> {
+  late final TextEditingController _controller;
+  late final FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialValue ?? '');
+    _focusNode = FocusNode();
+  }
+
+  @override
+  void didUpdateWidget(covariant EnvTextFieldEditor oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if ((widget.initialValue ?? '') != _controller.text) {
+      _controller.text = widget.initialValue ?? '';
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  void _insertTab() {
+    final selection = _controller.selection;
+    final text = _controller.text;
+    const tabSpaces = '  ';
+
+    final newText = text.replaceRange(
+      selection.start,
+      selection.end,
+      tabSpaces,
+    );
+
+    _controller.value = TextEditingValue(
+      text: newText,
+      selection: TextSelection.collapsed(
+        offset: selection.start + tabSpaces.length,
+      ),
+    );
+
+    widget.onChanged?.call(_controller.text);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CallbackShortcuts(
+      bindings: <ShortcutActivator, VoidCallback>{
+        const SingleActivator(LogicalKeyboardKey.tab): _insertTab,
+      },
+      child: EnvironmentTriggerField(
+        key: Key(widget.fieldKey),
+        keyId: widget.fieldKey,
+        controller: _controller,
+        focusNode: _focusNode,
+        readOnly: widget.readOnly,
+        onChanged: widget.onChanged,
+        decoration: InputDecoration(
+          hintText: widget.hintText ?? 'Enter request body',
+          border: InputBorder.none,
+          contentPadding: const EdgeInsets.all(12),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_body.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_body.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:apidash/providers/providers.dart';
 import 'package:apidash/widgets/widgets.dart';
 import 'package:apidash/consts.dart';
+import 'package:apidash/screens/common_widgets/envfield_editor.dart';
 import 'request_form_data.dart';
 
 class EditRequestBody extends ConsumerWidget {
@@ -66,7 +67,7 @@ class EditRequestBody extends ConsumerWidget {
               ),
               _ => Padding(
                 padding: kPt5o10,
-                child: TextFieldEditor(
+                child: EnvTextFieldEditor(
                   key: Key("$selectedId-body"),
                   fieldKey: "$selectedId-body-editor",
                   initialValue: requestModel?.httpRequestModel?.body,


### PR DESCRIPTION
## PR Description

Adds environment variable support to the plain text request body editor.

This PR introduces a new `EnvTextFieldEditor` built on top of `EnvironmentTriggerField` and updates the REST plain text request body to use it. This enables environment variable suggestions/insertion in text request bodies while keeping the JSON and GraphQL editors unchanged.

## Related Issues
- Closes #591

### Checklist
-  I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
-  I have updated my branch and synced it with project `main` branch before making this PR
-  I am using the latest Flutter stable branch (run `flutter upgrade` and verify)


## Added/updated tests?
_We encourage you to add relevant test cases._

 No, and this is why: I focused this PR on the editor integration for env variable support in the plain text request body. I was not able to add reliable test coverage in this contribution.

## OS on which you have developed and tested the feature?

- macOS
