### PR TITLE
fix(json_field_editor): pass correct style for special characters

### DIFF
--- a/packages/json_field_editor/lib/src/json_field.dart
+++ b/packages/json_field_editor/lib/src/json_field.dart
@@ -241,7 +241,7 @@ class JsonFieldState extends State<JsonField> {
             keyHighlightStyle: keyHighlightStyle,
             nullHighlightStyle: nullHighlightStyle,
             numberHighlightStyle: numberHighlightStyle,
-            specialCharHighlightStyle: stringHighlightStyle,
+            specialCharHighlightStyle: specialCharHighlightStyle,
             stringHighlightStyle: stringHighlightStyle,
             commonTextStyle: commonTextStyle,
             isFormating: widget.isFormatting,


### PR DESCRIPTION
## Summary
Fix copy-paste error in json_field_editor where `specialCharHighlightStyle` was receiving `stringHighlightStyle` instead of the correct field defined in the widget state.

Special characters (`{`, `}`, `[`, `]`, `,`, `:`) were being styled using the string highlight style instead of their own `specialCharHighlightStyle` (a grey color defined on line 164-166 of `json_field.dart`).

This has been like this since the first commit of json_field_editor — the field and default style were set up correctly, but the wiring to `JsonHighlight` used the wrong variable.

## Changes
One-line fix in `packages/json_field_editor/lib/src/json_field.dart` line 244.

## Test plan
- [x] All 11 existing `json_field_editor` tests pass (`flutter test`)
- [x] Verified on macOS
- [ ] Could not test on Windows (no access to a Windows machine)

Related: #1283