### PR TITLE
Fix Select Model button fallback text for empty model string

### DIFF
--- a/lib/screens/common_widgets/ai/ai_model_selector_button.dart
+++ b/lib/screens/common_widgets/ai/ai_model_selector_button.dart
@@ -48,7 +48,7 @@ class AIModelSelectorButton extends StatelessWidget {
             },
       child: Text(
         (aiRequestModel?.model?.isNotEmpty == true)
-            ? aiRequestModel!.model
+            ? aiRequestModel!.model!
             : kLabelSelectModel,
         maxLines: 1,
         overflow: TextOverflow.ellipsis,

--- a/lib/screens/common_widgets/ai/ai_model_selector_button.dart
+++ b/lib/screens/common_widgets/ai/ai_model_selector_button.dart
@@ -47,7 +47,9 @@ class AIModelSelectorButton extends StatelessWidget {
               onModelUpdated?.call(newAIRequestModel);
             },
       child: Text(
-        aiRequestModel?.model ?? kLabelSelectModel,
+        (aiRequestModel?.model?.isNotEmpty == true)
+            ? aiRequestModel!.model
+            : kLabelSelectModel,
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
       ),

--- a/test/screens/common_widgets/ai/ai_model_selector_button_test.dart
+++ b/test/screens/common_widgets/ai/ai_model_selector_button_test.dart
@@ -1,0 +1,42 @@
+import 'package:apidash/consts.dart';
+import 'package:apidash/screens/common_widgets/ai/ai_model_selector_button.dart';
+import 'package:apidash_core/apidash_core.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AIModelSelectorButton Tests', () {
+    testWidgets('shows kLabelSelectModel when model is null',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(const MaterialApp(
+        home: Scaffold(
+          body: AIModelSelectorButton(aiRequestModel: null),
+        ),
+      ));
+      expect(find.text(kLabelSelectModel), findsOneWidget);
+    });
+
+    testWidgets('shows kLabelSelectModel when model is empty string',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(const MaterialApp(
+        home: Scaffold(
+          body: AIModelSelectorButton(
+              aiRequestModel: AIRequestModel(model: '')),
+        ),
+      ));
+      expect(find.text(kLabelSelectModel), findsOneWidget);
+    });
+
+    testWidgets('shows model name when model is not empty',
+        (WidgetTester tester) async {
+      const testModelName = 'gpt-4o';
+      await tester.pumpWidget(const MaterialApp(
+        home: Scaffold(
+          body: AIModelSelectorButton(
+              aiRequestModel: AIRequestModel(model: testModelName)),
+        ),
+      ));
+      expect(find.text(testModelName), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## PR Description

This PR fixes a bug where the "Select Model" button displays an empty text instead of its fallback label. 
Previously, the button used the `??` operator which only checks for strict `null`. However, when a selected model string is cleared or evaluates to an empty string `""`, the text widget would render a blank space instead of showing `kLabelSelectModel`. This PR updates the logic to explicitly check `aiRequestModel?.model?.isNotEmpty` to ensure the fallback text is always displayed correctly.

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [ ] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [ ] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: This is a trivial UI fallback text fix that does not affect core logic, so specific unit tests are not necessary.

## OS on which you have developed and tested the feature?

- [x] macOS
- [ ] Windows
- [ ] Linux

