### PR TITLE
fix(json_field_editor): avoid createSpecialText runtime crash

### DIFF
--- a/packages/json_field_editor/lib/src/json_highlight/json_highlight.dart
+++ b/packages/json_field_editor/lib/src/json_highlight/json_highlight.dart
@@ -74,6 +74,6 @@ class JsonHighlight extends SpecialTextSpanBuilder {
     SpecialTextGestureTapCallback? onTap,
     required int index,
   }) {
-    throw UnimplementedError();
+    return null;
   }
 }

--- a/packages/json_field_editor/test/src/json_highlight/json_highlight_test.dart
+++ b/packages/json_field_editor/test/src/json_highlight/json_highlight_test.dart
@@ -22,5 +22,15 @@ void main() {
         ); // adjust this based on your expected result
       },
     );
+
+    test('createSpecialText returns null and does not throw', () {
+      var jsonHighlight = JsonHighlight(isFormating: true);
+
+      expect(
+        () => jsonHighlight.createSpecialText('"', index: 0),
+        returnsNormally,
+      );
+      expect(jsonHighlight.createSpecialText('"', index: 0), isNull);
+    });
   });
 }


### PR DESCRIPTION
## Summary
Fixes a potential runtime crash in `json_field_editor` by replacing an `UnimplementedError` path in `JsonHighlight.createSpecialText` with safe null behavior.

## Linked issue
Closes #1438

## Root cause
`JsonHighlight` extends `SpecialTextSpanBuilder` and overrides `createSpecialText`, but the override threw `UnimplementedError`. If this method is called by the rendering flow, it crashes at runtime.

## Changes
- Updated `JsonHighlight.createSpecialText` to return `null` instead of throwing.
- Added regression test to verify the method:
  - returns `null`
  - does not throw

## Files changed
- `packages/json_field_editor/lib/src/json_highlight/json_highlight.dart`
- `packages/json_field_editor/test/src/json_highlight/json_highlight_test.dart`

## Local validation
Commands run locally:
- `flutter test packages/json_field_editor/test/src/json_highlight/json_highlight_test.dart`
- `flutter test packages/json_field_editor`
- `flutter analyze packages/json_field_editor`

Results:
- Both test commands passed.
- Analyzer reported 5 pre-existing info-level lints in the package (no new errors introduced by this PR).

## Risk and compatibility
- Very low risk and behavior-preserving for existing highlighting logic.
- Returning `null` matches expected "no special text" behavior and avoids crash paths.
