### PR TITLE
fix(better_networking): handle query-only input in stripUrlParams

### DIFF
--- a/packages/better_networking/lib/utils/uri_utils.dart
+++ b/packages/better_networking/lib/utils/uri_utils.dart
@@ -17,6 +17,11 @@ String stripUriParams(Uri uri) {
   return "${uri.scheme}://${uri.authority}${uri.path}";
 }
 
+/// Removes everything from the first `?` onwards using string splitting.
+///
+/// This helper is intentionally string-based and does not enforce strict URI
+/// semantics. For example, a `?` that appears after `#` is still treated as a
+/// split point.
 String stripUrlParams(String url) {
   var idx = url.indexOf("?");
   return idx >= 0 ? url.substring(0, idx) : url;

--- a/packages/better_networking/test/utils/uri_utils_test.dart
+++ b/packages/better_networking/test/utils/uri_utils_test.dart
@@ -210,7 +210,7 @@ void main() {
       expect(stripUrlParams(url), "");
     });
 
-    test('stripUrlParams keeps fragment before query delimiter', () {
+    test('stripUrlParams splits on ? even when it appears after #', () {
       const url = "https://example.com/page#frag?x=1";
       expect(stripUrlParams(url), "https://example.com/page#frag");
     });


### PR DESCRIPTION
## Summary
Fixes an edge case in URL utility behavior where stripUrlParams did not strip query strings when the query delimiter was at index 0.

## Root cause
stripUrlParams only stripped when indexOf('?') was greater than 0. For query-only inputs like ?x=1, the index is 0, so the query was incorrectly preserved.

## Changes
- Updated stripUrlParams in better_networking URI utils:
  - from idx > 0 to idx >= 0
- Added tests in uri_utils_test:
  - query-only input returns empty string
  - fragment before query delimiter is preserved correctly

## Files changed
- packages/better_networking/lib/utils/uri_utils.dart
- packages/better_networking/test/utils/uri_utils_test.dart

## Local validation
Commands run locally:
- flutter test packages/better_networking/test/utils/uri_utils_test.dart
- flutter test packages/better_networking
- flutter analyze packages/better_networking

Results:
- Both test commands passed.
- Analyze reports 3 pre-existing info-level lints unrelated to this change.

## Risk
Low risk, one-line logic fix plus regression coverage. No API changes.
