### PR TITLE
getEnabledRows mis-filters duplicate rows #1441

### DIFF
--- a/packages/better_networking/lib/utils/http_request_utils.dart
+++ b/packages/better_networking/lib/utils/http_request_utils.dart
@@ -80,8 +80,9 @@ List<NameValueModel>? getEnabledRows(
   if (rows == null || isRowEnabledList == null) {
     return rows;
   }
-  List<NameValueModel> finalRows = rows
-      .where((element) => isRowEnabledList[rows.indexOf(element)])
+  List<NameValueModel> finalRows = rows.asMap().entries
+      .where((entry) => entry.key < isRowEnabledList.length && isRowEnabledList[entry.key])
+      .map((entry) => entry.value)
       .toList();
   return finalRows == [] ? null : finalRows;
 }

--- a/packages/better_networking/test/utils/http_request_utils_test.dart
+++ b/packages/better_networking/test/utils/http_request_utils_test.dart
@@ -197,6 +197,16 @@ void main() {
         [kvRow1, kvRow3],
       );
     });
+    test('Filters duplicate rows by position, not by value', () {
+      const duplicateRow = NameValueModel(name: "dup", value: "same");
+      expect(
+        getEnabledRows(
+          [duplicateRow, duplicateRow],
+          [false, true],
+        ),
+        [duplicateRow],
+      );
+    });
   });
 
   group('Testing getRequestBody', () {


### PR DESCRIPTION
## PR Description

Fixes incorrect row filtering in `better_networking` when request rows contain duplicate values.

### What changed
- Updated `getEnabledRows` to use index-based iteration (`rows.asMap().entries`) instead of `rows.indexOf(element)`.
- Added a regression test for duplicate rows with different enabled flags.

### Why
`getEnabledRows` previously used `rows.indexOf(element)` to map rows to `isRowEnabledList`, which breaks for duplicates because `indexOf` always returns the first matching index.  
With index-based iteration, each row is filtered by its actual position.

## Related Issues

- Closes #1441

### Validation
- `flutter test packages/better_networking/test/utils/http_request_utils_test.dart`
- `flutter test packages/better_networking`
- `flutter analyze packages/better_networking` (3 existing info-level lints; no blocking errors)

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux