### PR TITLE
refactor(genai): enforce ModelProvider overrides at compile-time

### DIFF
--- a/packages/genai/lib/models/model_provider.dart
+++ b/packages/genai/lib/models/model_provider.dart
@@ -2,17 +2,11 @@ import 'package:better_networking/better_networking.dart';
 import '../models/models.dart';
 
 abstract class ModelProvider {
-  AIRequestModel get defaultAIRequestModel => throw UnimplementedError();
+  AIRequestModel get defaultAIRequestModel;
 
-  HttpRequestModel? createRequest(AIRequestModel? aiRequestModel) {
-    throw UnimplementedError();
-  }
+  HttpRequestModel? createRequest(AIRequestModel? aiRequestModel);
 
-  String? outputFormatter(Map x) {
-    throw UnimplementedError();
-  }
+  String? outputFormatter(Map x);
 
-  String? streamOutputFormatter(Map x) {
-    throw UnimplementedError();
-  }
+  String? streamOutputFormatter(Map x);
 }


### PR DESCRIPTION
## Summary
Hardens `genai` provider contracts by enforcing required overrides at compile-time instead of failing at runtime.

## Root cause
`ModelProvider` methods were implemented with `throw UnimplementedError()`. If a future provider misses an override, this fails only at runtime.

## Changes
- Converted `ModelProvider` members to abstract declarations:
  - `defaultAIRequestModel`
  - `createRequest(...)`
  - `outputFormatter(...)`
  - `streamOutputFormatter(...)`

## Why this helps
- Missing provider implementations are caught by the compiler.
- Eliminates latent runtime crash paths from base `UnimplementedError` methods.

## Files changed
- `packages/genai/lib/models/model_provider.dart`

## Local validation
Commands run:
- `flutter test packages/genai/test/interface/model_providers/gemini_test.dart`
- `flutter test packages/genai`
- `flutter analyze packages/genai`

Results:
- Targeted provider test passed.
- Full `genai` test suite has pre-existing failures unrelated to this change (requires env setup such as `GEMINI_API_KEY` and has baseline failures in existing tests).
- `flutter analyze packages/genai` reports existing warnings/info, none introduced by this patch.

## Risk
Low risk, no behavior change for current providers; this is contract enforcement for future implementations.
