### PR TITLE
fix: use positional index in getEnabledRows to correctly handle duplicate rows

### DIFF
--- a/packages/better_networking/lib/utils/http_request_utils.dart
+++ b/packages/better_networking/lib/utils/http_request_utils.dart
@@ -81,9 +81,12 @@ List<NameValueModel>? getEnabledRows(
     return rows;
   }
   List<NameValueModel> finalRows = rows
-      .where((element) => isRowEnabledList[rows.indexOf(element)])
+      .asMap()
+      .entries
+      .where((entry) => isRowEnabledList[entry.key])
+      .map((entry) => entry.value)
       .toList();
-  return finalRows == [] ? null : finalRows;
+  return finalRows;
 }
 
 String? getRequestBody(APIType type, HttpRequestModel httpRequestModel) {

--- a/packages/better_networking/test/utils/http_request_utils_test.dart
+++ b/packages/better_networking/test/utils/http_request_utils_test.dart
@@ -197,6 +197,16 @@ void main() {
         [kvRow1, kvRow3],
       );
     });
+    test('Testing duplicate rows are filtered by position not value', () {
+      const dupRow = NameValueModel(name: "code", value: "IN");
+      expect(
+        getEnabledRows(
+          [kvRow1, dupRow],
+          [false, true],
+        ),
+        [dupRow],
+      );
+    });
   });
 
   group('Testing getRequestBody', () {


### PR DESCRIPTION
Fixes #1441

## Problem
`getEnabledRows` used `rows.indexOf(element)` to look up each row's enabled flag. `indexOf` returns the index of the first matching element by value equality, so when two rows share the same name/value, both resolve to the first row's index. The second row's enabled flag is never used correctly.

## Fix
Replace value-based lookup with `asMap().entries` iteration, which uses stable positional indices. Each row, including duplicates, now correctly maps to its own position in `isRowEnabledList`.

Also removes the `finalRows == []` check which never evaluates to true in Dart (list equality requires `listEquals`).

## Testing
Added regression test: two identical rows with `[false, true]` flags now correctly returns only the second row.