### PR TITLE
fix(design-system): implement missing ADListTile checkbox/button variants

### DIFF
--- a/packages/apidash_design_system/lib/widgets/list_tile.dart
+++ b/packages/apidash_design_system/lib/widgets/list_tile.dart
@@ -33,10 +33,19 @@ class ADListTile extends StatelessWidget {
           value: value ?? false,
           onChanged: onChanged,
         ),
-      // TODO: Handle this case.
-      ListTileType.checkbox => throw UnimplementedError(),
-      // TODO: Handle this case.
-      ListTileType.button => throw UnimplementedError(),
+      ListTileType.checkbox => CheckboxListTile(
+          hoverColor: hoverColor,
+          title: Text(title),
+          subtitle: subtitle == null ? null : Text(subtitle ?? ''),
+          value: value ?? false,
+          onChanged: onChanged,
+        ),
+      ListTileType.button => ListTile(
+          hoverColor: hoverColor,
+          title: Text(title),
+          subtitle: subtitle == null ? null : Text(subtitle ?? ''),
+          onTap: () => onChanged?.call(value),
+        ),
     };
   }
 }

--- a/packages/apidash_design_system/test/widgets/list_tile_test.dart
+++ b/packages/apidash_design_system/test/widgets/list_tile_test.dart
@@ -1,0 +1,70 @@
+import 'package:apidash_design_system/widgets/list_tile.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ADListTile', () {
+    testWidgets('switchOnOff renders and triggers onChanged', (tester) async {
+      bool? changedValue;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ADListTile(
+              type: ListTileType.switchOnOff,
+              title: 'Switch Tile',
+              value: false,
+              onChanged: (value) => changedValue = value,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Switch Tile'), findsOneWidget);
+      await tester.tap(find.byType(Switch));
+      await tester.pumpAndSettle();
+      expect(changedValue, true);
+    });
+
+    testWidgets('checkbox renders and triggers onChanged', (tester) async {
+      bool? changedValue;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ADListTile(
+              type: ListTileType.checkbox,
+              title: 'Checkbox Tile',
+              value: false,
+              onChanged: (value) => changedValue = value,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Checkbox Tile'), findsOneWidget);
+      await tester.tap(find.byType(Checkbox));
+      await tester.pumpAndSettle();
+      expect(changedValue, true);
+    });
+
+    testWidgets('button renders and triggers onChanged on tap', (tester) async {
+      bool? changedValue;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ADListTile(
+              type: ListTileType.button,
+              title: 'Button Tile',
+              value: true,
+              onChanged: (value) => changedValue = value,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Button Tile'), findsOneWidget);
+      await tester.tap(find.byType(ListTile));
+      await tester.pumpAndSettle();
+      expect(changedValue, true);
+    });
+  });
+}


### PR DESCRIPTION
## PR Description
Implemented missing `checkbox` and `button` variants in `ADListTile` that were throwing `UnimplementedError`.

- `checkbox` → `CheckboxListTile` wired to existing `value/onChanged`
- `button` → `ListTile` with `onTap` triggering `onChanged?.call(value)`

Added widget tests for all 3 modes.

## Related Issues
- Closes #1435

## Added/updated tests?
- [x] Yes

## OS
- [x] Windows
