### PR TITLE
fix(better_networking): correct duplicate-row filtering in getEnabledRows

### DIFF
--- a/packages/better_networking/lib/utils/http_request_utils.dart
+++ b/packages/better_networking/lib/utils/http_request_utils.dart
@@ -80,10 +80,11 @@ List<NameValueModel>? getEnabledRows(
   if (rows == null || isRowEnabledList == null) {
     return rows;
   }
-  List<NameValueModel> finalRows = rows
-      .where((element) => isRowEnabledList[rows.indexOf(element)])
+  final finalRows = rows.asMap().entries
+      .where((entry) => isRowEnabledList[entry.key])
+      .map((entry) => entry.value)
       .toList();
-  return finalRows == [] ? null : finalRows;
+  return finalRows;
 }
 
 String? getRequestBody(APIType type, HttpRequestModel httpRequestModel) {

--- a/packages/better_networking/test/utils/http_request_utils_test.dart
+++ b/packages/better_networking/test/utils/http_request_utils_test.dart
@@ -197,6 +197,18 @@ void main() {
         [kvRow1, kvRow3],
       );
     });
+    test('Testing duplicate rows use their own enabled index', () {
+      const duplicateA = NameValueModel(name: 'dup', value: 'same');
+      const duplicateB = NameValueModel(name: 'dup', value: 'same');
+
+      expect(
+        getEnabledRows(
+          [duplicateA, duplicateB],
+          [true, false],
+        ),
+        [duplicateA],
+      );
+    });
   });
 
   group('Testing getRequestBody', () {


### PR DESCRIPTION
## Summary
Fixes incorrect filtering in `getEnabledRows` when request rows contain duplicate values.

## Linked issue
Closes #1441

## Root cause
`getEnabledRows` used `rows.indexOf(element)` while iterating rows. For duplicate row values, `indexOf` always resolves to the first duplicate index, causing later duplicates to read the wrong enable flag.

## Changes
- Updated `getEnabledRows` to use index-stable iteration via `rows.asMap().entries`.
- Added regression test `Testing duplicate rows use their own enabled index`.

## Before vs after
- Before: `[dup, dup]` with flags `[true, false]` incorrectly returned both rows.
- After: returns only the first row, matching positional flags.

## Files changed
- `packages/better_networking/lib/utils/http_request_utils.dart`
- `packages/better_networking/test/utils/http_request_utils_test.dart`

## Local validation
Commands run:
- `flutter test packages/better_networking/test/utils/http_request_utils_test.dart`
- `flutter test packages/better_networking`
- `flutter analyze packages/better_networking`

Results:
- Both test commands passed.
- `flutter analyze` reported 3 pre-existing info-level lints in package files unrelated to this change.

## Risk and compatibility
- Low risk, minimal focused diff.
- No public API changes.
- Existing behavior for unique rows remains unchanged; duplicate rows now behave correctly.
