### PR TITLE
Fix getEnabledRows incorrect mapping for duplicate rows (Fixes #1440)

### DIFF
--- a/packages/better_networking/lib/utils/http_request_utils.dart
+++ b/packages/better_networking/lib/utils/http_request_utils.dart
@@ -80,10 +80,11 @@ List<NameValueModel>? getEnabledRows(
   if (rows == null || isRowEnabledList == null) {
     return rows;
   }
-  List<NameValueModel> finalRows = rows
-      .where((element) => isRowEnabledList[rows.indexOf(element)])
-      .toList();
-  return finalRows == [] ? null : finalRows;
+  List<NameValueModel> finalRows = [
+    for (final entry in rows.asMap().entries)
+      if (isRowEnabledList[entry.key]) entry.value,
+  ];
+  return finalRows;
 }
 
 String? getRequestBody(APIType type, HttpRequestModel httpRequestModel) {

--- a/packages/better_networking/test/utils/http_request_utils_test.dart
+++ b/packages/better_networking/test/utils/http_request_utils_test.dart
@@ -197,6 +197,16 @@ void main() {
         [kvRow1, kvRow3],
       );
     });
+    test('Testing for duplicate rows with different enabled states', () {
+      const dupRow = NameValueModel(name: "code", value: "IN");
+      expect(
+        getEnabledRows(
+          [dupRow, dupRow, dupRow],
+          [true, false, true],
+        ),
+        [dupRow, dupRow],
+      );
+    });
   });
 
   group('Testing getRequestBody', () {


### PR DESCRIPTION
Fixes #1440

## Problem

`getEnabledRows` uses `rows.indexOf(element)` to look up each row's enabled
state from `isRowEnabledList`. When `rows` contains duplicate `NameValueModel`
entries, `indexOf` always returns the index of the **first** occurrence, causing
all duplicates to incorrectly reuse the first occurrence's enabled flag.

## Root Cause

`List.indexOf()` performs an equality search and returns the first match. Since
`NameValueModel` has value equality (same `name` + `value` = equal), duplicate
entries are indistinguishable to `indexOf`, and all resolve to index 0.

## Fix

Replaced `.where()` + `indexOf` with a collection-for over `rows.asMap().entries`,
which iterates by position. Each row maps to `isRowEnabledList[index]` using its
actual list index rather than a search-based index.

Also removed the no-op `finalRows == []` null check — Dart list instance equality
against a new `[]` literal is always `false`, so the condition never triggered.

## Before vs After

| Input | Before (indexOf) | After (index-based) |
|-------|------------------|---------------------|
| 3 duplicate rows, flags `[true, false, true]` | All 3 returned (all map to index 0 → `true`) | Only rows 0 & 2 returned ✓ |

## Test Coverage

- All 5 existing `getEnabledRows` tests pass unchanged
- New regression test: 3 identical `NameValueModel` rows with `[true, false, true]`
  flags — verifies only positions 0 and 2 are returned

## Files Changed

- `packages/better_networking/lib/utils/http_request_utils.dart`
- `packages/better_networking/test/utils/http_request_utils_test.dart`
