### PR TITLE
feat: add TemplateFetchService for API Explorer remote JSON support

### DIFF
--- a/lib/services/api_explorer/template_fetch_service.dart
+++ b/lib/services/api_explorer/template_fetch_service.dart
@@ -1,0 +1,24 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+class TemplateFetchService {
+  static const String templateUrl =
+      'https://raw.githubusercontent.com/rishav-singh15/api-explorer-pipeline/main/sample_output.json';
+
+  static Future<Map<String, dynamic>?> fetchTemplate() async {
+    try {
+      final response = await http.get(Uri.parse(templateUrl));
+
+      if (response.statusCode == 200) {
+        return jsonDecode(response.body);
+      }
+    } catch (e) {
+      return null;
+    }
+
+    return null;
+  }
+}
+
+// NOTE: This is a minimal PoC to demonstrate remote template fetching.
+// Integration with ApiTemplate model and UI will be done in future steps.


### PR DESCRIPTION
## Overview

This PR introduces a minimal `TemplateFetchService` to demonstrate how API Explorer templates can be fetched from a remote JSON source.

Since the API Explorer feature is not fully integrated in the current codebase (as seen from PR #837), this serves as an initial step toward connecting an external automation pipeline with API Dash.

---

## What this PR does

- Adds `TemplateFetchService` under `lib/services/api_explorer/`
- Fetches template JSON from a remote GitHub source
- Parses the response into a usable Dart map structure

---

## Why this is needed

The API Explorer feature relies on externally generated templates (via an automation pipeline parsing OpenAPI/HTML/Markdown specs).

Currently:
- Templates are mocked or not fully integrated
- No clear data ingestion point exists for external template sources

This PR introduces a simple entry point for:

External pipeline -> JSON templates -> API Dash consumption

---

## Current Scope

This is a minimal proof-of-concept and intentionally keeps scope small:

- Supports fetching a single template JSON
- Does not yet map to `ApiTemplate` model
- No UI or provider integration

---

## Future Work

- Map response to `ApiTemplate` model (`explorer_model.dart`)
- Integrate with state providers (e.g. Riverpod)
- Support multiple templates
- Add schema validation
- Connect with GitHub Actions-based pipeline

---

## Notes

The JSON used here is generated from a Python-based OpenAPI parsing pipeline:
OpenAPI -> Parsed endpoints ->Tagged ->ApiTemplate-like JSON

This PR demonstrates how such pipeline output can be consumed inside API Dash.

---

## Checklist

- [x] I have gone through the contributing guide
- [x] I have updated my branch and synced it with project main branch
- [x] I am using the latest Flutter stable branch
- [ ] I have run the tests (`flutter test`) ; skipped as this is a minimal service addition with no existing integration

---

## OS

- [ ] Windows  
- [x] macOS  
- [ ] Linux  