### PR TITLE
fix(better_networking): resolve incorrect index mapping in getEnabledRows for duplicate rows

### DIFF
--- a/packages/better_networking/lib/utils/http_request_utils.dart
+++ b/packages/better_networking/lib/utils/http_request_utils.dart
@@ -81,7 +81,10 @@ List<NameValueModel>? getEnabledRows(
     return rows;
   }
   List<NameValueModel> finalRows = rows
-      .where((element) => isRowEnabledList[rows.indexOf(element)])
+      .asMap()
+      .entries
+      .where((entry) => isRowEnabledList[entry.key])
+      .map((entry) => entry.value)
       .toList();
   return finalRows == [] ? null : finalRows;
 }

--- a/packages/better_networking/test/utils/http_request_utils_test.dart
+++ b/packages/better_networking/test/utils/http_request_utils_test.dart
@@ -197,6 +197,16 @@ void main() {
         [kvRow1, kvRow3],
       );
     });
+    test('Testing duplicate rows with different enabled flags', () {
+      const dupRow = NameValueModel(name: "code", value: "IN");
+      expect(
+        getEnabledRows(
+          [dupRow, dupRow],
+          [true, false],
+        ),
+        [dupRow],
+      );
+    });
   });
 
   group('Testing getRequestBody', () {


### PR DESCRIPTION
## PR Description

Replaced `rows.indexOf(element)` with `asMap().entries` based iteration in `getEnabledRows` so that duplicate rows map to their own position index instead of reusing the first match's index.

## Related Issues

- Closes #1441

### Checklist
- [x] I have gone through the contributing guide
- [x] I have updated my branch and synced it with project `main` branch before making this PR

## Added/updated tests?

- [x] Yes

## OS on which you have developed and tested the feature?

- [x] Windows