### PR TITLE
feat(request-body): add application/x-www-form-urlencoded body type (#337)

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -139,7 +139,7 @@ class DashApp extends ConsumerWidget {
               )
             : //Stack(
               //  children: [
-                  !kIsLinux && !kIsMobile
+                      kIsDesktop && !kIsLinux
                       ? const App()
                       : context.isMediumWindow
                           ? (kIsMobile && !userOnboarded)

--- a/lib/codegen/dart/dio.dart
+++ b/lib/codegen/dart/dio.dart
@@ -82,6 +82,10 @@ class DartDioCodeGen {
               .assign(refer('convert.json.decode').call([strContent]));
         case ContentType.text:
           dataExp = declareFinal('data').assign(strContent);
+        case ContentType.formUrlEncoded:
+          dataExp = declareFinal('data').assign(
+            literalMap({for (var e in formData) e['name']: e['value']}),
+          );
         // when add new type of [ContentType], need update [dataExp].
         case ContentType.formdata:
           dataExp = declareFinal('data').assign(refer('dio.FormData()'));

--- a/lib/providers/js_runtime_adapter.dart
+++ b/lib/providers/js_runtime_adapter.dart
@@ -1,0 +1,2 @@
+export 'js_runtime_adapter_io.dart'
+    if (dart.library.html) 'js_runtime_adapter_web.dart';

--- a/lib/providers/js_runtime_adapter_io.dart
+++ b/lib/providers/js_runtime_adapter_io.dart
@@ -1,0 +1,6 @@
+import 'package:flutter_js/flutter_js.dart';
+
+typedef JsRuntimeAdapter = JavascriptRuntime;
+typedef JsEvalResultAdapter = JsEvalResult;
+
+JsRuntimeAdapter createJsRuntime() => getJavascriptRuntime();

--- a/lib/providers/js_runtime_adapter_web.dart
+++ b/lib/providers/js_runtime_adapter_web.dart
@@ -1,0 +1,27 @@
+class JsEvalResultAdapter {
+  const JsEvalResultAdapter({
+    required this.isError,
+    required this.stringResult,
+  });
+
+  final bool isError;
+  final String stringResult;
+}
+
+typedef JsMessageHandler = void Function(dynamic args);
+
+class JsRuntimeAdapter {
+  JsEvalResultAdapter evaluate(String code) {
+    return const JsEvalResultAdapter(
+      isError: true,
+      stringResult:
+          'JavaScript scripting is not supported on web target in this build.',
+    );
+  }
+
+  void onMessage(String channel, JsMessageHandler handler) {}
+
+  void dispose() {}
+}
+
+JsRuntimeAdapter createJsRuntime() => JsRuntimeAdapter();

--- a/lib/providers/js_runtime_notifier.dart
+++ b/lib/providers/js_runtime_notifier.dart
@@ -1,9 +1,9 @@
 import 'dart:convert';
 import 'package:apidash_core/apidash_core.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_js/flutter_js.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
+import 'js_runtime_adapter.dart';
 import '../models/models.dart';
 import '../utils/utils.dart';
 import '../providers/terminal_providers.dart';
@@ -41,12 +41,12 @@ class JsRuntimeNotifier extends StateNotifier<JsRuntimeState> {
   JsRuntimeNotifier(this.ref) : super(const JsRuntimeState());
 
   final Ref ref;
-  late final JavascriptRuntime _runtime;
+  late final JsRuntimeAdapter _runtime;
   String? _currentRequestId;
 
   void _initialize() {
     if (state.initialized) return;
-    _runtime = getJavascriptRuntime();
+    _runtime = createJsRuntime();
     _setupJsBridge();
     state = state.copyWith(initialized: true);
   }
@@ -64,7 +64,7 @@ class JsRuntimeNotifier extends StateNotifier<JsRuntimeState> {
     super.dispose();
   }
 
-  JsEvalResult evaluate(String code) {
+  JsEvalResultAdapter evaluate(String code) {
     // If disposed, prevent usage
     if (!mounted) {
       throw StateError('JsRuntimeNotifier used after dispose');

--- a/lib/screens/history/history_widgets/his_request_pane.dart
+++ b/lib/screens/history/history_widgets/his_request_pane.dart
@@ -203,7 +203,8 @@ class HisRequestBody extends ConsumerWidget {
           kVSpacer5,
           Expanded(
             child: switch (contentType) {
-              ContentType.formdata => Padding(
+              ContentType.formdata ||
+              ContentType.formUrlEncoded => Padding(
                 padding: kPh4,
                 child: RequestFormDataTable(rows: requestModel?.formData ?? []),
               ),

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/request_body.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/request_body.dart
@@ -45,7 +45,8 @@ class EditRequestBody extends ConsumerWidget {
         switch (apiType) {
           APIType.rest => Expanded(
             child: switch (contentType) {
-              ContentType.formdata => const Padding(
+              ContentType.formdata ||
+              ContentType.formUrlEncoded => const Padding(
                 padding: kPh4,
                 child: FormDataWidget(),
               ),

--- a/packages/better_networking/lib/consts.dart
+++ b/packages/better_networking/lib/consts.dart
@@ -165,7 +165,8 @@ List<String> kStreamingResponseTypes = [
 enum ContentType {
   json("$kTypeApplication/$kSubTypeJson"),
   text("$kTypeText/$kSubTypePlain"),
-  formdata("$kTypeMultipart/$kSubTypeFormData");
+  formdata("$kTypeMultipart/$kSubTypeFormData"),
+  formUrlEncoded("$kTypeApplication/$kSubTypeXWwwFormUrlencoded");
 
   const ContentType(this.header);
   final String header;

--- a/packages/better_networking/lib/models/auth/api_auth_model.freezed.dart
+++ b/packages/better_networking/lib/models/auth/api_auth_model.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,52 +9,70 @@ part of 'api_auth_model.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
-
-AuthModel _$AuthModelFromJson(Map<String, dynamic> json) {
-  return _AuthModel.fromJson(json);
-}
 
 /// @nodoc
 mixin _$AuthModel {
-  APIAuthType get type => throw _privateConstructorUsedError;
-  AuthApiKeyModel? get apikey => throw _privateConstructorUsedError;
-  AuthBearerModel? get bearer => throw _privateConstructorUsedError;
-  AuthBasicAuthModel? get basic => throw _privateConstructorUsedError;
-  AuthJwtModel? get jwt => throw _privateConstructorUsedError;
-  AuthDigestModel? get digest => throw _privateConstructorUsedError;
-  AuthOAuth1Model? get oauth1 => throw _privateConstructorUsedError;
-  AuthOAuth2Model? get oauth2 => throw _privateConstructorUsedError;
-
-  /// Serializes this AuthModel to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  APIAuthType get type;
+  AuthApiKeyModel? get apikey;
+  AuthBearerModel? get bearer;
+  AuthBasicAuthModel? get basic;
+  AuthJwtModel? get jwt;
+  AuthDigestModel? get digest;
+  AuthOAuth1Model? get oauth1;
+  AuthOAuth2Model? get oauth2;
 
   /// Create a copy of AuthModel
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $AuthModelCopyWith<AuthModel> get copyWith =>
-      throw _privateConstructorUsedError;
+      _$AuthModelCopyWithImpl<AuthModel>(this as AuthModel, _$identity);
+
+  /// Serializes this AuthModel to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is AuthModel &&
+            (identical(other.type, type) || other.type == type) &&
+            (identical(other.apikey, apikey) || other.apikey == apikey) &&
+            (identical(other.bearer, bearer) || other.bearer == bearer) &&
+            (identical(other.basic, basic) || other.basic == basic) &&
+            (identical(other.jwt, jwt) || other.jwt == jwt) &&
+            (identical(other.digest, digest) || other.digest == digest) &&
+            (identical(other.oauth1, oauth1) || other.oauth1 == oauth1) &&
+            (identical(other.oauth2, oauth2) || other.oauth2 == oauth2));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, type, apikey, bearer, basic, jwt, digest, oauth1, oauth2);
+
+  @override
+  String toString() {
+    return 'AuthModel(type: $type, apikey: $apikey, bearer: $bearer, basic: $basic, jwt: $jwt, digest: $digest, oauth1: $oauth1, oauth2: $oauth2)';
+  }
 }
 
 /// @nodoc
-abstract class $AuthModelCopyWith<$Res> {
-  factory $AuthModelCopyWith(AuthModel value, $Res Function(AuthModel) then) =
-      _$AuthModelCopyWithImpl<$Res, AuthModel>;
+abstract mixin class $AuthModelCopyWith<$Res> {
+  factory $AuthModelCopyWith(AuthModel value, $Res Function(AuthModel) _then) =
+      _$AuthModelCopyWithImpl;
   @useResult
-  $Res call({
-    APIAuthType type,
-    AuthApiKeyModel? apikey,
-    AuthBearerModel? bearer,
-    AuthBasicAuthModel? basic,
-    AuthJwtModel? jwt,
-    AuthDigestModel? digest,
-    AuthOAuth1Model? oauth1,
-    AuthOAuth2Model? oauth2,
-  });
+  $Res call(
+      {APIAuthType type,
+      AuthApiKeyModel? apikey,
+      AuthBearerModel? bearer,
+      AuthBasicAuthModel? basic,
+      AuthJwtModel? jwt,
+      AuthDigestModel? digest,
+      AuthOAuth1Model? oauth1,
+      AuthOAuth2Model? oauth2});
 
   $AuthApiKeyModelCopyWith<$Res>? get apikey;
   $AuthBearerModelCopyWith<$Res>? get bearer;
@@ -66,14 +84,11 @@ abstract class $AuthModelCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$AuthModelCopyWithImpl<$Res, $Val extends AuthModel>
-    implements $AuthModelCopyWith<$Res> {
-  _$AuthModelCopyWithImpl(this._value, this._then);
+class _$AuthModelCopyWithImpl<$Res> implements $AuthModelCopyWith<$Res> {
+  _$AuthModelCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final AuthModel _self;
+  final $Res Function(AuthModel) _then;
 
   /// Create a copy of AuthModel
   /// with the given fields replaced by the non-null parameter values.
@@ -89,43 +104,40 @@ class _$AuthModelCopyWithImpl<$Res, $Val extends AuthModel>
     Object? oauth1 = freezed,
     Object? oauth2 = freezed,
   }) {
-    return _then(
-      _value.copyWith(
-            type: null == type
-                ? _value.type
-                : type // ignore: cast_nullable_to_non_nullable
-                      as APIAuthType,
-            apikey: freezed == apikey
-                ? _value.apikey
-                : apikey // ignore: cast_nullable_to_non_nullable
-                      as AuthApiKeyModel?,
-            bearer: freezed == bearer
-                ? _value.bearer
-                : bearer // ignore: cast_nullable_to_non_nullable
-                      as AuthBearerModel?,
-            basic: freezed == basic
-                ? _value.basic
-                : basic // ignore: cast_nullable_to_non_nullable
-                      as AuthBasicAuthModel?,
-            jwt: freezed == jwt
-                ? _value.jwt
-                : jwt // ignore: cast_nullable_to_non_nullable
-                      as AuthJwtModel?,
-            digest: freezed == digest
-                ? _value.digest
-                : digest // ignore: cast_nullable_to_non_nullable
-                      as AuthDigestModel?,
-            oauth1: freezed == oauth1
-                ? _value.oauth1
-                : oauth1 // ignore: cast_nullable_to_non_nullable
-                      as AuthOAuth1Model?,
-            oauth2: freezed == oauth2
-                ? _value.oauth2
-                : oauth2 // ignore: cast_nullable_to_non_nullable
-                      as AuthOAuth2Model?,
-          )
-          as $Val,
-    );
+    return _then(_self.copyWith(
+      type: null == type
+          ? _self.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as APIAuthType,
+      apikey: freezed == apikey
+          ? _self.apikey
+          : apikey // ignore: cast_nullable_to_non_nullable
+              as AuthApiKeyModel?,
+      bearer: freezed == bearer
+          ? _self.bearer
+          : bearer // ignore: cast_nullable_to_non_nullable
+              as AuthBearerModel?,
+      basic: freezed == basic
+          ? _self.basic
+          : basic // ignore: cast_nullable_to_non_nullable
+              as AuthBasicAuthModel?,
+      jwt: freezed == jwt
+          ? _self.jwt
+          : jwt // ignore: cast_nullable_to_non_nullable
+              as AuthJwtModel?,
+      digest: freezed == digest
+          ? _self.digest
+          : digest // ignore: cast_nullable_to_non_nullable
+              as AuthDigestModel?,
+      oauth1: freezed == oauth1
+          ? _self.oauth1
+          : oauth1 // ignore: cast_nullable_to_non_nullable
+              as AuthOAuth1Model?,
+      oauth2: freezed == oauth2
+          ? _self.oauth2
+          : oauth2 // ignore: cast_nullable_to_non_nullable
+              as AuthOAuth2Model?,
+    ));
   }
 
   /// Create a copy of AuthModel
@@ -133,12 +145,12 @@ class _$AuthModelCopyWithImpl<$Res, $Val extends AuthModel>
   @override
   @pragma('vm:prefer-inline')
   $AuthApiKeyModelCopyWith<$Res>? get apikey {
-    if (_value.apikey == null) {
+    if (_self.apikey == null) {
       return null;
     }
 
-    return $AuthApiKeyModelCopyWith<$Res>(_value.apikey!, (value) {
-      return _then(_value.copyWith(apikey: value) as $Val);
+    return $AuthApiKeyModelCopyWith<$Res>(_self.apikey!, (value) {
+      return _then(_self.copyWith(apikey: value));
     });
   }
 
@@ -147,12 +159,12 @@ class _$AuthModelCopyWithImpl<$Res, $Val extends AuthModel>
   @override
   @pragma('vm:prefer-inline')
   $AuthBearerModelCopyWith<$Res>? get bearer {
-    if (_value.bearer == null) {
+    if (_self.bearer == null) {
       return null;
     }
 
-    return $AuthBearerModelCopyWith<$Res>(_value.bearer!, (value) {
-      return _then(_value.copyWith(bearer: value) as $Val);
+    return $AuthBearerModelCopyWith<$Res>(_self.bearer!, (value) {
+      return _then(_self.copyWith(bearer: value));
     });
   }
 
@@ -161,12 +173,12 @@ class _$AuthModelCopyWithImpl<$Res, $Val extends AuthModel>
   @override
   @pragma('vm:prefer-inline')
   $AuthBasicAuthModelCopyWith<$Res>? get basic {
-    if (_value.basic == null) {
+    if (_self.basic == null) {
       return null;
     }
 
-    return $AuthBasicAuthModelCopyWith<$Res>(_value.basic!, (value) {
-      return _then(_value.copyWith(basic: value) as $Val);
+    return $AuthBasicAuthModelCopyWith<$Res>(_self.basic!, (value) {
+      return _then(_self.copyWith(basic: value));
     });
   }
 
@@ -175,12 +187,12 @@ class _$AuthModelCopyWithImpl<$Res, $Val extends AuthModel>
   @override
   @pragma('vm:prefer-inline')
   $AuthJwtModelCopyWith<$Res>? get jwt {
-    if (_value.jwt == null) {
+    if (_self.jwt == null) {
       return null;
     }
 
-    return $AuthJwtModelCopyWith<$Res>(_value.jwt!, (value) {
-      return _then(_value.copyWith(jwt: value) as $Val);
+    return $AuthJwtModelCopyWith<$Res>(_self.jwt!, (value) {
+      return _then(_self.copyWith(jwt: value));
     });
   }
 
@@ -189,12 +201,12 @@ class _$AuthModelCopyWithImpl<$Res, $Val extends AuthModel>
   @override
   @pragma('vm:prefer-inline')
   $AuthDigestModelCopyWith<$Res>? get digest {
-    if (_value.digest == null) {
+    if (_self.digest == null) {
       return null;
     }
 
-    return $AuthDigestModelCopyWith<$Res>(_value.digest!, (value) {
-      return _then(_value.copyWith(digest: value) as $Val);
+    return $AuthDigestModelCopyWith<$Res>(_self.digest!, (value) {
+      return _then(_self.copyWith(digest: value));
     });
   }
 
@@ -203,12 +215,12 @@ class _$AuthModelCopyWithImpl<$Res, $Val extends AuthModel>
   @override
   @pragma('vm:prefer-inline')
   $AuthOAuth1ModelCopyWith<$Res>? get oauth1 {
-    if (_value.oauth1 == null) {
+    if (_self.oauth1 == null) {
       return null;
     }
 
-    return $AuthOAuth1ModelCopyWith<$Res>(_value.oauth1!, (value) {
-      return _then(_value.copyWith(oauth1: value) as $Val);
+    return $AuthOAuth1ModelCopyWith<$Res>(_self.oauth1!, (value) {
+      return _then(_self.copyWith(oauth1: value));
     });
   }
 
@@ -217,131 +229,218 @@ class _$AuthModelCopyWithImpl<$Res, $Val extends AuthModel>
   @override
   @pragma('vm:prefer-inline')
   $AuthOAuth2ModelCopyWith<$Res>? get oauth2 {
-    if (_value.oauth2 == null) {
+    if (_self.oauth2 == null) {
       return null;
     }
 
-    return $AuthOAuth2ModelCopyWith<$Res>(_value.oauth2!, (value) {
-      return _then(_value.copyWith(oauth2: value) as $Val);
+    return $AuthOAuth2ModelCopyWith<$Res>(_self.oauth2!, (value) {
+      return _then(_self.copyWith(oauth2: value));
     });
   }
 }
 
-/// @nodoc
-abstract class _$$AuthModelImplCopyWith<$Res>
-    implements $AuthModelCopyWith<$Res> {
-  factory _$$AuthModelImplCopyWith(
-    _$AuthModelImpl value,
-    $Res Function(_$AuthModelImpl) then,
-  ) = __$$AuthModelImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({
-    APIAuthType type,
-    AuthApiKeyModel? apikey,
-    AuthBearerModel? bearer,
-    AuthBasicAuthModel? basic,
-    AuthJwtModel? jwt,
-    AuthDigestModel? digest,
-    AuthOAuth1Model? oauth1,
-    AuthOAuth2Model? oauth2,
-  });
+/// Adds pattern-matching-related methods to [AuthModel].
+extension AuthModelPatterns on AuthModel {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
 
-  @override
-  $AuthApiKeyModelCopyWith<$Res>? get apikey;
-  @override
-  $AuthBearerModelCopyWith<$Res>? get bearer;
-  @override
-  $AuthBasicAuthModelCopyWith<$Res>? get basic;
-  @override
-  $AuthJwtModelCopyWith<$Res>? get jwt;
-  @override
-  $AuthDigestModelCopyWith<$Res>? get digest;
-  @override
-  $AuthOAuth1ModelCopyWith<$Res>? get oauth1;
-  @override
-  $AuthOAuth2ModelCopyWith<$Res>? get oauth2;
-}
-
-/// @nodoc
-class __$$AuthModelImplCopyWithImpl<$Res>
-    extends _$AuthModelCopyWithImpl<$Res, _$AuthModelImpl>
-    implements _$$AuthModelImplCopyWith<$Res> {
-  __$$AuthModelImplCopyWithImpl(
-    _$AuthModelImpl _value,
-    $Res Function(_$AuthModelImpl) _then,
-  ) : super(_value, _then);
-
-  /// Create a copy of AuthModel
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? type = null,
-    Object? apikey = freezed,
-    Object? bearer = freezed,
-    Object? basic = freezed,
-    Object? jwt = freezed,
-    Object? digest = freezed,
-    Object? oauth1 = freezed,
-    Object? oauth2 = freezed,
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_AuthModel value)? $default, {
+    required TResult orElse(),
   }) {
-    return _then(
-      _$AuthModelImpl(
-        type: null == type
-            ? _value.type
-            : type // ignore: cast_nullable_to_non_nullable
-                  as APIAuthType,
-        apikey: freezed == apikey
-            ? _value.apikey
-            : apikey // ignore: cast_nullable_to_non_nullable
-                  as AuthApiKeyModel?,
-        bearer: freezed == bearer
-            ? _value.bearer
-            : bearer // ignore: cast_nullable_to_non_nullable
-                  as AuthBearerModel?,
-        basic: freezed == basic
-            ? _value.basic
-            : basic // ignore: cast_nullable_to_non_nullable
-                  as AuthBasicAuthModel?,
-        jwt: freezed == jwt
-            ? _value.jwt
-            : jwt // ignore: cast_nullable_to_non_nullable
-                  as AuthJwtModel?,
-        digest: freezed == digest
-            ? _value.digest
-            : digest // ignore: cast_nullable_to_non_nullable
-                  as AuthDigestModel?,
-        oauth1: freezed == oauth1
-            ? _value.oauth1
-            : oauth1 // ignore: cast_nullable_to_non_nullable
-                  as AuthOAuth1Model?,
-        oauth2: freezed == oauth2
-            ? _value.oauth2
-            : oauth2 // ignore: cast_nullable_to_non_nullable
-                  as AuthOAuth2Model?,
-      ),
-    );
+    final _that = this;
+    switch (_that) {
+      case _AuthModel() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_AuthModel value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthModel():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_AuthModel value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthModel() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            APIAuthType type,
+            AuthApiKeyModel? apikey,
+            AuthBearerModel? bearer,
+            AuthBasicAuthModel? basic,
+            AuthJwtModel? jwt,
+            AuthDigestModel? digest,
+            AuthOAuth1Model? oauth1,
+            AuthOAuth2Model? oauth2)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _AuthModel() when $default != null:
+        return $default(_that.type, _that.apikey, _that.bearer, _that.basic,
+            _that.jwt, _that.digest, _that.oauth1, _that.oauth2);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            APIAuthType type,
+            AuthApiKeyModel? apikey,
+            AuthBearerModel? bearer,
+            AuthBasicAuthModel? basic,
+            AuthJwtModel? jwt,
+            AuthDigestModel? digest,
+            AuthOAuth1Model? oauth1,
+            AuthOAuth2Model? oauth2)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthModel():
+        return $default(_that.type, _that.apikey, _that.bearer, _that.basic,
+            _that.jwt, _that.digest, _that.oauth1, _that.oauth2);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            APIAuthType type,
+            AuthApiKeyModel? apikey,
+            AuthBearerModel? bearer,
+            AuthBasicAuthModel? basic,
+            AuthJwtModel? jwt,
+            AuthDigestModel? digest,
+            AuthOAuth1Model? oauth1,
+            AuthOAuth2Model? oauth2)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthModel() when $default != null:
+        return $default(_that.type, _that.apikey, _that.bearer, _that.basic,
+            _that.jwt, _that.digest, _that.oauth1, _that.oauth2);
+      case _:
+        return null;
+    }
   }
 }
 
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true, anyMap: true)
-class _$AuthModelImpl implements _AuthModel {
-  const _$AuthModelImpl({
-    required this.type,
-    this.apikey,
-    this.bearer,
-    this.basic,
-    this.jwt,
-    this.digest,
-    this.oauth1,
-    this.oauth2,
-  });
-
-  factory _$AuthModelImpl.fromJson(Map<String, dynamic> json) =>
-      _$$AuthModelImplFromJson(json);
+class _AuthModel implements AuthModel {
+  const _AuthModel(
+      {required this.type,
+      this.apikey,
+      this.bearer,
+      this.basic,
+      this.jwt,
+      this.digest,
+      this.oauth1,
+      this.oauth2});
+  factory _AuthModel.fromJson(Map<String, dynamic> json) =>
+      _$AuthModelFromJson(json);
 
   @override
   final APIAuthType type;
@@ -360,16 +459,26 @@ class _$AuthModelImpl implements _AuthModel {
   @override
   final AuthOAuth2Model? oauth2;
 
+  /// Create a copy of AuthModel
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'AuthModel(type: $type, apikey: $apikey, bearer: $bearer, basic: $basic, jwt: $jwt, digest: $digest, oauth1: $oauth1, oauth2: $oauth2)';
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$AuthModelCopyWith<_AuthModel> get copyWith =>
+      __$AuthModelCopyWithImpl<_AuthModel>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$AuthModelToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AuthModelImpl &&
+            other is _AuthModel &&
             (identical(other.type, type) || other.type == type) &&
             (identical(other.apikey, apikey) || other.apikey == apikey) &&
             (identical(other.bearer, bearer) || other.bearer == bearer) &&
@@ -383,67 +492,202 @@ class _$AuthModelImpl implements _AuthModel {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
-    runtimeType,
-    type,
-    apikey,
-    bearer,
-    basic,
-    jwt,
-    digest,
-    oauth1,
-    oauth2,
-  );
-
-  /// Create a copy of AuthModel
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$AuthModelImplCopyWith<_$AuthModelImpl> get copyWith =>
-      __$$AuthModelImplCopyWithImpl<_$AuthModelImpl>(this, _$identity);
+      runtimeType, type, apikey, bearer, basic, jwt, digest, oauth1, oauth2);
 
   @override
-  Map<String, dynamic> toJson() {
-    return _$$AuthModelImplToJson(this);
+  String toString() {
+    return 'AuthModel(type: $type, apikey: $apikey, bearer: $bearer, basic: $basic, jwt: $jwt, digest: $digest, oauth1: $oauth1, oauth2: $oauth2)';
   }
 }
 
-abstract class _AuthModel implements AuthModel {
-  const factory _AuthModel({
-    required final APIAuthType type,
-    final AuthApiKeyModel? apikey,
-    final AuthBearerModel? bearer,
-    final AuthBasicAuthModel? basic,
-    final AuthJwtModel? jwt,
-    final AuthDigestModel? digest,
-    final AuthOAuth1Model? oauth1,
-    final AuthOAuth2Model? oauth2,
-  }) = _$AuthModelImpl;
+/// @nodoc
+abstract mixin class _$AuthModelCopyWith<$Res>
+    implements $AuthModelCopyWith<$Res> {
+  factory _$AuthModelCopyWith(
+          _AuthModel value, $Res Function(_AuthModel) _then) =
+      __$AuthModelCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {APIAuthType type,
+      AuthApiKeyModel? apikey,
+      AuthBearerModel? bearer,
+      AuthBasicAuthModel? basic,
+      AuthJwtModel? jwt,
+      AuthDigestModel? digest,
+      AuthOAuth1Model? oauth1,
+      AuthOAuth2Model? oauth2});
 
-  factory _AuthModel.fromJson(Map<String, dynamic> json) =
-      _$AuthModelImpl.fromJson;
+  @override
+  $AuthApiKeyModelCopyWith<$Res>? get apikey;
+  @override
+  $AuthBearerModelCopyWith<$Res>? get bearer;
+  @override
+  $AuthBasicAuthModelCopyWith<$Res>? get basic;
+  @override
+  $AuthJwtModelCopyWith<$Res>? get jwt;
+  @override
+  $AuthDigestModelCopyWith<$Res>? get digest;
+  @override
+  $AuthOAuth1ModelCopyWith<$Res>? get oauth1;
+  @override
+  $AuthOAuth2ModelCopyWith<$Res>? get oauth2;
+}
 
-  @override
-  APIAuthType get type;
-  @override
-  AuthApiKeyModel? get apikey;
-  @override
-  AuthBearerModel? get bearer;
-  @override
-  AuthBasicAuthModel? get basic;
-  @override
-  AuthJwtModel? get jwt;
-  @override
-  AuthDigestModel? get digest;
-  @override
-  AuthOAuth1Model? get oauth1;
-  @override
-  AuthOAuth2Model? get oauth2;
+/// @nodoc
+class __$AuthModelCopyWithImpl<$Res> implements _$AuthModelCopyWith<$Res> {
+  __$AuthModelCopyWithImpl(this._self, this._then);
+
+  final _AuthModel _self;
+  final $Res Function(_AuthModel) _then;
 
   /// Create a copy of AuthModel
   /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$AuthModelImplCopyWith<_$AuthModelImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? type = null,
+    Object? apikey = freezed,
+    Object? bearer = freezed,
+    Object? basic = freezed,
+    Object? jwt = freezed,
+    Object? digest = freezed,
+    Object? oauth1 = freezed,
+    Object? oauth2 = freezed,
+  }) {
+    return _then(_AuthModel(
+      type: null == type
+          ? _self.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as APIAuthType,
+      apikey: freezed == apikey
+          ? _self.apikey
+          : apikey // ignore: cast_nullable_to_non_nullable
+              as AuthApiKeyModel?,
+      bearer: freezed == bearer
+          ? _self.bearer
+          : bearer // ignore: cast_nullable_to_non_nullable
+              as AuthBearerModel?,
+      basic: freezed == basic
+          ? _self.basic
+          : basic // ignore: cast_nullable_to_non_nullable
+              as AuthBasicAuthModel?,
+      jwt: freezed == jwt
+          ? _self.jwt
+          : jwt // ignore: cast_nullable_to_non_nullable
+              as AuthJwtModel?,
+      digest: freezed == digest
+          ? _self.digest
+          : digest // ignore: cast_nullable_to_non_nullable
+              as AuthDigestModel?,
+      oauth1: freezed == oauth1
+          ? _self.oauth1
+          : oauth1 // ignore: cast_nullable_to_non_nullable
+              as AuthOAuth1Model?,
+      oauth2: freezed == oauth2
+          ? _self.oauth2
+          : oauth2 // ignore: cast_nullable_to_non_nullable
+              as AuthOAuth2Model?,
+    ));
+  }
+
+  /// Create a copy of AuthModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $AuthApiKeyModelCopyWith<$Res>? get apikey {
+    if (_self.apikey == null) {
+      return null;
+    }
+
+    return $AuthApiKeyModelCopyWith<$Res>(_self.apikey!, (value) {
+      return _then(_self.copyWith(apikey: value));
+    });
+  }
+
+  /// Create a copy of AuthModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $AuthBearerModelCopyWith<$Res>? get bearer {
+    if (_self.bearer == null) {
+      return null;
+    }
+
+    return $AuthBearerModelCopyWith<$Res>(_self.bearer!, (value) {
+      return _then(_self.copyWith(bearer: value));
+    });
+  }
+
+  /// Create a copy of AuthModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $AuthBasicAuthModelCopyWith<$Res>? get basic {
+    if (_self.basic == null) {
+      return null;
+    }
+
+    return $AuthBasicAuthModelCopyWith<$Res>(_self.basic!, (value) {
+      return _then(_self.copyWith(basic: value));
+    });
+  }
+
+  /// Create a copy of AuthModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $AuthJwtModelCopyWith<$Res>? get jwt {
+    if (_self.jwt == null) {
+      return null;
+    }
+
+    return $AuthJwtModelCopyWith<$Res>(_self.jwt!, (value) {
+      return _then(_self.copyWith(jwt: value));
+    });
+  }
+
+  /// Create a copy of AuthModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $AuthDigestModelCopyWith<$Res>? get digest {
+    if (_self.digest == null) {
+      return null;
+    }
+
+    return $AuthDigestModelCopyWith<$Res>(_self.digest!, (value) {
+      return _then(_self.copyWith(digest: value));
+    });
+  }
+
+  /// Create a copy of AuthModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $AuthOAuth1ModelCopyWith<$Res>? get oauth1 {
+    if (_self.oauth1 == null) {
+      return null;
+    }
+
+    return $AuthOAuth1ModelCopyWith<$Res>(_self.oauth1!, (value) {
+      return _then(_self.copyWith(oauth1: value));
+    });
+  }
+
+  /// Create a copy of AuthModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $AuthOAuth2ModelCopyWith<$Res>? get oauth2 {
+    if (_self.oauth2 == null) {
+      return null;
+    }
+
+    return $AuthOAuth2ModelCopyWith<$Res>(_self.oauth2!, (value) {
+      return _then(_self.copyWith(oauth2: value));
+    });
+  }
 }
+
+// dart format on

--- a/packages/better_networking/lib/models/auth/api_auth_model.g.dart
+++ b/packages/better_networking/lib/models/auth/api_auth_model.g.dart
@@ -6,44 +6,39 @@ part of 'api_auth_model.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$AuthModelImpl _$$AuthModelImplFromJson(Map json) => _$AuthModelImpl(
-  type: $enumDecode(_$APIAuthTypeEnumMap, json['type']),
-  apikey: json['apikey'] == null
-      ? null
-      : AuthApiKeyModel.fromJson(
-          Map<String, dynamic>.from(json['apikey'] as Map),
-        ),
-  bearer: json['bearer'] == null
-      ? null
-      : AuthBearerModel.fromJson(
-          Map<String, dynamic>.from(json['bearer'] as Map),
-        ),
-  basic: json['basic'] == null
-      ? null
-      : AuthBasicAuthModel.fromJson(
-          Map<String, dynamic>.from(json['basic'] as Map),
-        ),
-  jwt: json['jwt'] == null
-      ? null
-      : AuthJwtModel.fromJson(Map<String, dynamic>.from(json['jwt'] as Map)),
-  digest: json['digest'] == null
-      ? null
-      : AuthDigestModel.fromJson(
-          Map<String, dynamic>.from(json['digest'] as Map),
-        ),
-  oauth1: json['oauth1'] == null
-      ? null
-      : AuthOAuth1Model.fromJson(
-          Map<String, dynamic>.from(json['oauth1'] as Map),
-        ),
-  oauth2: json['oauth2'] == null
-      ? null
-      : AuthOAuth2Model.fromJson(
-          Map<String, dynamic>.from(json['oauth2'] as Map),
-        ),
-);
+_AuthModel _$AuthModelFromJson(Map json) => _AuthModel(
+      type: $enumDecode(_$APIAuthTypeEnumMap, json['type']),
+      apikey: json['apikey'] == null
+          ? null
+          : AuthApiKeyModel.fromJson(
+              Map<String, dynamic>.from(json['apikey'] as Map)),
+      bearer: json['bearer'] == null
+          ? null
+          : AuthBearerModel.fromJson(
+              Map<String, dynamic>.from(json['bearer'] as Map)),
+      basic: json['basic'] == null
+          ? null
+          : AuthBasicAuthModel.fromJson(
+              Map<String, dynamic>.from(json['basic'] as Map)),
+      jwt: json['jwt'] == null
+          ? null
+          : AuthJwtModel.fromJson(
+              Map<String, dynamic>.from(json['jwt'] as Map)),
+      digest: json['digest'] == null
+          ? null
+          : AuthDigestModel.fromJson(
+              Map<String, dynamic>.from(json['digest'] as Map)),
+      oauth1: json['oauth1'] == null
+          ? null
+          : AuthOAuth1Model.fromJson(
+              Map<String, dynamic>.from(json['oauth1'] as Map)),
+      oauth2: json['oauth2'] == null
+          ? null
+          : AuthOAuth2Model.fromJson(
+              Map<String, dynamic>.from(json['oauth2'] as Map)),
+    );
 
-Map<String, dynamic> _$$AuthModelImplToJson(_$AuthModelImpl instance) =>
+Map<String, dynamic> _$AuthModelToJson(_AuthModel instance) =>
     <String, dynamic>{
       'type': _$APIAuthTypeEnumMap[instance.type]!,
       'apikey': instance.apikey?.toJson(),

--- a/packages/better_networking/lib/models/auth/auth_api_key_model.freezed.dart
+++ b/packages/better_networking/lib/models/auth/auth_api_key_model.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,163 +9,31 @@ part of 'auth_api_key_model.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
-
-AuthApiKeyModel _$AuthApiKeyModelFromJson(Map<String, dynamic> json) {
-  return _AuthApiKeyModel.fromJson(json);
-}
 
 /// @nodoc
 mixin _$AuthApiKeyModel {
-  String get key => throw _privateConstructorUsedError;
-  String get location =>
-      throw _privateConstructorUsedError; // 'header' or 'query'
-  String get name => throw _privateConstructorUsedError;
-
-  /// Serializes this AuthApiKeyModel to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  String get key;
+  String get location; // 'header' or 'query'
+  String get name;
 
   /// Create a copy of AuthApiKeyModel
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $AuthApiKeyModelCopyWith<AuthApiKeyModel> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+      _$AuthApiKeyModelCopyWithImpl<AuthApiKeyModel>(
+          this as AuthApiKeyModel, _$identity);
 
-/// @nodoc
-abstract class $AuthApiKeyModelCopyWith<$Res> {
-  factory $AuthApiKeyModelCopyWith(
-    AuthApiKeyModel value,
-    $Res Function(AuthApiKeyModel) then,
-  ) = _$AuthApiKeyModelCopyWithImpl<$Res, AuthApiKeyModel>;
-  @useResult
-  $Res call({String key, String location, String name});
-}
-
-/// @nodoc
-class _$AuthApiKeyModelCopyWithImpl<$Res, $Val extends AuthApiKeyModel>
-    implements $AuthApiKeyModelCopyWith<$Res> {
-  _$AuthApiKeyModelCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of AuthApiKeyModel
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? key = null,
-    Object? location = null,
-    Object? name = null,
-  }) {
-    return _then(
-      _value.copyWith(
-            key: null == key
-                ? _value.key
-                : key // ignore: cast_nullable_to_non_nullable
-                      as String,
-            location: null == location
-                ? _value.location
-                : location // ignore: cast_nullable_to_non_nullable
-                      as String,
-            name: null == name
-                ? _value.name
-                : name // ignore: cast_nullable_to_non_nullable
-                      as String,
-          )
-          as $Val,
-    );
-  }
-}
-
-/// @nodoc
-abstract class _$$AuthApiKeyModelImplCopyWith<$Res>
-    implements $AuthApiKeyModelCopyWith<$Res> {
-  factory _$$AuthApiKeyModelImplCopyWith(
-    _$AuthApiKeyModelImpl value,
-    $Res Function(_$AuthApiKeyModelImpl) then,
-  ) = __$$AuthApiKeyModelImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String key, String location, String name});
-}
-
-/// @nodoc
-class __$$AuthApiKeyModelImplCopyWithImpl<$Res>
-    extends _$AuthApiKeyModelCopyWithImpl<$Res, _$AuthApiKeyModelImpl>
-    implements _$$AuthApiKeyModelImplCopyWith<$Res> {
-  __$$AuthApiKeyModelImplCopyWithImpl(
-    _$AuthApiKeyModelImpl _value,
-    $Res Function(_$AuthApiKeyModelImpl) _then,
-  ) : super(_value, _then);
-
-  /// Create a copy of AuthApiKeyModel
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? key = null,
-    Object? location = null,
-    Object? name = null,
-  }) {
-    return _then(
-      _$AuthApiKeyModelImpl(
-        key: null == key
-            ? _value.key
-            : key // ignore: cast_nullable_to_non_nullable
-                  as String,
-        location: null == location
-            ? _value.location
-            : location // ignore: cast_nullable_to_non_nullable
-                  as String,
-        name: null == name
-            ? _value.name
-            : name // ignore: cast_nullable_to_non_nullable
-                  as String,
-      ),
-    );
-  }
-}
-
-/// @nodoc
-@JsonSerializable()
-class _$AuthApiKeyModelImpl implements _AuthApiKeyModel {
-  const _$AuthApiKeyModelImpl({
-    required this.key,
-    this.location = 'header',
-    this.name = 'x-api-key',
-  });
-
-  factory _$AuthApiKeyModelImpl.fromJson(Map<String, dynamic> json) =>
-      _$$AuthApiKeyModelImplFromJson(json);
-
-  @override
-  final String key;
-  @override
-  @JsonKey()
-  final String location;
-  // 'header' or 'query'
-  @override
-  @JsonKey()
-  final String name;
-
-  @override
-  String toString() {
-    return 'AuthApiKeyModel(key: $key, location: $location, name: $name)';
-  }
+  /// Serializes this AuthApiKeyModel to a JSON map.
+  Map<String, dynamic> toJson();
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AuthApiKeyModelImpl &&
+            other is AuthApiKeyModel &&
             (identical(other.key, key) || other.key == key) &&
             (identical(other.location, location) ||
                 other.location == location) &&
@@ -176,44 +44,309 @@ class _$AuthApiKeyModelImpl implements _AuthApiKeyModel {
   @override
   int get hashCode => Object.hash(runtimeType, key, location, name);
 
-  /// Create a copy of AuthApiKeyModel
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$AuthApiKeyModelImplCopyWith<_$AuthApiKeyModelImpl> get copyWith =>
-      __$$AuthApiKeyModelImplCopyWithImpl<_$AuthApiKeyModelImpl>(
-        this,
-        _$identity,
-      );
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$AuthApiKeyModelImplToJson(this);
+  String toString() {
+    return 'AuthApiKeyModel(key: $key, location: $location, name: $name)';
   }
 }
 
-abstract class _AuthApiKeyModel implements AuthApiKeyModel {
-  const factory _AuthApiKeyModel({
-    required final String key,
-    final String location,
-    final String name,
-  }) = _$AuthApiKeyModelImpl;
+/// @nodoc
+abstract mixin class $AuthApiKeyModelCopyWith<$Res> {
+  factory $AuthApiKeyModelCopyWith(
+          AuthApiKeyModel value, $Res Function(AuthApiKeyModel) _then) =
+      _$AuthApiKeyModelCopyWithImpl;
+  @useResult
+  $Res call({String key, String location, String name});
+}
 
-  factory _AuthApiKeyModel.fromJson(Map<String, dynamic> json) =
-      _$AuthApiKeyModelImpl.fromJson;
+/// @nodoc
+class _$AuthApiKeyModelCopyWithImpl<$Res>
+    implements $AuthApiKeyModelCopyWith<$Res> {
+  _$AuthApiKeyModelCopyWithImpl(this._self, this._then);
+
+  final AuthApiKeyModel _self;
+  final $Res Function(AuthApiKeyModel) _then;
+
+  /// Create a copy of AuthApiKeyModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? key = null,
+    Object? location = null,
+    Object? name = null,
+  }) {
+    return _then(_self.copyWith(
+      key: null == key
+          ? _self.key
+          : key // ignore: cast_nullable_to_non_nullable
+              as String,
+      location: null == location
+          ? _self.location
+          : location // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [AuthApiKeyModel].
+extension AuthApiKeyModelPatterns on AuthApiKeyModel {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_AuthApiKeyModel value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _AuthApiKeyModel() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_AuthApiKeyModel value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthApiKeyModel():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_AuthApiKeyModel value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthApiKeyModel() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String key, String location, String name)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _AuthApiKeyModel() when $default != null:
+        return $default(_that.key, _that.location, _that.name);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String key, String location, String name) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthApiKeyModel():
+        return $default(_that.key, _that.location, _that.name);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String key, String location, String name)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthApiKeyModel() when $default != null:
+        return $default(_that.key, _that.location, _that.name);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _AuthApiKeyModel implements AuthApiKeyModel {
+  const _AuthApiKeyModel(
+      {required this.key, this.location = 'header', this.name = 'x-api-key'});
+  factory _AuthApiKeyModel.fromJson(Map<String, dynamic> json) =>
+      _$AuthApiKeyModelFromJson(json);
 
   @override
-  String get key;
+  final String key;
   @override
-  String get location; // 'header' or 'query'
+  @JsonKey()
+  final String location;
+// 'header' or 'query'
   @override
-  String get name;
+  @JsonKey()
+  final String name;
 
   /// Create a copy of AuthApiKeyModel
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$AuthApiKeyModelImplCopyWith<_$AuthApiKeyModelImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  _$AuthApiKeyModelCopyWith<_AuthApiKeyModel> get copyWith =>
+      __$AuthApiKeyModelCopyWithImpl<_AuthApiKeyModel>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$AuthApiKeyModelToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _AuthApiKeyModel &&
+            (identical(other.key, key) || other.key == key) &&
+            (identical(other.location, location) ||
+                other.location == location) &&
+            (identical(other.name, name) || other.name == name));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, key, location, name);
+
+  @override
+  String toString() {
+    return 'AuthApiKeyModel(key: $key, location: $location, name: $name)';
+  }
 }
+
+/// @nodoc
+abstract mixin class _$AuthApiKeyModelCopyWith<$Res>
+    implements $AuthApiKeyModelCopyWith<$Res> {
+  factory _$AuthApiKeyModelCopyWith(
+          _AuthApiKeyModel value, $Res Function(_AuthApiKeyModel) _then) =
+      __$AuthApiKeyModelCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String key, String location, String name});
+}
+
+/// @nodoc
+class __$AuthApiKeyModelCopyWithImpl<$Res>
+    implements _$AuthApiKeyModelCopyWith<$Res> {
+  __$AuthApiKeyModelCopyWithImpl(this._self, this._then);
+
+  final _AuthApiKeyModel _self;
+  final $Res Function(_AuthApiKeyModel) _then;
+
+  /// Create a copy of AuthApiKeyModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? key = null,
+    Object? location = null,
+    Object? name = null,
+  }) {
+    return _then(_AuthApiKeyModel(
+      key: null == key
+          ? _self.key
+          : key // ignore: cast_nullable_to_non_nullable
+              as String,
+      location: null == location
+          ? _self.location
+          : location // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+// dart format on

--- a/packages/better_networking/lib/models/auth/auth_api_key_model.g.dart
+++ b/packages/better_networking/lib/models/auth/auth_api_key_model.g.dart
@@ -6,18 +6,16 @@ part of 'auth_api_key_model.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$AuthApiKeyModelImpl _$$AuthApiKeyModelImplFromJson(
-  Map<String, dynamic> json,
-) => _$AuthApiKeyModelImpl(
-  key: json['key'] as String,
-  location: json['location'] as String? ?? 'header',
-  name: json['name'] as String? ?? 'x-api-key',
-);
+_AuthApiKeyModel _$AuthApiKeyModelFromJson(Map<String, dynamic> json) =>
+    _AuthApiKeyModel(
+      key: json['key'] as String,
+      location: json['location'] as String? ?? 'header',
+      name: json['name'] as String? ?? 'x-api-key',
+    );
 
-Map<String, dynamic> _$$AuthApiKeyModelImplToJson(
-  _$AuthApiKeyModelImpl instance,
-) => <String, dynamic>{
-  'key': instance.key,
-  'location': instance.location,
-  'name': instance.name,
-};
+Map<String, dynamic> _$AuthApiKeyModelToJson(_AuthApiKeyModel instance) =>
+    <String, dynamic>{
+      'key': instance.key,
+      'location': instance.location,
+      'name': instance.name,
+    };

--- a/packages/better_networking/lib/models/auth/auth_basic_model.freezed.dart
+++ b/packages/better_networking/lib/models/auth/auth_basic_model.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,139 +9,30 @@ part of 'auth_basic_model.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
-
-AuthBasicAuthModel _$AuthBasicAuthModelFromJson(Map<String, dynamic> json) {
-  return _AuthBasicAuthModel.fromJson(json);
-}
 
 /// @nodoc
 mixin _$AuthBasicAuthModel {
-  String get username => throw _privateConstructorUsedError;
-  String get password => throw _privateConstructorUsedError;
-
-  /// Serializes this AuthBasicAuthModel to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  String get username;
+  String get password;
 
   /// Create a copy of AuthBasicAuthModel
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $AuthBasicAuthModelCopyWith<AuthBasicAuthModel> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+      _$AuthBasicAuthModelCopyWithImpl<AuthBasicAuthModel>(
+          this as AuthBasicAuthModel, _$identity);
 
-/// @nodoc
-abstract class $AuthBasicAuthModelCopyWith<$Res> {
-  factory $AuthBasicAuthModelCopyWith(
-    AuthBasicAuthModel value,
-    $Res Function(AuthBasicAuthModel) then,
-  ) = _$AuthBasicAuthModelCopyWithImpl<$Res, AuthBasicAuthModel>;
-  @useResult
-  $Res call({String username, String password});
-}
-
-/// @nodoc
-class _$AuthBasicAuthModelCopyWithImpl<$Res, $Val extends AuthBasicAuthModel>
-    implements $AuthBasicAuthModelCopyWith<$Res> {
-  _$AuthBasicAuthModelCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of AuthBasicAuthModel
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({Object? username = null, Object? password = null}) {
-    return _then(
-      _value.copyWith(
-            username: null == username
-                ? _value.username
-                : username // ignore: cast_nullable_to_non_nullable
-                      as String,
-            password: null == password
-                ? _value.password
-                : password // ignore: cast_nullable_to_non_nullable
-                      as String,
-          )
-          as $Val,
-    );
-  }
-}
-
-/// @nodoc
-abstract class _$$AuthBasicAuthModelImplCopyWith<$Res>
-    implements $AuthBasicAuthModelCopyWith<$Res> {
-  factory _$$AuthBasicAuthModelImplCopyWith(
-    _$AuthBasicAuthModelImpl value,
-    $Res Function(_$AuthBasicAuthModelImpl) then,
-  ) = __$$AuthBasicAuthModelImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String username, String password});
-}
-
-/// @nodoc
-class __$$AuthBasicAuthModelImplCopyWithImpl<$Res>
-    extends _$AuthBasicAuthModelCopyWithImpl<$Res, _$AuthBasicAuthModelImpl>
-    implements _$$AuthBasicAuthModelImplCopyWith<$Res> {
-  __$$AuthBasicAuthModelImplCopyWithImpl(
-    _$AuthBasicAuthModelImpl _value,
-    $Res Function(_$AuthBasicAuthModelImpl) _then,
-  ) : super(_value, _then);
-
-  /// Create a copy of AuthBasicAuthModel
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({Object? username = null, Object? password = null}) {
-    return _then(
-      _$AuthBasicAuthModelImpl(
-        username: null == username
-            ? _value.username
-            : username // ignore: cast_nullable_to_non_nullable
-                  as String,
-        password: null == password
-            ? _value.password
-            : password // ignore: cast_nullable_to_non_nullable
-                  as String,
-      ),
-    );
-  }
-}
-
-/// @nodoc
-@JsonSerializable()
-class _$AuthBasicAuthModelImpl implements _AuthBasicAuthModel {
-  const _$AuthBasicAuthModelImpl({
-    required this.username,
-    required this.password,
-  });
-
-  factory _$AuthBasicAuthModelImpl.fromJson(Map<String, dynamic> json) =>
-      _$$AuthBasicAuthModelImplFromJson(json);
-
-  @override
-  final String username;
-  @override
-  final String password;
-
-  @override
-  String toString() {
-    return 'AuthBasicAuthModel(username: $username, password: $password)';
-  }
+  /// Serializes this AuthBasicAuthModel to a JSON map.
+  Map<String, dynamic> toJson();
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AuthBasicAuthModelImpl &&
+            other is AuthBasicAuthModel &&
             (identical(other.username, username) ||
                 other.username == username) &&
             (identical(other.password, password) ||
@@ -152,41 +43,293 @@ class _$AuthBasicAuthModelImpl implements _AuthBasicAuthModel {
   @override
   int get hashCode => Object.hash(runtimeType, username, password);
 
-  /// Create a copy of AuthBasicAuthModel
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$AuthBasicAuthModelImplCopyWith<_$AuthBasicAuthModelImpl> get copyWith =>
-      __$$AuthBasicAuthModelImplCopyWithImpl<_$AuthBasicAuthModelImpl>(
-        this,
-        _$identity,
-      );
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$AuthBasicAuthModelImplToJson(this);
+  String toString() {
+    return 'AuthBasicAuthModel(username: $username, password: $password)';
   }
 }
 
-abstract class _AuthBasicAuthModel implements AuthBasicAuthModel {
-  const factory _AuthBasicAuthModel({
-    required final String username,
-    required final String password,
-  }) = _$AuthBasicAuthModelImpl;
+/// @nodoc
+abstract mixin class $AuthBasicAuthModelCopyWith<$Res> {
+  factory $AuthBasicAuthModelCopyWith(
+          AuthBasicAuthModel value, $Res Function(AuthBasicAuthModel) _then) =
+      _$AuthBasicAuthModelCopyWithImpl;
+  @useResult
+  $Res call({String username, String password});
+}
 
-  factory _AuthBasicAuthModel.fromJson(Map<String, dynamic> json) =
-      _$AuthBasicAuthModelImpl.fromJson;
+/// @nodoc
+class _$AuthBasicAuthModelCopyWithImpl<$Res>
+    implements $AuthBasicAuthModelCopyWith<$Res> {
+  _$AuthBasicAuthModelCopyWithImpl(this._self, this._then);
+
+  final AuthBasicAuthModel _self;
+  final $Res Function(AuthBasicAuthModel) _then;
+
+  /// Create a copy of AuthBasicAuthModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? username = null,
+    Object? password = null,
+  }) {
+    return _then(_self.copyWith(
+      username: null == username
+          ? _self.username
+          : username // ignore: cast_nullable_to_non_nullable
+              as String,
+      password: null == password
+          ? _self.password
+          : password // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [AuthBasicAuthModel].
+extension AuthBasicAuthModelPatterns on AuthBasicAuthModel {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_AuthBasicAuthModel value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _AuthBasicAuthModel() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_AuthBasicAuthModel value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthBasicAuthModel():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_AuthBasicAuthModel value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthBasicAuthModel() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String username, String password)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _AuthBasicAuthModel() when $default != null:
+        return $default(_that.username, _that.password);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String username, String password) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthBasicAuthModel():
+        return $default(_that.username, _that.password);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String username, String password)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthBasicAuthModel() when $default != null:
+        return $default(_that.username, _that.password);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _AuthBasicAuthModel implements AuthBasicAuthModel {
+  const _AuthBasicAuthModel({required this.username, required this.password});
+  factory _AuthBasicAuthModel.fromJson(Map<String, dynamic> json) =>
+      _$AuthBasicAuthModelFromJson(json);
 
   @override
-  String get username;
+  final String username;
   @override
-  String get password;
+  final String password;
 
   /// Create a copy of AuthBasicAuthModel
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$AuthBasicAuthModelImplCopyWith<_$AuthBasicAuthModelImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  _$AuthBasicAuthModelCopyWith<_AuthBasicAuthModel> get copyWith =>
+      __$AuthBasicAuthModelCopyWithImpl<_AuthBasicAuthModel>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$AuthBasicAuthModelToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _AuthBasicAuthModel &&
+            (identical(other.username, username) ||
+                other.username == username) &&
+            (identical(other.password, password) ||
+                other.password == password));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, username, password);
+
+  @override
+  String toString() {
+    return 'AuthBasicAuthModel(username: $username, password: $password)';
+  }
 }
+
+/// @nodoc
+abstract mixin class _$AuthBasicAuthModelCopyWith<$Res>
+    implements $AuthBasicAuthModelCopyWith<$Res> {
+  factory _$AuthBasicAuthModelCopyWith(
+          _AuthBasicAuthModel value, $Res Function(_AuthBasicAuthModel) _then) =
+      __$AuthBasicAuthModelCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String username, String password});
+}
+
+/// @nodoc
+class __$AuthBasicAuthModelCopyWithImpl<$Res>
+    implements _$AuthBasicAuthModelCopyWith<$Res> {
+  __$AuthBasicAuthModelCopyWithImpl(this._self, this._then);
+
+  final _AuthBasicAuthModel _self;
+  final $Res Function(_AuthBasicAuthModel) _then;
+
+  /// Create a copy of AuthBasicAuthModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? username = null,
+    Object? password = null,
+  }) {
+    return _then(_AuthBasicAuthModel(
+      username: null == username
+          ? _self.username
+          : username // ignore: cast_nullable_to_non_nullable
+              as String,
+      password: null == password
+          ? _self.password
+          : password // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+// dart format on

--- a/packages/better_networking/lib/models/auth/auth_basic_model.g.dart
+++ b/packages/better_networking/lib/models/auth/auth_basic_model.g.dart
@@ -6,16 +6,14 @@ part of 'auth_basic_model.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$AuthBasicAuthModelImpl _$$AuthBasicAuthModelImplFromJson(
-  Map<String, dynamic> json,
-) => _$AuthBasicAuthModelImpl(
-  username: json['username'] as String,
-  password: json['password'] as String,
-);
+_AuthBasicAuthModel _$AuthBasicAuthModelFromJson(Map<String, dynamic> json) =>
+    _AuthBasicAuthModel(
+      username: json['username'] as String,
+      password: json['password'] as String,
+    );
 
-Map<String, dynamic> _$$AuthBasicAuthModelImplToJson(
-  _$AuthBasicAuthModelImpl instance,
-) => <String, dynamic>{
-  'username': instance.username,
-  'password': instance.password,
-};
+Map<String, dynamic> _$AuthBasicAuthModelToJson(_AuthBasicAuthModel instance) =>
+    <String, dynamic>{
+      'username': instance.username,
+      'password': instance.password,
+    };

--- a/packages/better_networking/lib/models/auth/auth_bearer_model.freezed.dart
+++ b/packages/better_networking/lib/models/auth/auth_bearer_model.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,125 +9,29 @@ part of 'auth_bearer_model.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
-
-AuthBearerModel _$AuthBearerModelFromJson(Map<String, dynamic> json) {
-  return _AuthBearerModel.fromJson(json);
-}
 
 /// @nodoc
 mixin _$AuthBearerModel {
-  String get token => throw _privateConstructorUsedError;
-
-  /// Serializes this AuthBearerModel to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  String get token;
 
   /// Create a copy of AuthBearerModel
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $AuthBearerModelCopyWith<AuthBearerModel> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+      _$AuthBearerModelCopyWithImpl<AuthBearerModel>(
+          this as AuthBearerModel, _$identity);
 
-/// @nodoc
-abstract class $AuthBearerModelCopyWith<$Res> {
-  factory $AuthBearerModelCopyWith(
-    AuthBearerModel value,
-    $Res Function(AuthBearerModel) then,
-  ) = _$AuthBearerModelCopyWithImpl<$Res, AuthBearerModel>;
-  @useResult
-  $Res call({String token});
-}
-
-/// @nodoc
-class _$AuthBearerModelCopyWithImpl<$Res, $Val extends AuthBearerModel>
-    implements $AuthBearerModelCopyWith<$Res> {
-  _$AuthBearerModelCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of AuthBearerModel
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({Object? token = null}) {
-    return _then(
-      _value.copyWith(
-            token: null == token
-                ? _value.token
-                : token // ignore: cast_nullable_to_non_nullable
-                      as String,
-          )
-          as $Val,
-    );
-  }
-}
-
-/// @nodoc
-abstract class _$$AuthBearerModelImplCopyWith<$Res>
-    implements $AuthBearerModelCopyWith<$Res> {
-  factory _$$AuthBearerModelImplCopyWith(
-    _$AuthBearerModelImpl value,
-    $Res Function(_$AuthBearerModelImpl) then,
-  ) = __$$AuthBearerModelImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String token});
-}
-
-/// @nodoc
-class __$$AuthBearerModelImplCopyWithImpl<$Res>
-    extends _$AuthBearerModelCopyWithImpl<$Res, _$AuthBearerModelImpl>
-    implements _$$AuthBearerModelImplCopyWith<$Res> {
-  __$$AuthBearerModelImplCopyWithImpl(
-    _$AuthBearerModelImpl _value,
-    $Res Function(_$AuthBearerModelImpl) _then,
-  ) : super(_value, _then);
-
-  /// Create a copy of AuthBearerModel
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({Object? token = null}) {
-    return _then(
-      _$AuthBearerModelImpl(
-        token: null == token
-            ? _value.token
-            : token // ignore: cast_nullable_to_non_nullable
-                  as String,
-      ),
-    );
-  }
-}
-
-/// @nodoc
-@JsonSerializable()
-class _$AuthBearerModelImpl implements _AuthBearerModel {
-  const _$AuthBearerModelImpl({required this.token});
-
-  factory _$AuthBearerModelImpl.fromJson(Map<String, dynamic> json) =>
-      _$$AuthBearerModelImplFromJson(json);
-
-  @override
-  final String token;
-
-  @override
-  String toString() {
-    return 'AuthBearerModel(token: $token)';
-  }
+  /// Serializes this AuthBearerModel to a JSON map.
+  Map<String, dynamic> toJson();
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AuthBearerModelImpl &&
+            other is AuthBearerModel &&
             (identical(other.token, token) || other.token == token));
   }
 
@@ -135,37 +39,278 @@ class _$AuthBearerModelImpl implements _AuthBearerModel {
   @override
   int get hashCode => Object.hash(runtimeType, token);
 
-  /// Create a copy of AuthBearerModel
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$AuthBearerModelImplCopyWith<_$AuthBearerModelImpl> get copyWith =>
-      __$$AuthBearerModelImplCopyWithImpl<_$AuthBearerModelImpl>(
-        this,
-        _$identity,
-      );
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$AuthBearerModelImplToJson(this);
+  String toString() {
+    return 'AuthBearerModel(token: $token)';
   }
 }
 
-abstract class _AuthBearerModel implements AuthBearerModel {
-  const factory _AuthBearerModel({required final String token}) =
-      _$AuthBearerModelImpl;
+/// @nodoc
+abstract mixin class $AuthBearerModelCopyWith<$Res> {
+  factory $AuthBearerModelCopyWith(
+          AuthBearerModel value, $Res Function(AuthBearerModel) _then) =
+      _$AuthBearerModelCopyWithImpl;
+  @useResult
+  $Res call({String token});
+}
 
-  factory _AuthBearerModel.fromJson(Map<String, dynamic> json) =
-      _$AuthBearerModelImpl.fromJson;
+/// @nodoc
+class _$AuthBearerModelCopyWithImpl<$Res>
+    implements $AuthBearerModelCopyWith<$Res> {
+  _$AuthBearerModelCopyWithImpl(this._self, this._then);
+
+  final AuthBearerModel _self;
+  final $Res Function(AuthBearerModel) _then;
+
+  /// Create a copy of AuthBearerModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? token = null,
+  }) {
+    return _then(_self.copyWith(
+      token: null == token
+          ? _self.token
+          : token // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [AuthBearerModel].
+extension AuthBearerModelPatterns on AuthBearerModel {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_AuthBearerModel value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _AuthBearerModel() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_AuthBearerModel value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthBearerModel():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_AuthBearerModel value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthBearerModel() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String token)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _AuthBearerModel() when $default != null:
+        return $default(_that.token);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String token) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthBearerModel():
+        return $default(_that.token);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String token)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthBearerModel() when $default != null:
+        return $default(_that.token);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _AuthBearerModel implements AuthBearerModel {
+  const _AuthBearerModel({required this.token});
+  factory _AuthBearerModel.fromJson(Map<String, dynamic> json) =>
+      _$AuthBearerModelFromJson(json);
 
   @override
-  String get token;
+  final String token;
 
   /// Create a copy of AuthBearerModel
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$AuthBearerModelImplCopyWith<_$AuthBearerModelImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  _$AuthBearerModelCopyWith<_AuthBearerModel> get copyWith =>
+      __$AuthBearerModelCopyWithImpl<_AuthBearerModel>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$AuthBearerModelToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _AuthBearerModel &&
+            (identical(other.token, token) || other.token == token));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, token);
+
+  @override
+  String toString() {
+    return 'AuthBearerModel(token: $token)';
+  }
 }
+
+/// @nodoc
+abstract mixin class _$AuthBearerModelCopyWith<$Res>
+    implements $AuthBearerModelCopyWith<$Res> {
+  factory _$AuthBearerModelCopyWith(
+          _AuthBearerModel value, $Res Function(_AuthBearerModel) _then) =
+      __$AuthBearerModelCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String token});
+}
+
+/// @nodoc
+class __$AuthBearerModelCopyWithImpl<$Res>
+    implements _$AuthBearerModelCopyWith<$Res> {
+  __$AuthBearerModelCopyWithImpl(this._self, this._then);
+
+  final _AuthBearerModel _self;
+  final $Res Function(_AuthBearerModel) _then;
+
+  /// Create a copy of AuthBearerModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? token = null,
+  }) {
+    return _then(_AuthBearerModel(
+      token: null == token
+          ? _self.token
+          : token // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+// dart format on

--- a/packages/better_networking/lib/models/auth/auth_bearer_model.g.dart
+++ b/packages/better_networking/lib/models/auth/auth_bearer_model.g.dart
@@ -6,10 +6,12 @@ part of 'auth_bearer_model.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$AuthBearerModelImpl _$$AuthBearerModelImplFromJson(
-  Map<String, dynamic> json,
-) => _$AuthBearerModelImpl(token: json['token'] as String);
+_AuthBearerModel _$AuthBearerModelFromJson(Map<String, dynamic> json) =>
+    _AuthBearerModel(
+      token: json['token'] as String,
+    );
 
-Map<String, dynamic> _$$AuthBearerModelImplToJson(
-  _$AuthBearerModelImpl instance,
-) => <String, dynamic>{'token': instance.token};
+Map<String, dynamic> _$AuthBearerModelToJson(_AuthBearerModel instance) =>
+    <String, dynamic>{
+      'token': instance.token,
+    };

--- a/packages/better_networking/lib/models/auth/auth_digest_model.freezed.dart
+++ b/packages/better_networking/lib/models/auth/auth_digest_model.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,141 +9,81 @@ part of 'auth_digest_model.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
-
-AuthDigestModel _$AuthDigestModelFromJson(Map<String, dynamic> json) {
-  return _AuthDigestModel.fromJson(json);
-}
 
 /// @nodoc
 mixin _$AuthDigestModel {
-  String get username => throw _privateConstructorUsedError;
-  String get password => throw _privateConstructorUsedError;
-  String get realm => throw _privateConstructorUsedError;
-  String get nonce => throw _privateConstructorUsedError;
-  String get algorithm => throw _privateConstructorUsedError;
-  String get qop => throw _privateConstructorUsedError;
-  String get opaque => throw _privateConstructorUsedError;
-
-  /// Serializes this AuthDigestModel to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  String get username;
+  String get password;
+  String get realm;
+  String get nonce;
+  String get algorithm;
+  String get qop;
+  String get opaque;
 
   /// Create a copy of AuthDigestModel
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $AuthDigestModelCopyWith<AuthDigestModel> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $AuthDigestModelCopyWith<$Res> {
-  factory $AuthDigestModelCopyWith(
-    AuthDigestModel value,
-    $Res Function(AuthDigestModel) then,
-  ) = _$AuthDigestModelCopyWithImpl<$Res, AuthDigestModel>;
-  @useResult
-  $Res call({
-    String username,
-    String password,
-    String realm,
-    String nonce,
-    String algorithm,
-    String qop,
-    String opaque,
-  });
-}
-
-/// @nodoc
-class _$AuthDigestModelCopyWithImpl<$Res, $Val extends AuthDigestModel>
-    implements $AuthDigestModelCopyWith<$Res> {
-  _$AuthDigestModelCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of AuthDigestModel
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
+  $AuthDigestModelCopyWith<AuthDigestModel> get copyWith =>
+      _$AuthDigestModelCopyWithImpl<AuthDigestModel>(
+          this as AuthDigestModel, _$identity);
+
+  /// Serializes this AuthDigestModel to a JSON map.
+  Map<String, dynamic> toJson();
+
   @override
-  $Res call({
-    Object? username = null,
-    Object? password = null,
-    Object? realm = null,
-    Object? nonce = null,
-    Object? algorithm = null,
-    Object? qop = null,
-    Object? opaque = null,
-  }) {
-    return _then(
-      _value.copyWith(
-            username: null == username
-                ? _value.username
-                : username // ignore: cast_nullable_to_non_nullable
-                      as String,
-            password: null == password
-                ? _value.password
-                : password // ignore: cast_nullable_to_non_nullable
-                      as String,
-            realm: null == realm
-                ? _value.realm
-                : realm // ignore: cast_nullable_to_non_nullable
-                      as String,
-            nonce: null == nonce
-                ? _value.nonce
-                : nonce // ignore: cast_nullable_to_non_nullable
-                      as String,
-            algorithm: null == algorithm
-                ? _value.algorithm
-                : algorithm // ignore: cast_nullable_to_non_nullable
-                      as String,
-            qop: null == qop
-                ? _value.qop
-                : qop // ignore: cast_nullable_to_non_nullable
-                      as String,
-            opaque: null == opaque
-                ? _value.opaque
-                : opaque // ignore: cast_nullable_to_non_nullable
-                      as String,
-          )
-          as $Val,
-    );
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is AuthDigestModel &&
+            (identical(other.username, username) ||
+                other.username == username) &&
+            (identical(other.password, password) ||
+                other.password == password) &&
+            (identical(other.realm, realm) || other.realm == realm) &&
+            (identical(other.nonce, nonce) || other.nonce == nonce) &&
+            (identical(other.algorithm, algorithm) ||
+                other.algorithm == algorithm) &&
+            (identical(other.qop, qop) || other.qop == qop) &&
+            (identical(other.opaque, opaque) || other.opaque == opaque));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, username, password, realm, nonce, algorithm, qop, opaque);
+
+  @override
+  String toString() {
+    return 'AuthDigestModel(username: $username, password: $password, realm: $realm, nonce: $nonce, algorithm: $algorithm, qop: $qop, opaque: $opaque)';
   }
 }
 
 /// @nodoc
-abstract class _$$AuthDigestModelImplCopyWith<$Res>
-    implements $AuthDigestModelCopyWith<$Res> {
-  factory _$$AuthDigestModelImplCopyWith(
-    _$AuthDigestModelImpl value,
-    $Res Function(_$AuthDigestModelImpl) then,
-  ) = __$$AuthDigestModelImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $AuthDigestModelCopyWith<$Res> {
+  factory $AuthDigestModelCopyWith(
+          AuthDigestModel value, $Res Function(AuthDigestModel) _then) =
+      _$AuthDigestModelCopyWithImpl;
   @useResult
-  $Res call({
-    String username,
-    String password,
-    String realm,
-    String nonce,
-    String algorithm,
-    String qop,
-    String opaque,
-  });
+  $Res call(
+      {String username,
+      String password,
+      String realm,
+      String nonce,
+      String algorithm,
+      String qop,
+      String opaque});
 }
 
 /// @nodoc
-class __$$AuthDigestModelImplCopyWithImpl<$Res>
-    extends _$AuthDigestModelCopyWithImpl<$Res, _$AuthDigestModelImpl>
-    implements _$$AuthDigestModelImplCopyWith<$Res> {
-  __$$AuthDigestModelImplCopyWithImpl(
-    _$AuthDigestModelImpl _value,
-    $Res Function(_$AuthDigestModelImpl) _then,
-  ) : super(_value, _then);
+class _$AuthDigestModelCopyWithImpl<$Res>
+    implements $AuthDigestModelCopyWith<$Res> {
+  _$AuthDigestModelCopyWithImpl(this._self, this._then);
+
+  final AuthDigestModel _self;
+  final $Res Function(AuthDigestModel) _then;
 
   /// Create a copy of AuthDigestModel
   /// with the given fields replaced by the non-null parameter values.
@@ -158,56 +98,218 @@ class __$$AuthDigestModelImplCopyWithImpl<$Res>
     Object? qop = null,
     Object? opaque = null,
   }) {
-    return _then(
-      _$AuthDigestModelImpl(
-        username: null == username
-            ? _value.username
-            : username // ignore: cast_nullable_to_non_nullable
-                  as String,
-        password: null == password
-            ? _value.password
-            : password // ignore: cast_nullable_to_non_nullable
-                  as String,
-        realm: null == realm
-            ? _value.realm
-            : realm // ignore: cast_nullable_to_non_nullable
-                  as String,
-        nonce: null == nonce
-            ? _value.nonce
-            : nonce // ignore: cast_nullable_to_non_nullable
-                  as String,
-        algorithm: null == algorithm
-            ? _value.algorithm
-            : algorithm // ignore: cast_nullable_to_non_nullable
-                  as String,
-        qop: null == qop
-            ? _value.qop
-            : qop // ignore: cast_nullable_to_non_nullable
-                  as String,
-        opaque: null == opaque
-            ? _value.opaque
-            : opaque // ignore: cast_nullable_to_non_nullable
-                  as String,
-      ),
-    );
+    return _then(_self.copyWith(
+      username: null == username
+          ? _self.username
+          : username // ignore: cast_nullable_to_non_nullable
+              as String,
+      password: null == password
+          ? _self.password
+          : password // ignore: cast_nullable_to_non_nullable
+              as String,
+      realm: null == realm
+          ? _self.realm
+          : realm // ignore: cast_nullable_to_non_nullable
+              as String,
+      nonce: null == nonce
+          ? _self.nonce
+          : nonce // ignore: cast_nullable_to_non_nullable
+              as String,
+      algorithm: null == algorithm
+          ? _self.algorithm
+          : algorithm // ignore: cast_nullable_to_non_nullable
+              as String,
+      qop: null == qop
+          ? _self.qop
+          : qop // ignore: cast_nullable_to_non_nullable
+              as String,
+      opaque: null == opaque
+          ? _self.opaque
+          : opaque // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [AuthDigestModel].
+extension AuthDigestModelPatterns on AuthDigestModel {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_AuthDigestModel value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _AuthDigestModel() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_AuthDigestModel value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthDigestModel():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_AuthDigestModel value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthDigestModel() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String username, String password, String realm,
+            String nonce, String algorithm, String qop, String opaque)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _AuthDigestModel() when $default != null:
+        return $default(_that.username, _that.password, _that.realm,
+            _that.nonce, _that.algorithm, _that.qop, _that.opaque);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String username, String password, String realm,
+            String nonce, String algorithm, String qop, String opaque)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthDigestModel():
+        return $default(_that.username, _that.password, _that.realm,
+            _that.nonce, _that.algorithm, _that.qop, _that.opaque);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String username, String password, String realm,
+            String nonce, String algorithm, String qop, String opaque)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthDigestModel() when $default != null:
+        return $default(_that.username, _that.password, _that.realm,
+            _that.nonce, _that.algorithm, _that.qop, _that.opaque);
+      case _:
+        return null;
+    }
   }
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$AuthDigestModelImpl implements _AuthDigestModel {
-  const _$AuthDigestModelImpl({
-    required this.username,
-    required this.password,
-    required this.realm,
-    required this.nonce,
-    required this.algorithm,
-    required this.qop,
-    required this.opaque,
-  });
-
-  factory _$AuthDigestModelImpl.fromJson(Map<String, dynamic> json) =>
-      _$$AuthDigestModelImplFromJson(json);
+class _AuthDigestModel implements AuthDigestModel {
+  const _AuthDigestModel(
+      {required this.username,
+      required this.password,
+      required this.realm,
+      required this.nonce,
+      required this.algorithm,
+      required this.qop,
+      required this.opaque});
+  factory _AuthDigestModel.fromJson(Map<String, dynamic> json) =>
+      _$AuthDigestModelFromJson(json);
 
   @override
   final String username;
@@ -224,16 +326,26 @@ class _$AuthDigestModelImpl implements _AuthDigestModel {
   @override
   final String opaque;
 
+  /// Create a copy of AuthDigestModel
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'AuthDigestModel(username: $username, password: $password, realm: $realm, nonce: $nonce, algorithm: $algorithm, qop: $qop, opaque: $opaque)';
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$AuthDigestModelCopyWith<_AuthDigestModel> get copyWith =>
+      __$AuthDigestModelCopyWithImpl<_AuthDigestModel>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$AuthDigestModelToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AuthDigestModelImpl &&
+            other is _AuthDigestModel &&
             (identical(other.username, username) ||
                 other.username == username) &&
             (identical(other.password, password) ||
@@ -249,66 +361,84 @@ class _$AuthDigestModelImpl implements _AuthDigestModel {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
-    runtimeType,
-    username,
-    password,
-    realm,
-    nonce,
-    algorithm,
-    qop,
-    opaque,
-  );
-
-  /// Create a copy of AuthDigestModel
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$AuthDigestModelImplCopyWith<_$AuthDigestModelImpl> get copyWith =>
-      __$$AuthDigestModelImplCopyWithImpl<_$AuthDigestModelImpl>(
-        this,
-        _$identity,
-      );
+      runtimeType, username, password, realm, nonce, algorithm, qop, opaque);
 
   @override
-  Map<String, dynamic> toJson() {
-    return _$$AuthDigestModelImplToJson(this);
+  String toString() {
+    return 'AuthDigestModel(username: $username, password: $password, realm: $realm, nonce: $nonce, algorithm: $algorithm, qop: $qop, opaque: $opaque)';
   }
 }
 
-abstract class _AuthDigestModel implements AuthDigestModel {
-  const factory _AuthDigestModel({
-    required final String username,
-    required final String password,
-    required final String realm,
-    required final String nonce,
-    required final String algorithm,
-    required final String qop,
-    required final String opaque,
-  }) = _$AuthDigestModelImpl;
+/// @nodoc
+abstract mixin class _$AuthDigestModelCopyWith<$Res>
+    implements $AuthDigestModelCopyWith<$Res> {
+  factory _$AuthDigestModelCopyWith(
+          _AuthDigestModel value, $Res Function(_AuthDigestModel) _then) =
+      __$AuthDigestModelCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String username,
+      String password,
+      String realm,
+      String nonce,
+      String algorithm,
+      String qop,
+      String opaque});
+}
 
-  factory _AuthDigestModel.fromJson(Map<String, dynamic> json) =
-      _$AuthDigestModelImpl.fromJson;
+/// @nodoc
+class __$AuthDigestModelCopyWithImpl<$Res>
+    implements _$AuthDigestModelCopyWith<$Res> {
+  __$AuthDigestModelCopyWithImpl(this._self, this._then);
 
-  @override
-  String get username;
-  @override
-  String get password;
-  @override
-  String get realm;
-  @override
-  String get nonce;
-  @override
-  String get algorithm;
-  @override
-  String get qop;
-  @override
-  String get opaque;
+  final _AuthDigestModel _self;
+  final $Res Function(_AuthDigestModel) _then;
 
   /// Create a copy of AuthDigestModel
   /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$AuthDigestModelImplCopyWith<_$AuthDigestModelImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? username = null,
+    Object? password = null,
+    Object? realm = null,
+    Object? nonce = null,
+    Object? algorithm = null,
+    Object? qop = null,
+    Object? opaque = null,
+  }) {
+    return _then(_AuthDigestModel(
+      username: null == username
+          ? _self.username
+          : username // ignore: cast_nullable_to_non_nullable
+              as String,
+      password: null == password
+          ? _self.password
+          : password // ignore: cast_nullable_to_non_nullable
+              as String,
+      realm: null == realm
+          ? _self.realm
+          : realm // ignore: cast_nullable_to_non_nullable
+              as String,
+      nonce: null == nonce
+          ? _self.nonce
+          : nonce // ignore: cast_nullable_to_non_nullable
+              as String,
+      algorithm: null == algorithm
+          ? _self.algorithm
+          : algorithm // ignore: cast_nullable_to_non_nullable
+              as String,
+      qop: null == qop
+          ? _self.qop
+          : qop // ignore: cast_nullable_to_non_nullable
+              as String,
+      opaque: null == opaque
+          ? _self.opaque
+          : opaque // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
 }
+
+// dart format on

--- a/packages/better_networking/lib/models/auth/auth_digest_model.g.dart
+++ b/packages/better_networking/lib/models/auth/auth_digest_model.g.dart
@@ -6,26 +6,24 @@ part of 'auth_digest_model.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$AuthDigestModelImpl _$$AuthDigestModelImplFromJson(
-  Map<String, dynamic> json,
-) => _$AuthDigestModelImpl(
-  username: json['username'] as String,
-  password: json['password'] as String,
-  realm: json['realm'] as String,
-  nonce: json['nonce'] as String,
-  algorithm: json['algorithm'] as String,
-  qop: json['qop'] as String,
-  opaque: json['opaque'] as String,
-);
+_AuthDigestModel _$AuthDigestModelFromJson(Map<String, dynamic> json) =>
+    _AuthDigestModel(
+      username: json['username'] as String,
+      password: json['password'] as String,
+      realm: json['realm'] as String,
+      nonce: json['nonce'] as String,
+      algorithm: json['algorithm'] as String,
+      qop: json['qop'] as String,
+      opaque: json['opaque'] as String,
+    );
 
-Map<String, dynamic> _$$AuthDigestModelImplToJson(
-  _$AuthDigestModelImpl instance,
-) => <String, dynamic>{
-  'username': instance.username,
-  'password': instance.password,
-  'realm': instance.realm,
-  'nonce': instance.nonce,
-  'algorithm': instance.algorithm,
-  'qop': instance.qop,
-  'opaque': instance.opaque,
-};
+Map<String, dynamic> _$AuthDigestModelToJson(_AuthDigestModel instance) =>
+    <String, dynamic>{
+      'username': instance.username,
+      'password': instance.password,
+      'realm': instance.realm,
+      'nonce': instance.nonce,
+      'algorithm': instance.algorithm,
+      'qop': instance.qop,
+      'opaque': instance.opaque,
+    };

--- a/packages/better_networking/lib/models/auth/auth_jwt_model.freezed.dart
+++ b/packages/better_networking/lib/models/auth/auth_jwt_model.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,263 +9,37 @@ part of 'auth_jwt_model.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
-
-AuthJwtModel _$AuthJwtModelFromJson(Map<String, dynamic> json) {
-  return _AuthJwtModel.fromJson(json);
-}
 
 /// @nodoc
 mixin _$AuthJwtModel {
-  String get secret => throw _privateConstructorUsedError;
-  String? get privateKey => throw _privateConstructorUsedError;
-  String get payload => throw _privateConstructorUsedError;
-  String get addTokenTo => throw _privateConstructorUsedError;
-  String get algorithm => throw _privateConstructorUsedError;
-  bool get isSecretBase64Encoded => throw _privateConstructorUsedError;
-  String get headerPrefix => throw _privateConstructorUsedError;
-  String get queryParamKey => throw _privateConstructorUsedError;
-  String get header => throw _privateConstructorUsedError;
-
-  /// Serializes this AuthJwtModel to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  String get secret;
+  String? get privateKey;
+  String get payload;
+  String get addTokenTo;
+  String get algorithm;
+  bool get isSecretBase64Encoded;
+  String get headerPrefix;
+  String get queryParamKey;
+  String get header;
 
   /// Create a copy of AuthJwtModel
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $AuthJwtModelCopyWith<AuthJwtModel> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+      _$AuthJwtModelCopyWithImpl<AuthJwtModel>(
+          this as AuthJwtModel, _$identity);
 
-/// @nodoc
-abstract class $AuthJwtModelCopyWith<$Res> {
-  factory $AuthJwtModelCopyWith(
-    AuthJwtModel value,
-    $Res Function(AuthJwtModel) then,
-  ) = _$AuthJwtModelCopyWithImpl<$Res, AuthJwtModel>;
-  @useResult
-  $Res call({
-    String secret,
-    String? privateKey,
-    String payload,
-    String addTokenTo,
-    String algorithm,
-    bool isSecretBase64Encoded,
-    String headerPrefix,
-    String queryParamKey,
-    String header,
-  });
-}
-
-/// @nodoc
-class _$AuthJwtModelCopyWithImpl<$Res, $Val extends AuthJwtModel>
-    implements $AuthJwtModelCopyWith<$Res> {
-  _$AuthJwtModelCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of AuthJwtModel
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? secret = null,
-    Object? privateKey = freezed,
-    Object? payload = null,
-    Object? addTokenTo = null,
-    Object? algorithm = null,
-    Object? isSecretBase64Encoded = null,
-    Object? headerPrefix = null,
-    Object? queryParamKey = null,
-    Object? header = null,
-  }) {
-    return _then(
-      _value.copyWith(
-            secret: null == secret
-                ? _value.secret
-                : secret // ignore: cast_nullable_to_non_nullable
-                      as String,
-            privateKey: freezed == privateKey
-                ? _value.privateKey
-                : privateKey // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            payload: null == payload
-                ? _value.payload
-                : payload // ignore: cast_nullable_to_non_nullable
-                      as String,
-            addTokenTo: null == addTokenTo
-                ? _value.addTokenTo
-                : addTokenTo // ignore: cast_nullable_to_non_nullable
-                      as String,
-            algorithm: null == algorithm
-                ? _value.algorithm
-                : algorithm // ignore: cast_nullable_to_non_nullable
-                      as String,
-            isSecretBase64Encoded: null == isSecretBase64Encoded
-                ? _value.isSecretBase64Encoded
-                : isSecretBase64Encoded // ignore: cast_nullable_to_non_nullable
-                      as bool,
-            headerPrefix: null == headerPrefix
-                ? _value.headerPrefix
-                : headerPrefix // ignore: cast_nullable_to_non_nullable
-                      as String,
-            queryParamKey: null == queryParamKey
-                ? _value.queryParamKey
-                : queryParamKey // ignore: cast_nullable_to_non_nullable
-                      as String,
-            header: null == header
-                ? _value.header
-                : header // ignore: cast_nullable_to_non_nullable
-                      as String,
-          )
-          as $Val,
-    );
-  }
-}
-
-/// @nodoc
-abstract class _$$AuthJwtModelImplCopyWith<$Res>
-    implements $AuthJwtModelCopyWith<$Res> {
-  factory _$$AuthJwtModelImplCopyWith(
-    _$AuthJwtModelImpl value,
-    $Res Function(_$AuthJwtModelImpl) then,
-  ) = __$$AuthJwtModelImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({
-    String secret,
-    String? privateKey,
-    String payload,
-    String addTokenTo,
-    String algorithm,
-    bool isSecretBase64Encoded,
-    String headerPrefix,
-    String queryParamKey,
-    String header,
-  });
-}
-
-/// @nodoc
-class __$$AuthJwtModelImplCopyWithImpl<$Res>
-    extends _$AuthJwtModelCopyWithImpl<$Res, _$AuthJwtModelImpl>
-    implements _$$AuthJwtModelImplCopyWith<$Res> {
-  __$$AuthJwtModelImplCopyWithImpl(
-    _$AuthJwtModelImpl _value,
-    $Res Function(_$AuthJwtModelImpl) _then,
-  ) : super(_value, _then);
-
-  /// Create a copy of AuthJwtModel
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? secret = null,
-    Object? privateKey = freezed,
-    Object? payload = null,
-    Object? addTokenTo = null,
-    Object? algorithm = null,
-    Object? isSecretBase64Encoded = null,
-    Object? headerPrefix = null,
-    Object? queryParamKey = null,
-    Object? header = null,
-  }) {
-    return _then(
-      _$AuthJwtModelImpl(
-        secret: null == secret
-            ? _value.secret
-            : secret // ignore: cast_nullable_to_non_nullable
-                  as String,
-        privateKey: freezed == privateKey
-            ? _value.privateKey
-            : privateKey // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        payload: null == payload
-            ? _value.payload
-            : payload // ignore: cast_nullable_to_non_nullable
-                  as String,
-        addTokenTo: null == addTokenTo
-            ? _value.addTokenTo
-            : addTokenTo // ignore: cast_nullable_to_non_nullable
-                  as String,
-        algorithm: null == algorithm
-            ? _value.algorithm
-            : algorithm // ignore: cast_nullable_to_non_nullable
-                  as String,
-        isSecretBase64Encoded: null == isSecretBase64Encoded
-            ? _value.isSecretBase64Encoded
-            : isSecretBase64Encoded // ignore: cast_nullable_to_non_nullable
-                  as bool,
-        headerPrefix: null == headerPrefix
-            ? _value.headerPrefix
-            : headerPrefix // ignore: cast_nullable_to_non_nullable
-                  as String,
-        queryParamKey: null == queryParamKey
-            ? _value.queryParamKey
-            : queryParamKey // ignore: cast_nullable_to_non_nullable
-                  as String,
-        header: null == header
-            ? _value.header
-            : header // ignore: cast_nullable_to_non_nullable
-                  as String,
-      ),
-    );
-  }
-}
-
-/// @nodoc
-@JsonSerializable()
-class _$AuthJwtModelImpl implements _AuthJwtModel {
-  const _$AuthJwtModelImpl({
-    required this.secret,
-    this.privateKey,
-    required this.payload,
-    required this.addTokenTo,
-    required this.algorithm,
-    required this.isSecretBase64Encoded,
-    required this.headerPrefix,
-    required this.queryParamKey,
-    required this.header,
-  });
-
-  factory _$AuthJwtModelImpl.fromJson(Map<String, dynamic> json) =>
-      _$$AuthJwtModelImplFromJson(json);
-
-  @override
-  final String secret;
-  @override
-  final String? privateKey;
-  @override
-  final String payload;
-  @override
-  final String addTokenTo;
-  @override
-  final String algorithm;
-  @override
-  final bool isSecretBase64Encoded;
-  @override
-  final String headerPrefix;
-  @override
-  final String queryParamKey;
-  @override
-  final String header;
-
-  @override
-  String toString() {
-    return 'AuthJwtModel(secret: $secret, privateKey: $privateKey, payload: $payload, addTokenTo: $addTokenTo, algorithm: $algorithm, isSecretBase64Encoded: $isSecretBase64Encoded, headerPrefix: $headerPrefix, queryParamKey: $queryParamKey, header: $header)';
-  }
+  /// Serializes this AuthJwtModel to a JSON map.
+  Map<String, dynamic> toJson();
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AuthJwtModelImpl &&
+            other is AuthJwtModel &&
             (identical(other.secret, secret) || other.secret == secret) &&
             (identical(other.privateKey, privateKey) ||
                 other.privateKey == privateKey) &&
@@ -286,71 +60,492 @@ class _$AuthJwtModelImpl implements _AuthJwtModel {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
-    runtimeType,
-    secret,
-    privateKey,
-    payload,
-    addTokenTo,
-    algorithm,
-    isSecretBase64Encoded,
-    headerPrefix,
-    queryParamKey,
-    header,
-  );
-
-  /// Create a copy of AuthJwtModel
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$AuthJwtModelImplCopyWith<_$AuthJwtModelImpl> get copyWith =>
-      __$$AuthJwtModelImplCopyWithImpl<_$AuthJwtModelImpl>(this, _$identity);
+      runtimeType,
+      secret,
+      privateKey,
+      payload,
+      addTokenTo,
+      algorithm,
+      isSecretBase64Encoded,
+      headerPrefix,
+      queryParamKey,
+      header);
 
   @override
-  Map<String, dynamic> toJson() {
-    return _$$AuthJwtModelImplToJson(this);
+  String toString() {
+    return 'AuthJwtModel(secret: $secret, privateKey: $privateKey, payload: $payload, addTokenTo: $addTokenTo, algorithm: $algorithm, isSecretBase64Encoded: $isSecretBase64Encoded, headerPrefix: $headerPrefix, queryParamKey: $queryParamKey, header: $header)';
   }
 }
 
-abstract class _AuthJwtModel implements AuthJwtModel {
-  const factory _AuthJwtModel({
-    required final String secret,
-    final String? privateKey,
-    required final String payload,
-    required final String addTokenTo,
-    required final String algorithm,
-    required final bool isSecretBase64Encoded,
-    required final String headerPrefix,
-    required final String queryParamKey,
-    required final String header,
-  }) = _$AuthJwtModelImpl;
+/// @nodoc
+abstract mixin class $AuthJwtModelCopyWith<$Res> {
+  factory $AuthJwtModelCopyWith(
+          AuthJwtModel value, $Res Function(AuthJwtModel) _then) =
+      _$AuthJwtModelCopyWithImpl;
+  @useResult
+  $Res call(
+      {String secret,
+      String? privateKey,
+      String payload,
+      String addTokenTo,
+      String algorithm,
+      bool isSecretBase64Encoded,
+      String headerPrefix,
+      String queryParamKey,
+      String header});
+}
 
-  factory _AuthJwtModel.fromJson(Map<String, dynamic> json) =
-      _$AuthJwtModelImpl.fromJson;
+/// @nodoc
+class _$AuthJwtModelCopyWithImpl<$Res> implements $AuthJwtModelCopyWith<$Res> {
+  _$AuthJwtModelCopyWithImpl(this._self, this._then);
+
+  final AuthJwtModel _self;
+  final $Res Function(AuthJwtModel) _then;
+
+  /// Create a copy of AuthJwtModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? secret = null,
+    Object? privateKey = freezed,
+    Object? payload = null,
+    Object? addTokenTo = null,
+    Object? algorithm = null,
+    Object? isSecretBase64Encoded = null,
+    Object? headerPrefix = null,
+    Object? queryParamKey = null,
+    Object? header = null,
+  }) {
+    return _then(_self.copyWith(
+      secret: null == secret
+          ? _self.secret
+          : secret // ignore: cast_nullable_to_non_nullable
+              as String,
+      privateKey: freezed == privateKey
+          ? _self.privateKey
+          : privateKey // ignore: cast_nullable_to_non_nullable
+              as String?,
+      payload: null == payload
+          ? _self.payload
+          : payload // ignore: cast_nullable_to_non_nullable
+              as String,
+      addTokenTo: null == addTokenTo
+          ? _self.addTokenTo
+          : addTokenTo // ignore: cast_nullable_to_non_nullable
+              as String,
+      algorithm: null == algorithm
+          ? _self.algorithm
+          : algorithm // ignore: cast_nullable_to_non_nullable
+              as String,
+      isSecretBase64Encoded: null == isSecretBase64Encoded
+          ? _self.isSecretBase64Encoded
+          : isSecretBase64Encoded // ignore: cast_nullable_to_non_nullable
+              as bool,
+      headerPrefix: null == headerPrefix
+          ? _self.headerPrefix
+          : headerPrefix // ignore: cast_nullable_to_non_nullable
+              as String,
+      queryParamKey: null == queryParamKey
+          ? _self.queryParamKey
+          : queryParamKey // ignore: cast_nullable_to_non_nullable
+              as String,
+      header: null == header
+          ? _self.header
+          : header // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [AuthJwtModel].
+extension AuthJwtModelPatterns on AuthJwtModel {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_AuthJwtModel value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _AuthJwtModel() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_AuthJwtModel value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthJwtModel():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_AuthJwtModel value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthJwtModel() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String secret,
+            String? privateKey,
+            String payload,
+            String addTokenTo,
+            String algorithm,
+            bool isSecretBase64Encoded,
+            String headerPrefix,
+            String queryParamKey,
+            String header)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _AuthJwtModel() when $default != null:
+        return $default(
+            _that.secret,
+            _that.privateKey,
+            _that.payload,
+            _that.addTokenTo,
+            _that.algorithm,
+            _that.isSecretBase64Encoded,
+            _that.headerPrefix,
+            _that.queryParamKey,
+            _that.header);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String secret,
+            String? privateKey,
+            String payload,
+            String addTokenTo,
+            String algorithm,
+            bool isSecretBase64Encoded,
+            String headerPrefix,
+            String queryParamKey,
+            String header)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthJwtModel():
+        return $default(
+            _that.secret,
+            _that.privateKey,
+            _that.payload,
+            _that.addTokenTo,
+            _that.algorithm,
+            _that.isSecretBase64Encoded,
+            _that.headerPrefix,
+            _that.queryParamKey,
+            _that.header);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String secret,
+            String? privateKey,
+            String payload,
+            String addTokenTo,
+            String algorithm,
+            bool isSecretBase64Encoded,
+            String headerPrefix,
+            String queryParamKey,
+            String header)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthJwtModel() when $default != null:
+        return $default(
+            _that.secret,
+            _that.privateKey,
+            _that.payload,
+            _that.addTokenTo,
+            _that.algorithm,
+            _that.isSecretBase64Encoded,
+            _that.headerPrefix,
+            _that.queryParamKey,
+            _that.header);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _AuthJwtModel implements AuthJwtModel {
+  const _AuthJwtModel(
+      {required this.secret,
+      this.privateKey,
+      required this.payload,
+      required this.addTokenTo,
+      required this.algorithm,
+      required this.isSecretBase64Encoded,
+      required this.headerPrefix,
+      required this.queryParamKey,
+      required this.header});
+  factory _AuthJwtModel.fromJson(Map<String, dynamic> json) =>
+      _$AuthJwtModelFromJson(json);
 
   @override
-  String get secret;
+  final String secret;
   @override
-  String? get privateKey;
+  final String? privateKey;
   @override
-  String get payload;
+  final String payload;
   @override
-  String get addTokenTo;
+  final String addTokenTo;
   @override
-  String get algorithm;
+  final String algorithm;
   @override
-  bool get isSecretBase64Encoded;
+  final bool isSecretBase64Encoded;
   @override
-  String get headerPrefix;
+  final String headerPrefix;
   @override
-  String get queryParamKey;
+  final String queryParamKey;
   @override
-  String get header;
+  final String header;
 
   /// Create a copy of AuthJwtModel
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$AuthJwtModelImplCopyWith<_$AuthJwtModelImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  _$AuthJwtModelCopyWith<_AuthJwtModel> get copyWith =>
+      __$AuthJwtModelCopyWithImpl<_AuthJwtModel>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$AuthJwtModelToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _AuthJwtModel &&
+            (identical(other.secret, secret) || other.secret == secret) &&
+            (identical(other.privateKey, privateKey) ||
+                other.privateKey == privateKey) &&
+            (identical(other.payload, payload) || other.payload == payload) &&
+            (identical(other.addTokenTo, addTokenTo) ||
+                other.addTokenTo == addTokenTo) &&
+            (identical(other.algorithm, algorithm) ||
+                other.algorithm == algorithm) &&
+            (identical(other.isSecretBase64Encoded, isSecretBase64Encoded) ||
+                other.isSecretBase64Encoded == isSecretBase64Encoded) &&
+            (identical(other.headerPrefix, headerPrefix) ||
+                other.headerPrefix == headerPrefix) &&
+            (identical(other.queryParamKey, queryParamKey) ||
+                other.queryParamKey == queryParamKey) &&
+            (identical(other.header, header) || other.header == header));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      secret,
+      privateKey,
+      payload,
+      addTokenTo,
+      algorithm,
+      isSecretBase64Encoded,
+      headerPrefix,
+      queryParamKey,
+      header);
+
+  @override
+  String toString() {
+    return 'AuthJwtModel(secret: $secret, privateKey: $privateKey, payload: $payload, addTokenTo: $addTokenTo, algorithm: $algorithm, isSecretBase64Encoded: $isSecretBase64Encoded, headerPrefix: $headerPrefix, queryParamKey: $queryParamKey, header: $header)';
+  }
 }
+
+/// @nodoc
+abstract mixin class _$AuthJwtModelCopyWith<$Res>
+    implements $AuthJwtModelCopyWith<$Res> {
+  factory _$AuthJwtModelCopyWith(
+          _AuthJwtModel value, $Res Function(_AuthJwtModel) _then) =
+      __$AuthJwtModelCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String secret,
+      String? privateKey,
+      String payload,
+      String addTokenTo,
+      String algorithm,
+      bool isSecretBase64Encoded,
+      String headerPrefix,
+      String queryParamKey,
+      String header});
+}
+
+/// @nodoc
+class __$AuthJwtModelCopyWithImpl<$Res>
+    implements _$AuthJwtModelCopyWith<$Res> {
+  __$AuthJwtModelCopyWithImpl(this._self, this._then);
+
+  final _AuthJwtModel _self;
+  final $Res Function(_AuthJwtModel) _then;
+
+  /// Create a copy of AuthJwtModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? secret = null,
+    Object? privateKey = freezed,
+    Object? payload = null,
+    Object? addTokenTo = null,
+    Object? algorithm = null,
+    Object? isSecretBase64Encoded = null,
+    Object? headerPrefix = null,
+    Object? queryParamKey = null,
+    Object? header = null,
+  }) {
+    return _then(_AuthJwtModel(
+      secret: null == secret
+          ? _self.secret
+          : secret // ignore: cast_nullable_to_non_nullable
+              as String,
+      privateKey: freezed == privateKey
+          ? _self.privateKey
+          : privateKey // ignore: cast_nullable_to_non_nullable
+              as String?,
+      payload: null == payload
+          ? _self.payload
+          : payload // ignore: cast_nullable_to_non_nullable
+              as String,
+      addTokenTo: null == addTokenTo
+          ? _self.addTokenTo
+          : addTokenTo // ignore: cast_nullable_to_non_nullable
+              as String,
+      algorithm: null == algorithm
+          ? _self.algorithm
+          : algorithm // ignore: cast_nullable_to_non_nullable
+              as String,
+      isSecretBase64Encoded: null == isSecretBase64Encoded
+          ? _self.isSecretBase64Encoded
+          : isSecretBase64Encoded // ignore: cast_nullable_to_non_nullable
+              as bool,
+      headerPrefix: null == headerPrefix
+          ? _self.headerPrefix
+          : headerPrefix // ignore: cast_nullable_to_non_nullable
+              as String,
+      queryParamKey: null == queryParamKey
+          ? _self.queryParamKey
+          : queryParamKey // ignore: cast_nullable_to_non_nullable
+              as String,
+      header: null == header
+          ? _self.header
+          : header // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+// dart format on

--- a/packages/better_networking/lib/models/auth/auth_jwt_model.g.dart
+++ b/packages/better_networking/lib/models/auth/auth_jwt_model.g.dart
@@ -6,8 +6,8 @@ part of 'auth_jwt_model.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$AuthJwtModelImpl _$$AuthJwtModelImplFromJson(Map<String, dynamic> json) =>
-    _$AuthJwtModelImpl(
+_AuthJwtModel _$AuthJwtModelFromJson(Map<String, dynamic> json) =>
+    _AuthJwtModel(
       secret: json['secret'] as String,
       privateKey: json['privateKey'] as String?,
       payload: json['payload'] as String,
@@ -19,7 +19,7 @@ _$AuthJwtModelImpl _$$AuthJwtModelImplFromJson(Map<String, dynamic> json) =>
       header: json['header'] as String,
     );
 
-Map<String, dynamic> _$$AuthJwtModelImplToJson(_$AuthJwtModelImpl instance) =>
+Map<String, dynamic> _$AuthJwtModelToJson(_AuthJwtModel instance) =>
     <String, dynamic>{
       'secret': instance.secret,
       'privateKey': instance.privateKey,

--- a/packages/better_networking/lib/models/auth/auth_oauth1_model.freezed.dart
+++ b/packages/better_networking/lib/models/auth/auth_oauth1_model.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,198 +9,124 @@ part of 'auth_oauth1_model.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
-
-AuthOAuth1Model _$AuthOAuth1ModelFromJson(Map<String, dynamic> json) {
-  return _AuthOAuth1Model.fromJson(json);
-}
 
 /// @nodoc
 mixin _$AuthOAuth1Model {
-  String get consumerKey => throw _privateConstructorUsedError;
-  String get consumerSecret => throw _privateConstructorUsedError;
-  String? get credentialsFilePath => throw _privateConstructorUsedError;
-  String? get accessToken => throw _privateConstructorUsedError;
-  String? get tokenSecret => throw _privateConstructorUsedError;
-  OAuth1SignatureMethod get signatureMethod =>
-      throw _privateConstructorUsedError;
-  String get parameterLocation => throw _privateConstructorUsedError;
-  String get version => throw _privateConstructorUsedError;
-  String? get realm => throw _privateConstructorUsedError;
-  String? get callbackUrl => throw _privateConstructorUsedError;
-  String? get verifier => throw _privateConstructorUsedError;
-  String? get nonce => throw _privateConstructorUsedError;
-  String? get timestamp => throw _privateConstructorUsedError;
-  bool get includeBodyHash => throw _privateConstructorUsedError;
-
-  /// Serializes this AuthOAuth1Model to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  String get consumerKey;
+  String get consumerSecret;
+  String? get credentialsFilePath;
+  String? get accessToken;
+  String? get tokenSecret;
+  OAuth1SignatureMethod get signatureMethod;
+  String get parameterLocation;
+  String get version;
+  String? get realm;
+  String? get callbackUrl;
+  String? get verifier;
+  String? get nonce;
+  String? get timestamp;
+  bool get includeBodyHash;
 
   /// Create a copy of AuthOAuth1Model
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $AuthOAuth1ModelCopyWith<AuthOAuth1Model> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $AuthOAuth1ModelCopyWith<$Res> {
-  factory $AuthOAuth1ModelCopyWith(
-    AuthOAuth1Model value,
-    $Res Function(AuthOAuth1Model) then,
-  ) = _$AuthOAuth1ModelCopyWithImpl<$Res, AuthOAuth1Model>;
-  @useResult
-  $Res call({
-    String consumerKey,
-    String consumerSecret,
-    String? credentialsFilePath,
-    String? accessToken,
-    String? tokenSecret,
-    OAuth1SignatureMethod signatureMethod,
-    String parameterLocation,
-    String version,
-    String? realm,
-    String? callbackUrl,
-    String? verifier,
-    String? nonce,
-    String? timestamp,
-    bool includeBodyHash,
-  });
-}
-
-/// @nodoc
-class _$AuthOAuth1ModelCopyWithImpl<$Res, $Val extends AuthOAuth1Model>
-    implements $AuthOAuth1ModelCopyWith<$Res> {
-  _$AuthOAuth1ModelCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of AuthOAuth1Model
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
+  $AuthOAuth1ModelCopyWith<AuthOAuth1Model> get copyWith =>
+      _$AuthOAuth1ModelCopyWithImpl<AuthOAuth1Model>(
+          this as AuthOAuth1Model, _$identity);
+
+  /// Serializes this AuthOAuth1Model to a JSON map.
+  Map<String, dynamic> toJson();
+
   @override
-  $Res call({
-    Object? consumerKey = null,
-    Object? consumerSecret = null,
-    Object? credentialsFilePath = freezed,
-    Object? accessToken = freezed,
-    Object? tokenSecret = freezed,
-    Object? signatureMethod = null,
-    Object? parameterLocation = null,
-    Object? version = null,
-    Object? realm = freezed,
-    Object? callbackUrl = freezed,
-    Object? verifier = freezed,
-    Object? nonce = freezed,
-    Object? timestamp = freezed,
-    Object? includeBodyHash = null,
-  }) {
-    return _then(
-      _value.copyWith(
-            consumerKey: null == consumerKey
-                ? _value.consumerKey
-                : consumerKey // ignore: cast_nullable_to_non_nullable
-                      as String,
-            consumerSecret: null == consumerSecret
-                ? _value.consumerSecret
-                : consumerSecret // ignore: cast_nullable_to_non_nullable
-                      as String,
-            credentialsFilePath: freezed == credentialsFilePath
-                ? _value.credentialsFilePath
-                : credentialsFilePath // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            accessToken: freezed == accessToken
-                ? _value.accessToken
-                : accessToken // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            tokenSecret: freezed == tokenSecret
-                ? _value.tokenSecret
-                : tokenSecret // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            signatureMethod: null == signatureMethod
-                ? _value.signatureMethod
-                : signatureMethod // ignore: cast_nullable_to_non_nullable
-                      as OAuth1SignatureMethod,
-            parameterLocation: null == parameterLocation
-                ? _value.parameterLocation
-                : parameterLocation // ignore: cast_nullable_to_non_nullable
-                      as String,
-            version: null == version
-                ? _value.version
-                : version // ignore: cast_nullable_to_non_nullable
-                      as String,
-            realm: freezed == realm
-                ? _value.realm
-                : realm // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            callbackUrl: freezed == callbackUrl
-                ? _value.callbackUrl
-                : callbackUrl // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            verifier: freezed == verifier
-                ? _value.verifier
-                : verifier // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            nonce: freezed == nonce
-                ? _value.nonce
-                : nonce // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            timestamp: freezed == timestamp
-                ? _value.timestamp
-                : timestamp // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            includeBodyHash: null == includeBodyHash
-                ? _value.includeBodyHash
-                : includeBodyHash // ignore: cast_nullable_to_non_nullable
-                      as bool,
-          )
-          as $Val,
-    );
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is AuthOAuth1Model &&
+            (identical(other.consumerKey, consumerKey) ||
+                other.consumerKey == consumerKey) &&
+            (identical(other.consumerSecret, consumerSecret) ||
+                other.consumerSecret == consumerSecret) &&
+            (identical(other.credentialsFilePath, credentialsFilePath) ||
+                other.credentialsFilePath == credentialsFilePath) &&
+            (identical(other.accessToken, accessToken) ||
+                other.accessToken == accessToken) &&
+            (identical(other.tokenSecret, tokenSecret) ||
+                other.tokenSecret == tokenSecret) &&
+            (identical(other.signatureMethod, signatureMethod) ||
+                other.signatureMethod == signatureMethod) &&
+            (identical(other.parameterLocation, parameterLocation) ||
+                other.parameterLocation == parameterLocation) &&
+            (identical(other.version, version) || other.version == version) &&
+            (identical(other.realm, realm) || other.realm == realm) &&
+            (identical(other.callbackUrl, callbackUrl) ||
+                other.callbackUrl == callbackUrl) &&
+            (identical(other.verifier, verifier) ||
+                other.verifier == verifier) &&
+            (identical(other.nonce, nonce) || other.nonce == nonce) &&
+            (identical(other.timestamp, timestamp) ||
+                other.timestamp == timestamp) &&
+            (identical(other.includeBodyHash, includeBodyHash) ||
+                other.includeBodyHash == includeBodyHash));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      consumerKey,
+      consumerSecret,
+      credentialsFilePath,
+      accessToken,
+      tokenSecret,
+      signatureMethod,
+      parameterLocation,
+      version,
+      realm,
+      callbackUrl,
+      verifier,
+      nonce,
+      timestamp,
+      includeBodyHash);
+
+  @override
+  String toString() {
+    return 'AuthOAuth1Model(consumerKey: $consumerKey, consumerSecret: $consumerSecret, credentialsFilePath: $credentialsFilePath, accessToken: $accessToken, tokenSecret: $tokenSecret, signatureMethod: $signatureMethod, parameterLocation: $parameterLocation, version: $version, realm: $realm, callbackUrl: $callbackUrl, verifier: $verifier, nonce: $nonce, timestamp: $timestamp, includeBodyHash: $includeBodyHash)';
   }
 }
 
 /// @nodoc
-abstract class _$$AuthOAuth1ModelImplCopyWith<$Res>
-    implements $AuthOAuth1ModelCopyWith<$Res> {
-  factory _$$AuthOAuth1ModelImplCopyWith(
-    _$AuthOAuth1ModelImpl value,
-    $Res Function(_$AuthOAuth1ModelImpl) then,
-  ) = __$$AuthOAuth1ModelImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $AuthOAuth1ModelCopyWith<$Res> {
+  factory $AuthOAuth1ModelCopyWith(
+          AuthOAuth1Model value, $Res Function(AuthOAuth1Model) _then) =
+      _$AuthOAuth1ModelCopyWithImpl;
   @useResult
-  $Res call({
-    String consumerKey,
-    String consumerSecret,
-    String? credentialsFilePath,
-    String? accessToken,
-    String? tokenSecret,
-    OAuth1SignatureMethod signatureMethod,
-    String parameterLocation,
-    String version,
-    String? realm,
-    String? callbackUrl,
-    String? verifier,
-    String? nonce,
-    String? timestamp,
-    bool includeBodyHash,
-  });
+  $Res call(
+      {String consumerKey,
+      String consumerSecret,
+      String? credentialsFilePath,
+      String? accessToken,
+      String? tokenSecret,
+      OAuth1SignatureMethod signatureMethod,
+      String parameterLocation,
+      String version,
+      String? realm,
+      String? callbackUrl,
+      String? verifier,
+      String? nonce,
+      String? timestamp,
+      bool includeBodyHash});
 }
 
 /// @nodoc
-class __$$AuthOAuth1ModelImplCopyWithImpl<$Res>
-    extends _$AuthOAuth1ModelCopyWithImpl<$Res, _$AuthOAuth1ModelImpl>
-    implements _$$AuthOAuth1ModelImplCopyWith<$Res> {
-  __$$AuthOAuth1ModelImplCopyWithImpl(
-    _$AuthOAuth1ModelImpl _value,
-    $Res Function(_$AuthOAuth1ModelImpl) _then,
-  ) : super(_value, _then);
+class _$AuthOAuth1ModelCopyWithImpl<$Res>
+    implements $AuthOAuth1ModelCopyWith<$Res> {
+  _$AuthOAuth1ModelCopyWithImpl(this._self, this._then);
+
+  final AuthOAuth1Model _self;
+  final $Res Function(AuthOAuth1Model) _then;
 
   /// Create a copy of AuthOAuth1Model
   /// with the given fields replaced by the non-null parameter values.
@@ -222,91 +148,331 @@ class __$$AuthOAuth1ModelImplCopyWithImpl<$Res>
     Object? timestamp = freezed,
     Object? includeBodyHash = null,
   }) {
-    return _then(
-      _$AuthOAuth1ModelImpl(
-        consumerKey: null == consumerKey
-            ? _value.consumerKey
-            : consumerKey // ignore: cast_nullable_to_non_nullable
-                  as String,
-        consumerSecret: null == consumerSecret
-            ? _value.consumerSecret
-            : consumerSecret // ignore: cast_nullable_to_non_nullable
-                  as String,
-        credentialsFilePath: freezed == credentialsFilePath
-            ? _value.credentialsFilePath
-            : credentialsFilePath // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        accessToken: freezed == accessToken
-            ? _value.accessToken
-            : accessToken // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        tokenSecret: freezed == tokenSecret
-            ? _value.tokenSecret
-            : tokenSecret // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        signatureMethod: null == signatureMethod
-            ? _value.signatureMethod
-            : signatureMethod // ignore: cast_nullable_to_non_nullable
-                  as OAuth1SignatureMethod,
-        parameterLocation: null == parameterLocation
-            ? _value.parameterLocation
-            : parameterLocation // ignore: cast_nullable_to_non_nullable
-                  as String,
-        version: null == version
-            ? _value.version
-            : version // ignore: cast_nullable_to_non_nullable
-                  as String,
-        realm: freezed == realm
-            ? _value.realm
-            : realm // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        callbackUrl: freezed == callbackUrl
-            ? _value.callbackUrl
-            : callbackUrl // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        verifier: freezed == verifier
-            ? _value.verifier
-            : verifier // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        nonce: freezed == nonce
-            ? _value.nonce
-            : nonce // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        timestamp: freezed == timestamp
-            ? _value.timestamp
-            : timestamp // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        includeBodyHash: null == includeBodyHash
-            ? _value.includeBodyHash
-            : includeBodyHash // ignore: cast_nullable_to_non_nullable
-                  as bool,
-      ),
-    );
+    return _then(_self.copyWith(
+      consumerKey: null == consumerKey
+          ? _self.consumerKey
+          : consumerKey // ignore: cast_nullable_to_non_nullable
+              as String,
+      consumerSecret: null == consumerSecret
+          ? _self.consumerSecret
+          : consumerSecret // ignore: cast_nullable_to_non_nullable
+              as String,
+      credentialsFilePath: freezed == credentialsFilePath
+          ? _self.credentialsFilePath
+          : credentialsFilePath // ignore: cast_nullable_to_non_nullable
+              as String?,
+      accessToken: freezed == accessToken
+          ? _self.accessToken
+          : accessToken // ignore: cast_nullable_to_non_nullable
+              as String?,
+      tokenSecret: freezed == tokenSecret
+          ? _self.tokenSecret
+          : tokenSecret // ignore: cast_nullable_to_non_nullable
+              as String?,
+      signatureMethod: null == signatureMethod
+          ? _self.signatureMethod
+          : signatureMethod // ignore: cast_nullable_to_non_nullable
+              as OAuth1SignatureMethod,
+      parameterLocation: null == parameterLocation
+          ? _self.parameterLocation
+          : parameterLocation // ignore: cast_nullable_to_non_nullable
+              as String,
+      version: null == version
+          ? _self.version
+          : version // ignore: cast_nullable_to_non_nullable
+              as String,
+      realm: freezed == realm
+          ? _self.realm
+          : realm // ignore: cast_nullable_to_non_nullable
+              as String?,
+      callbackUrl: freezed == callbackUrl
+          ? _self.callbackUrl
+          : callbackUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+      verifier: freezed == verifier
+          ? _self.verifier
+          : verifier // ignore: cast_nullable_to_non_nullable
+              as String?,
+      nonce: freezed == nonce
+          ? _self.nonce
+          : nonce // ignore: cast_nullable_to_non_nullable
+              as String?,
+      timestamp: freezed == timestamp
+          ? _self.timestamp
+          : timestamp // ignore: cast_nullable_to_non_nullable
+              as String?,
+      includeBodyHash: null == includeBodyHash
+          ? _self.includeBodyHash
+          : includeBodyHash // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [AuthOAuth1Model].
+extension AuthOAuth1ModelPatterns on AuthOAuth1Model {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_AuthOAuth1Model value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _AuthOAuth1Model() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_AuthOAuth1Model value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthOAuth1Model():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_AuthOAuth1Model value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthOAuth1Model() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String consumerKey,
+            String consumerSecret,
+            String? credentialsFilePath,
+            String? accessToken,
+            String? tokenSecret,
+            OAuth1SignatureMethod signatureMethod,
+            String parameterLocation,
+            String version,
+            String? realm,
+            String? callbackUrl,
+            String? verifier,
+            String? nonce,
+            String? timestamp,
+            bool includeBodyHash)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _AuthOAuth1Model() when $default != null:
+        return $default(
+            _that.consumerKey,
+            _that.consumerSecret,
+            _that.credentialsFilePath,
+            _that.accessToken,
+            _that.tokenSecret,
+            _that.signatureMethod,
+            _that.parameterLocation,
+            _that.version,
+            _that.realm,
+            _that.callbackUrl,
+            _that.verifier,
+            _that.nonce,
+            _that.timestamp,
+            _that.includeBodyHash);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String consumerKey,
+            String consumerSecret,
+            String? credentialsFilePath,
+            String? accessToken,
+            String? tokenSecret,
+            OAuth1SignatureMethod signatureMethod,
+            String parameterLocation,
+            String version,
+            String? realm,
+            String? callbackUrl,
+            String? verifier,
+            String? nonce,
+            String? timestamp,
+            bool includeBodyHash)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthOAuth1Model():
+        return $default(
+            _that.consumerKey,
+            _that.consumerSecret,
+            _that.credentialsFilePath,
+            _that.accessToken,
+            _that.tokenSecret,
+            _that.signatureMethod,
+            _that.parameterLocation,
+            _that.version,
+            _that.realm,
+            _that.callbackUrl,
+            _that.verifier,
+            _that.nonce,
+            _that.timestamp,
+            _that.includeBodyHash);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String consumerKey,
+            String consumerSecret,
+            String? credentialsFilePath,
+            String? accessToken,
+            String? tokenSecret,
+            OAuth1SignatureMethod signatureMethod,
+            String parameterLocation,
+            String version,
+            String? realm,
+            String? callbackUrl,
+            String? verifier,
+            String? nonce,
+            String? timestamp,
+            bool includeBodyHash)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthOAuth1Model() when $default != null:
+        return $default(
+            _that.consumerKey,
+            _that.consumerSecret,
+            _that.credentialsFilePath,
+            _that.accessToken,
+            _that.tokenSecret,
+            _that.signatureMethod,
+            _that.parameterLocation,
+            _that.version,
+            _that.realm,
+            _that.callbackUrl,
+            _that.verifier,
+            _that.nonce,
+            _that.timestamp,
+            _that.includeBodyHash);
+      case _:
+        return null;
+    }
   }
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$AuthOAuth1ModelImpl implements _AuthOAuth1Model {
-  const _$AuthOAuth1ModelImpl({
-    required this.consumerKey,
-    required this.consumerSecret,
-    this.credentialsFilePath,
-    this.accessToken,
-    this.tokenSecret,
-    this.signatureMethod = OAuth1SignatureMethod.hmacSha1,
-    this.parameterLocation = "header",
-    this.version = '1.0',
-    this.realm,
-    this.callbackUrl,
-    this.verifier,
-    this.nonce,
-    this.timestamp,
-    this.includeBodyHash = false,
-  });
-
-  factory _$AuthOAuth1ModelImpl.fromJson(Map<String, dynamic> json) =>
-      _$$AuthOAuth1ModelImplFromJson(json);
+class _AuthOAuth1Model implements AuthOAuth1Model {
+  const _AuthOAuth1Model(
+      {required this.consumerKey,
+      required this.consumerSecret,
+      this.credentialsFilePath,
+      this.accessToken,
+      this.tokenSecret,
+      this.signatureMethod = OAuth1SignatureMethod.hmacSha1,
+      this.parameterLocation = "header",
+      this.version = '1.0',
+      this.realm,
+      this.callbackUrl,
+      this.verifier,
+      this.nonce,
+      this.timestamp,
+      this.includeBodyHash = false});
+  factory _AuthOAuth1Model.fromJson(Map<String, dynamic> json) =>
+      _$AuthOAuth1ModelFromJson(json);
 
   @override
   final String consumerKey;
@@ -341,16 +507,26 @@ class _$AuthOAuth1ModelImpl implements _AuthOAuth1Model {
   @JsonKey()
   final bool includeBodyHash;
 
+  /// Create a copy of AuthOAuth1Model
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'AuthOAuth1Model(consumerKey: $consumerKey, consumerSecret: $consumerSecret, credentialsFilePath: $credentialsFilePath, accessToken: $accessToken, tokenSecret: $tokenSecret, signatureMethod: $signatureMethod, parameterLocation: $parameterLocation, version: $version, realm: $realm, callbackUrl: $callbackUrl, verifier: $verifier, nonce: $nonce, timestamp: $timestamp, includeBodyHash: $includeBodyHash)';
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$AuthOAuth1ModelCopyWith<_AuthOAuth1Model> get copyWith =>
+      __$AuthOAuth1ModelCopyWithImpl<_AuthOAuth1Model>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$AuthOAuth1ModelToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AuthOAuth1ModelImpl &&
+            other is _AuthOAuth1Model &&
             (identical(other.consumerKey, consumerKey) ||
                 other.consumerKey == consumerKey) &&
             (identical(other.consumerSecret, consumerSecret) ||
@@ -381,94 +557,140 @@ class _$AuthOAuth1ModelImpl implements _AuthOAuth1Model {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
-    runtimeType,
-    consumerKey,
-    consumerSecret,
-    credentialsFilePath,
-    accessToken,
-    tokenSecret,
-    signatureMethod,
-    parameterLocation,
-    version,
-    realm,
-    callbackUrl,
-    verifier,
-    nonce,
-    timestamp,
-    includeBodyHash,
-  );
-
-  /// Create a copy of AuthOAuth1Model
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$AuthOAuth1ModelImplCopyWith<_$AuthOAuth1ModelImpl> get copyWith =>
-      __$$AuthOAuth1ModelImplCopyWithImpl<_$AuthOAuth1ModelImpl>(
-        this,
-        _$identity,
-      );
+      runtimeType,
+      consumerKey,
+      consumerSecret,
+      credentialsFilePath,
+      accessToken,
+      tokenSecret,
+      signatureMethod,
+      parameterLocation,
+      version,
+      realm,
+      callbackUrl,
+      verifier,
+      nonce,
+      timestamp,
+      includeBodyHash);
 
   @override
-  Map<String, dynamic> toJson() {
-    return _$$AuthOAuth1ModelImplToJson(this);
+  String toString() {
+    return 'AuthOAuth1Model(consumerKey: $consumerKey, consumerSecret: $consumerSecret, credentialsFilePath: $credentialsFilePath, accessToken: $accessToken, tokenSecret: $tokenSecret, signatureMethod: $signatureMethod, parameterLocation: $parameterLocation, version: $version, realm: $realm, callbackUrl: $callbackUrl, verifier: $verifier, nonce: $nonce, timestamp: $timestamp, includeBodyHash: $includeBodyHash)';
   }
 }
 
-abstract class _AuthOAuth1Model implements AuthOAuth1Model {
-  const factory _AuthOAuth1Model({
-    required final String consumerKey,
-    required final String consumerSecret,
-    final String? credentialsFilePath,
-    final String? accessToken,
-    final String? tokenSecret,
-    final OAuth1SignatureMethod signatureMethod,
-    final String parameterLocation,
-    final String version,
-    final String? realm,
-    final String? callbackUrl,
-    final String? verifier,
-    final String? nonce,
-    final String? timestamp,
-    final bool includeBodyHash,
-  }) = _$AuthOAuth1ModelImpl;
+/// @nodoc
+abstract mixin class _$AuthOAuth1ModelCopyWith<$Res>
+    implements $AuthOAuth1ModelCopyWith<$Res> {
+  factory _$AuthOAuth1ModelCopyWith(
+          _AuthOAuth1Model value, $Res Function(_AuthOAuth1Model) _then) =
+      __$AuthOAuth1ModelCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String consumerKey,
+      String consumerSecret,
+      String? credentialsFilePath,
+      String? accessToken,
+      String? tokenSecret,
+      OAuth1SignatureMethod signatureMethod,
+      String parameterLocation,
+      String version,
+      String? realm,
+      String? callbackUrl,
+      String? verifier,
+      String? nonce,
+      String? timestamp,
+      bool includeBodyHash});
+}
 
-  factory _AuthOAuth1Model.fromJson(Map<String, dynamic> json) =
-      _$AuthOAuth1ModelImpl.fromJson;
+/// @nodoc
+class __$AuthOAuth1ModelCopyWithImpl<$Res>
+    implements _$AuthOAuth1ModelCopyWith<$Res> {
+  __$AuthOAuth1ModelCopyWithImpl(this._self, this._then);
 
-  @override
-  String get consumerKey;
-  @override
-  String get consumerSecret;
-  @override
-  String? get credentialsFilePath;
-  @override
-  String? get accessToken;
-  @override
-  String? get tokenSecret;
-  @override
-  OAuth1SignatureMethod get signatureMethod;
-  @override
-  String get parameterLocation;
-  @override
-  String get version;
-  @override
-  String? get realm;
-  @override
-  String? get callbackUrl;
-  @override
-  String? get verifier;
-  @override
-  String? get nonce;
-  @override
-  String? get timestamp;
-  @override
-  bool get includeBodyHash;
+  final _AuthOAuth1Model _self;
+  final $Res Function(_AuthOAuth1Model) _then;
 
   /// Create a copy of AuthOAuth1Model
   /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$AuthOAuth1ModelImplCopyWith<_$AuthOAuth1ModelImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? consumerKey = null,
+    Object? consumerSecret = null,
+    Object? credentialsFilePath = freezed,
+    Object? accessToken = freezed,
+    Object? tokenSecret = freezed,
+    Object? signatureMethod = null,
+    Object? parameterLocation = null,
+    Object? version = null,
+    Object? realm = freezed,
+    Object? callbackUrl = freezed,
+    Object? verifier = freezed,
+    Object? nonce = freezed,
+    Object? timestamp = freezed,
+    Object? includeBodyHash = null,
+  }) {
+    return _then(_AuthOAuth1Model(
+      consumerKey: null == consumerKey
+          ? _self.consumerKey
+          : consumerKey // ignore: cast_nullable_to_non_nullable
+              as String,
+      consumerSecret: null == consumerSecret
+          ? _self.consumerSecret
+          : consumerSecret // ignore: cast_nullable_to_non_nullable
+              as String,
+      credentialsFilePath: freezed == credentialsFilePath
+          ? _self.credentialsFilePath
+          : credentialsFilePath // ignore: cast_nullable_to_non_nullable
+              as String?,
+      accessToken: freezed == accessToken
+          ? _self.accessToken
+          : accessToken // ignore: cast_nullable_to_non_nullable
+              as String?,
+      tokenSecret: freezed == tokenSecret
+          ? _self.tokenSecret
+          : tokenSecret // ignore: cast_nullable_to_non_nullable
+              as String?,
+      signatureMethod: null == signatureMethod
+          ? _self.signatureMethod
+          : signatureMethod // ignore: cast_nullable_to_non_nullable
+              as OAuth1SignatureMethod,
+      parameterLocation: null == parameterLocation
+          ? _self.parameterLocation
+          : parameterLocation // ignore: cast_nullable_to_non_nullable
+              as String,
+      version: null == version
+          ? _self.version
+          : version // ignore: cast_nullable_to_non_nullable
+              as String,
+      realm: freezed == realm
+          ? _self.realm
+          : realm // ignore: cast_nullable_to_non_nullable
+              as String?,
+      callbackUrl: freezed == callbackUrl
+          ? _self.callbackUrl
+          : callbackUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+      verifier: freezed == verifier
+          ? _self.verifier
+          : verifier // ignore: cast_nullable_to_non_nullable
+              as String?,
+      nonce: freezed == nonce
+          ? _self.nonce
+          : nonce // ignore: cast_nullable_to_non_nullable
+              as String?,
+      timestamp: freezed == timestamp
+          ? _self.timestamp
+          : timestamp // ignore: cast_nullable_to_non_nullable
+              as String?,
+      includeBodyHash: null == includeBodyHash
+          ? _self.includeBodyHash
+          : includeBodyHash // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
 }
+
+// dart format on

--- a/packages/better_networking/lib/models/auth/auth_oauth1_model.g.dart
+++ b/packages/better_networking/lib/models/auth/auth_oauth1_model.g.dart
@@ -6,48 +6,44 @@ part of 'auth_oauth1_model.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$AuthOAuth1ModelImpl _$$AuthOAuth1ModelImplFromJson(
-  Map<String, dynamic> json,
-) => _$AuthOAuth1ModelImpl(
-  consumerKey: json['consumerKey'] as String,
-  consumerSecret: json['consumerSecret'] as String,
-  credentialsFilePath: json['credentialsFilePath'] as String?,
-  accessToken: json['accessToken'] as String?,
-  tokenSecret: json['tokenSecret'] as String?,
-  signatureMethod:
-      $enumDecodeNullable(
-        _$OAuth1SignatureMethodEnumMap,
-        json['signatureMethod'],
-      ) ??
-      OAuth1SignatureMethod.hmacSha1,
-  parameterLocation: json['parameterLocation'] as String? ?? "header",
-  version: json['version'] as String? ?? '1.0',
-  realm: json['realm'] as String?,
-  callbackUrl: json['callbackUrl'] as String?,
-  verifier: json['verifier'] as String?,
-  nonce: json['nonce'] as String?,
-  timestamp: json['timestamp'] as String?,
-  includeBodyHash: json['includeBodyHash'] as bool? ?? false,
-);
+_AuthOAuth1Model _$AuthOAuth1ModelFromJson(Map<String, dynamic> json) =>
+    _AuthOAuth1Model(
+      consumerKey: json['consumerKey'] as String,
+      consumerSecret: json['consumerSecret'] as String,
+      credentialsFilePath: json['credentialsFilePath'] as String?,
+      accessToken: json['accessToken'] as String?,
+      tokenSecret: json['tokenSecret'] as String?,
+      signatureMethod: $enumDecodeNullable(
+              _$OAuth1SignatureMethodEnumMap, json['signatureMethod']) ??
+          OAuth1SignatureMethod.hmacSha1,
+      parameterLocation: json['parameterLocation'] as String? ?? "header",
+      version: json['version'] as String? ?? '1.0',
+      realm: json['realm'] as String?,
+      callbackUrl: json['callbackUrl'] as String?,
+      verifier: json['verifier'] as String?,
+      nonce: json['nonce'] as String?,
+      timestamp: json['timestamp'] as String?,
+      includeBodyHash: json['includeBodyHash'] as bool? ?? false,
+    );
 
-Map<String, dynamic> _$$AuthOAuth1ModelImplToJson(
-  _$AuthOAuth1ModelImpl instance,
-) => <String, dynamic>{
-  'consumerKey': instance.consumerKey,
-  'consumerSecret': instance.consumerSecret,
-  'credentialsFilePath': instance.credentialsFilePath,
-  'accessToken': instance.accessToken,
-  'tokenSecret': instance.tokenSecret,
-  'signatureMethod': _$OAuth1SignatureMethodEnumMap[instance.signatureMethod]!,
-  'parameterLocation': instance.parameterLocation,
-  'version': instance.version,
-  'realm': instance.realm,
-  'callbackUrl': instance.callbackUrl,
-  'verifier': instance.verifier,
-  'nonce': instance.nonce,
-  'timestamp': instance.timestamp,
-  'includeBodyHash': instance.includeBodyHash,
-};
+Map<String, dynamic> _$AuthOAuth1ModelToJson(_AuthOAuth1Model instance) =>
+    <String, dynamic>{
+      'consumerKey': instance.consumerKey,
+      'consumerSecret': instance.consumerSecret,
+      'credentialsFilePath': instance.credentialsFilePath,
+      'accessToken': instance.accessToken,
+      'tokenSecret': instance.tokenSecret,
+      'signatureMethod':
+          _$OAuth1SignatureMethodEnumMap[instance.signatureMethod]!,
+      'parameterLocation': instance.parameterLocation,
+      'version': instance.version,
+      'realm': instance.realm,
+      'callbackUrl': instance.callbackUrl,
+      'verifier': instance.verifier,
+      'nonce': instance.nonce,
+      'timestamp': instance.timestamp,
+      'includeBodyHash': instance.includeBodyHash,
+    };
 
 const _$OAuth1SignatureMethodEnumMap = {
   OAuth1SignatureMethod.hmacSha1: 'hmacSha1',

--- a/packages/better_networking/lib/models/auth/auth_oauth2_model.freezed.dart
+++ b/packages/better_networking/lib/models/auth/auth_oauth2_model.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,221 +9,140 @@ part of 'auth_oauth2_model.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
-
-AuthOAuth2Model _$AuthOAuth2ModelFromJson(Map<String, dynamic> json) {
-  return _AuthOAuth2Model.fromJson(json);
-}
 
 /// @nodoc
 mixin _$AuthOAuth2Model {
-  OAuth2GrantType get grantType => throw _privateConstructorUsedError;
-  String get authorizationUrl => throw _privateConstructorUsedError;
-  String get accessTokenUrl => throw _privateConstructorUsedError;
-  String get clientId => throw _privateConstructorUsedError;
-  String get clientSecret => throw _privateConstructorUsedError;
-  String? get credentialsFilePath => throw _privateConstructorUsedError;
-  String? get redirectUrl => throw _privateConstructorUsedError;
-  String? get scope => throw _privateConstructorUsedError;
-  String? get state => throw _privateConstructorUsedError;
-  String get codeChallengeMethod => throw _privateConstructorUsedError;
-  String? get codeVerifier => throw _privateConstructorUsedError;
-  String? get codeChallenge => throw _privateConstructorUsedError;
-  String? get username => throw _privateConstructorUsedError;
-  String? get password => throw _privateConstructorUsedError;
-  String? get refreshToken => throw _privateConstructorUsedError;
-  String? get identityToken => throw _privateConstructorUsedError;
-  String? get accessToken => throw _privateConstructorUsedError;
-
-  /// Serializes this AuthOAuth2Model to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  OAuth2GrantType get grantType;
+  String get authorizationUrl;
+  String get accessTokenUrl;
+  String get clientId;
+  String get clientSecret;
+  String? get credentialsFilePath;
+  String? get redirectUrl;
+  String? get scope;
+  String? get state;
+  String get codeChallengeMethod;
+  String? get codeVerifier;
+  String? get codeChallenge;
+  String? get username;
+  String? get password;
+  String? get refreshToken;
+  String? get identityToken;
+  String? get accessToken;
 
   /// Create a copy of AuthOAuth2Model
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $AuthOAuth2ModelCopyWith<AuthOAuth2Model> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $AuthOAuth2ModelCopyWith<$Res> {
-  factory $AuthOAuth2ModelCopyWith(
-    AuthOAuth2Model value,
-    $Res Function(AuthOAuth2Model) then,
-  ) = _$AuthOAuth2ModelCopyWithImpl<$Res, AuthOAuth2Model>;
-  @useResult
-  $Res call({
-    OAuth2GrantType grantType,
-    String authorizationUrl,
-    String accessTokenUrl,
-    String clientId,
-    String clientSecret,
-    String? credentialsFilePath,
-    String? redirectUrl,
-    String? scope,
-    String? state,
-    String codeChallengeMethod,
-    String? codeVerifier,
-    String? codeChallenge,
-    String? username,
-    String? password,
-    String? refreshToken,
-    String? identityToken,
-    String? accessToken,
-  });
-}
-
-/// @nodoc
-class _$AuthOAuth2ModelCopyWithImpl<$Res, $Val extends AuthOAuth2Model>
-    implements $AuthOAuth2ModelCopyWith<$Res> {
-  _$AuthOAuth2ModelCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of AuthOAuth2Model
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
+  $AuthOAuth2ModelCopyWith<AuthOAuth2Model> get copyWith =>
+      _$AuthOAuth2ModelCopyWithImpl<AuthOAuth2Model>(
+          this as AuthOAuth2Model, _$identity);
+
+  /// Serializes this AuthOAuth2Model to a JSON map.
+  Map<String, dynamic> toJson();
+
   @override
-  $Res call({
-    Object? grantType = null,
-    Object? authorizationUrl = null,
-    Object? accessTokenUrl = null,
-    Object? clientId = null,
-    Object? clientSecret = null,
-    Object? credentialsFilePath = freezed,
-    Object? redirectUrl = freezed,
-    Object? scope = freezed,
-    Object? state = freezed,
-    Object? codeChallengeMethod = null,
-    Object? codeVerifier = freezed,
-    Object? codeChallenge = freezed,
-    Object? username = freezed,
-    Object? password = freezed,
-    Object? refreshToken = freezed,
-    Object? identityToken = freezed,
-    Object? accessToken = freezed,
-  }) {
-    return _then(
-      _value.copyWith(
-            grantType: null == grantType
-                ? _value.grantType
-                : grantType // ignore: cast_nullable_to_non_nullable
-                      as OAuth2GrantType,
-            authorizationUrl: null == authorizationUrl
-                ? _value.authorizationUrl
-                : authorizationUrl // ignore: cast_nullable_to_non_nullable
-                      as String,
-            accessTokenUrl: null == accessTokenUrl
-                ? _value.accessTokenUrl
-                : accessTokenUrl // ignore: cast_nullable_to_non_nullable
-                      as String,
-            clientId: null == clientId
-                ? _value.clientId
-                : clientId // ignore: cast_nullable_to_non_nullable
-                      as String,
-            clientSecret: null == clientSecret
-                ? _value.clientSecret
-                : clientSecret // ignore: cast_nullable_to_non_nullable
-                      as String,
-            credentialsFilePath: freezed == credentialsFilePath
-                ? _value.credentialsFilePath
-                : credentialsFilePath // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            redirectUrl: freezed == redirectUrl
-                ? _value.redirectUrl
-                : redirectUrl // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            scope: freezed == scope
-                ? _value.scope
-                : scope // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            state: freezed == state
-                ? _value.state
-                : state // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            codeChallengeMethod: null == codeChallengeMethod
-                ? _value.codeChallengeMethod
-                : codeChallengeMethod // ignore: cast_nullable_to_non_nullable
-                      as String,
-            codeVerifier: freezed == codeVerifier
-                ? _value.codeVerifier
-                : codeVerifier // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            codeChallenge: freezed == codeChallenge
-                ? _value.codeChallenge
-                : codeChallenge // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            username: freezed == username
-                ? _value.username
-                : username // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            password: freezed == password
-                ? _value.password
-                : password // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            refreshToken: freezed == refreshToken
-                ? _value.refreshToken
-                : refreshToken // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            identityToken: freezed == identityToken
-                ? _value.identityToken
-                : identityToken // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            accessToken: freezed == accessToken
-                ? _value.accessToken
-                : accessToken // ignore: cast_nullable_to_non_nullable
-                      as String?,
-          )
-          as $Val,
-    );
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is AuthOAuth2Model &&
+            (identical(other.grantType, grantType) ||
+                other.grantType == grantType) &&
+            (identical(other.authorizationUrl, authorizationUrl) ||
+                other.authorizationUrl == authorizationUrl) &&
+            (identical(other.accessTokenUrl, accessTokenUrl) ||
+                other.accessTokenUrl == accessTokenUrl) &&
+            (identical(other.clientId, clientId) ||
+                other.clientId == clientId) &&
+            (identical(other.clientSecret, clientSecret) ||
+                other.clientSecret == clientSecret) &&
+            (identical(other.credentialsFilePath, credentialsFilePath) ||
+                other.credentialsFilePath == credentialsFilePath) &&
+            (identical(other.redirectUrl, redirectUrl) ||
+                other.redirectUrl == redirectUrl) &&
+            (identical(other.scope, scope) || other.scope == scope) &&
+            (identical(other.state, state) || other.state == state) &&
+            (identical(other.codeChallengeMethod, codeChallengeMethod) ||
+                other.codeChallengeMethod == codeChallengeMethod) &&
+            (identical(other.codeVerifier, codeVerifier) ||
+                other.codeVerifier == codeVerifier) &&
+            (identical(other.codeChallenge, codeChallenge) ||
+                other.codeChallenge == codeChallenge) &&
+            (identical(other.username, username) ||
+                other.username == username) &&
+            (identical(other.password, password) ||
+                other.password == password) &&
+            (identical(other.refreshToken, refreshToken) ||
+                other.refreshToken == refreshToken) &&
+            (identical(other.identityToken, identityToken) ||
+                other.identityToken == identityToken) &&
+            (identical(other.accessToken, accessToken) ||
+                other.accessToken == accessToken));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      grantType,
+      authorizationUrl,
+      accessTokenUrl,
+      clientId,
+      clientSecret,
+      credentialsFilePath,
+      redirectUrl,
+      scope,
+      state,
+      codeChallengeMethod,
+      codeVerifier,
+      codeChallenge,
+      username,
+      password,
+      refreshToken,
+      identityToken,
+      accessToken);
+
+  @override
+  String toString() {
+    return 'AuthOAuth2Model(grantType: $grantType, authorizationUrl: $authorizationUrl, accessTokenUrl: $accessTokenUrl, clientId: $clientId, clientSecret: $clientSecret, credentialsFilePath: $credentialsFilePath, redirectUrl: $redirectUrl, scope: $scope, state: $state, codeChallengeMethod: $codeChallengeMethod, codeVerifier: $codeVerifier, codeChallenge: $codeChallenge, username: $username, password: $password, refreshToken: $refreshToken, identityToken: $identityToken, accessToken: $accessToken)';
   }
 }
 
 /// @nodoc
-abstract class _$$AuthOAuth2ModelImplCopyWith<$Res>
-    implements $AuthOAuth2ModelCopyWith<$Res> {
-  factory _$$AuthOAuth2ModelImplCopyWith(
-    _$AuthOAuth2ModelImpl value,
-    $Res Function(_$AuthOAuth2ModelImpl) then,
-  ) = __$$AuthOAuth2ModelImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $AuthOAuth2ModelCopyWith<$Res> {
+  factory $AuthOAuth2ModelCopyWith(
+          AuthOAuth2Model value, $Res Function(AuthOAuth2Model) _then) =
+      _$AuthOAuth2ModelCopyWithImpl;
   @useResult
-  $Res call({
-    OAuth2GrantType grantType,
-    String authorizationUrl,
-    String accessTokenUrl,
-    String clientId,
-    String clientSecret,
-    String? credentialsFilePath,
-    String? redirectUrl,
-    String? scope,
-    String? state,
-    String codeChallengeMethod,
-    String? codeVerifier,
-    String? codeChallenge,
-    String? username,
-    String? password,
-    String? refreshToken,
-    String? identityToken,
-    String? accessToken,
-  });
+  $Res call(
+      {OAuth2GrantType grantType,
+      String authorizationUrl,
+      String accessTokenUrl,
+      String clientId,
+      String clientSecret,
+      String? credentialsFilePath,
+      String? redirectUrl,
+      String? scope,
+      String? state,
+      String codeChallengeMethod,
+      String? codeVerifier,
+      String? codeChallenge,
+      String? username,
+      String? password,
+      String? refreshToken,
+      String? identityToken,
+      String? accessToken});
 }
 
 /// @nodoc
-class __$$AuthOAuth2ModelImplCopyWithImpl<$Res>
-    extends _$AuthOAuth2ModelCopyWithImpl<$Res, _$AuthOAuth2ModelImpl>
-    implements _$$AuthOAuth2ModelImplCopyWith<$Res> {
-  __$$AuthOAuth2ModelImplCopyWithImpl(
-    _$AuthOAuth2ModelImpl _value,
-    $Res Function(_$AuthOAuth2ModelImpl) _then,
-  ) : super(_value, _then);
+class _$AuthOAuth2ModelCopyWithImpl<$Res>
+    implements $AuthOAuth2ModelCopyWith<$Res> {
+  _$AuthOAuth2ModelCopyWithImpl(this._self, this._then);
+
+  final AuthOAuth2Model _self;
+  final $Res Function(AuthOAuth2Model) _then;
 
   /// Create a copy of AuthOAuth2Model
   /// with the given fields replaced by the non-null parameter values.
@@ -248,106 +167,364 @@ class __$$AuthOAuth2ModelImplCopyWithImpl<$Res>
     Object? identityToken = freezed,
     Object? accessToken = freezed,
   }) {
-    return _then(
-      _$AuthOAuth2ModelImpl(
-        grantType: null == grantType
-            ? _value.grantType
-            : grantType // ignore: cast_nullable_to_non_nullable
-                  as OAuth2GrantType,
-        authorizationUrl: null == authorizationUrl
-            ? _value.authorizationUrl
-            : authorizationUrl // ignore: cast_nullable_to_non_nullable
-                  as String,
-        accessTokenUrl: null == accessTokenUrl
-            ? _value.accessTokenUrl
-            : accessTokenUrl // ignore: cast_nullable_to_non_nullable
-                  as String,
-        clientId: null == clientId
-            ? _value.clientId
-            : clientId // ignore: cast_nullable_to_non_nullable
-                  as String,
-        clientSecret: null == clientSecret
-            ? _value.clientSecret
-            : clientSecret // ignore: cast_nullable_to_non_nullable
-                  as String,
-        credentialsFilePath: freezed == credentialsFilePath
-            ? _value.credentialsFilePath
-            : credentialsFilePath // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        redirectUrl: freezed == redirectUrl
-            ? _value.redirectUrl
-            : redirectUrl // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        scope: freezed == scope
-            ? _value.scope
-            : scope // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        state: freezed == state
-            ? _value.state
-            : state // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        codeChallengeMethod: null == codeChallengeMethod
-            ? _value.codeChallengeMethod
-            : codeChallengeMethod // ignore: cast_nullable_to_non_nullable
-                  as String,
-        codeVerifier: freezed == codeVerifier
-            ? _value.codeVerifier
-            : codeVerifier // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        codeChallenge: freezed == codeChallenge
-            ? _value.codeChallenge
-            : codeChallenge // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        username: freezed == username
-            ? _value.username
-            : username // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        password: freezed == password
-            ? _value.password
-            : password // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        refreshToken: freezed == refreshToken
-            ? _value.refreshToken
-            : refreshToken // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        identityToken: freezed == identityToken
-            ? _value.identityToken
-            : identityToken // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        accessToken: freezed == accessToken
-            ? _value.accessToken
-            : accessToken // ignore: cast_nullable_to_non_nullable
-                  as String?,
-      ),
-    );
+    return _then(_self.copyWith(
+      grantType: null == grantType
+          ? _self.grantType
+          : grantType // ignore: cast_nullable_to_non_nullable
+              as OAuth2GrantType,
+      authorizationUrl: null == authorizationUrl
+          ? _self.authorizationUrl
+          : authorizationUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      accessTokenUrl: null == accessTokenUrl
+          ? _self.accessTokenUrl
+          : accessTokenUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      clientId: null == clientId
+          ? _self.clientId
+          : clientId // ignore: cast_nullable_to_non_nullable
+              as String,
+      clientSecret: null == clientSecret
+          ? _self.clientSecret
+          : clientSecret // ignore: cast_nullable_to_non_nullable
+              as String,
+      credentialsFilePath: freezed == credentialsFilePath
+          ? _self.credentialsFilePath
+          : credentialsFilePath // ignore: cast_nullable_to_non_nullable
+              as String?,
+      redirectUrl: freezed == redirectUrl
+          ? _self.redirectUrl
+          : redirectUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+      scope: freezed == scope
+          ? _self.scope
+          : scope // ignore: cast_nullable_to_non_nullable
+              as String?,
+      state: freezed == state
+          ? _self.state
+          : state // ignore: cast_nullable_to_non_nullable
+              as String?,
+      codeChallengeMethod: null == codeChallengeMethod
+          ? _self.codeChallengeMethod
+          : codeChallengeMethod // ignore: cast_nullable_to_non_nullable
+              as String,
+      codeVerifier: freezed == codeVerifier
+          ? _self.codeVerifier
+          : codeVerifier // ignore: cast_nullable_to_non_nullable
+              as String?,
+      codeChallenge: freezed == codeChallenge
+          ? _self.codeChallenge
+          : codeChallenge // ignore: cast_nullable_to_non_nullable
+              as String?,
+      username: freezed == username
+          ? _self.username
+          : username // ignore: cast_nullable_to_non_nullable
+              as String?,
+      password: freezed == password
+          ? _self.password
+          : password // ignore: cast_nullable_to_non_nullable
+              as String?,
+      refreshToken: freezed == refreshToken
+          ? _self.refreshToken
+          : refreshToken // ignore: cast_nullable_to_non_nullable
+              as String?,
+      identityToken: freezed == identityToken
+          ? _self.identityToken
+          : identityToken // ignore: cast_nullable_to_non_nullable
+              as String?,
+      accessToken: freezed == accessToken
+          ? _self.accessToken
+          : accessToken // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [AuthOAuth2Model].
+extension AuthOAuth2ModelPatterns on AuthOAuth2Model {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_AuthOAuth2Model value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _AuthOAuth2Model() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_AuthOAuth2Model value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthOAuth2Model():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_AuthOAuth2Model value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthOAuth2Model() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            OAuth2GrantType grantType,
+            String authorizationUrl,
+            String accessTokenUrl,
+            String clientId,
+            String clientSecret,
+            String? credentialsFilePath,
+            String? redirectUrl,
+            String? scope,
+            String? state,
+            String codeChallengeMethod,
+            String? codeVerifier,
+            String? codeChallenge,
+            String? username,
+            String? password,
+            String? refreshToken,
+            String? identityToken,
+            String? accessToken)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _AuthOAuth2Model() when $default != null:
+        return $default(
+            _that.grantType,
+            _that.authorizationUrl,
+            _that.accessTokenUrl,
+            _that.clientId,
+            _that.clientSecret,
+            _that.credentialsFilePath,
+            _that.redirectUrl,
+            _that.scope,
+            _that.state,
+            _that.codeChallengeMethod,
+            _that.codeVerifier,
+            _that.codeChallenge,
+            _that.username,
+            _that.password,
+            _that.refreshToken,
+            _that.identityToken,
+            _that.accessToken);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            OAuth2GrantType grantType,
+            String authorizationUrl,
+            String accessTokenUrl,
+            String clientId,
+            String clientSecret,
+            String? credentialsFilePath,
+            String? redirectUrl,
+            String? scope,
+            String? state,
+            String codeChallengeMethod,
+            String? codeVerifier,
+            String? codeChallenge,
+            String? username,
+            String? password,
+            String? refreshToken,
+            String? identityToken,
+            String? accessToken)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthOAuth2Model():
+        return $default(
+            _that.grantType,
+            _that.authorizationUrl,
+            _that.accessTokenUrl,
+            _that.clientId,
+            _that.clientSecret,
+            _that.credentialsFilePath,
+            _that.redirectUrl,
+            _that.scope,
+            _that.state,
+            _that.codeChallengeMethod,
+            _that.codeVerifier,
+            _that.codeChallenge,
+            _that.username,
+            _that.password,
+            _that.refreshToken,
+            _that.identityToken,
+            _that.accessToken);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            OAuth2GrantType grantType,
+            String authorizationUrl,
+            String accessTokenUrl,
+            String clientId,
+            String clientSecret,
+            String? credentialsFilePath,
+            String? redirectUrl,
+            String? scope,
+            String? state,
+            String codeChallengeMethod,
+            String? codeVerifier,
+            String? codeChallenge,
+            String? username,
+            String? password,
+            String? refreshToken,
+            String? identityToken,
+            String? accessToken)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthOAuth2Model() when $default != null:
+        return $default(
+            _that.grantType,
+            _that.authorizationUrl,
+            _that.accessTokenUrl,
+            _that.clientId,
+            _that.clientSecret,
+            _that.credentialsFilePath,
+            _that.redirectUrl,
+            _that.scope,
+            _that.state,
+            _that.codeChallengeMethod,
+            _that.codeVerifier,
+            _that.codeChallenge,
+            _that.username,
+            _that.password,
+            _that.refreshToken,
+            _that.identityToken,
+            _that.accessToken);
+      case _:
+        return null;
+    }
   }
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$AuthOAuth2ModelImpl implements _AuthOAuth2Model {
-  const _$AuthOAuth2ModelImpl({
-    this.grantType = OAuth2GrantType.authorizationCode,
-    required this.authorizationUrl,
-    required this.accessTokenUrl,
-    required this.clientId,
-    required this.clientSecret,
-    this.credentialsFilePath,
-    this.redirectUrl,
-    this.scope,
-    this.state,
-    this.codeChallengeMethod = "sha-256",
-    this.codeVerifier,
-    this.codeChallenge,
-    this.username,
-    this.password,
-    this.refreshToken,
-    this.identityToken,
-    this.accessToken,
-  });
-
-  factory _$AuthOAuth2ModelImpl.fromJson(Map<String, dynamic> json) =>
-      _$$AuthOAuth2ModelImplFromJson(json);
+class _AuthOAuth2Model implements AuthOAuth2Model {
+  const _AuthOAuth2Model(
+      {this.grantType = OAuth2GrantType.authorizationCode,
+      required this.authorizationUrl,
+      required this.accessTokenUrl,
+      required this.clientId,
+      required this.clientSecret,
+      this.credentialsFilePath,
+      this.redirectUrl,
+      this.scope,
+      this.state,
+      this.codeChallengeMethod = "sha-256",
+      this.codeVerifier,
+      this.codeChallenge,
+      this.username,
+      this.password,
+      this.refreshToken,
+      this.identityToken,
+      this.accessToken});
+  factory _AuthOAuth2Model.fromJson(Map<String, dynamic> json) =>
+      _$AuthOAuth2ModelFromJson(json);
 
   @override
   @JsonKey()
@@ -386,16 +563,26 @@ class _$AuthOAuth2ModelImpl implements _AuthOAuth2Model {
   @override
   final String? accessToken;
 
+  /// Create a copy of AuthOAuth2Model
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'AuthOAuth2Model(grantType: $grantType, authorizationUrl: $authorizationUrl, accessTokenUrl: $accessTokenUrl, clientId: $clientId, clientSecret: $clientSecret, credentialsFilePath: $credentialsFilePath, redirectUrl: $redirectUrl, scope: $scope, state: $state, codeChallengeMethod: $codeChallengeMethod, codeVerifier: $codeVerifier, codeChallenge: $codeChallenge, username: $username, password: $password, refreshToken: $refreshToken, identityToken: $identityToken, accessToken: $accessToken)';
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$AuthOAuth2ModelCopyWith<_AuthOAuth2Model> get copyWith =>
+      __$AuthOAuth2ModelCopyWithImpl<_AuthOAuth2Model>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$AuthOAuth2ModelToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AuthOAuth2ModelImpl &&
+            other is _AuthOAuth2Model &&
             (identical(other.grantType, grantType) ||
                 other.grantType == grantType) &&
             (identical(other.authorizationUrl, authorizationUrl) ||
@@ -433,106 +620,161 @@ class _$AuthOAuth2ModelImpl implements _AuthOAuth2Model {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
-    runtimeType,
-    grantType,
-    authorizationUrl,
-    accessTokenUrl,
-    clientId,
-    clientSecret,
-    credentialsFilePath,
-    redirectUrl,
-    scope,
-    state,
-    codeChallengeMethod,
-    codeVerifier,
-    codeChallenge,
-    username,
-    password,
-    refreshToken,
-    identityToken,
-    accessToken,
-  );
-
-  /// Create a copy of AuthOAuth2Model
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$AuthOAuth2ModelImplCopyWith<_$AuthOAuth2ModelImpl> get copyWith =>
-      __$$AuthOAuth2ModelImplCopyWithImpl<_$AuthOAuth2ModelImpl>(
-        this,
-        _$identity,
-      );
+      runtimeType,
+      grantType,
+      authorizationUrl,
+      accessTokenUrl,
+      clientId,
+      clientSecret,
+      credentialsFilePath,
+      redirectUrl,
+      scope,
+      state,
+      codeChallengeMethod,
+      codeVerifier,
+      codeChallenge,
+      username,
+      password,
+      refreshToken,
+      identityToken,
+      accessToken);
 
   @override
-  Map<String, dynamic> toJson() {
-    return _$$AuthOAuth2ModelImplToJson(this);
+  String toString() {
+    return 'AuthOAuth2Model(grantType: $grantType, authorizationUrl: $authorizationUrl, accessTokenUrl: $accessTokenUrl, clientId: $clientId, clientSecret: $clientSecret, credentialsFilePath: $credentialsFilePath, redirectUrl: $redirectUrl, scope: $scope, state: $state, codeChallengeMethod: $codeChallengeMethod, codeVerifier: $codeVerifier, codeChallenge: $codeChallenge, username: $username, password: $password, refreshToken: $refreshToken, identityToken: $identityToken, accessToken: $accessToken)';
   }
 }
 
-abstract class _AuthOAuth2Model implements AuthOAuth2Model {
-  const factory _AuthOAuth2Model({
-    final OAuth2GrantType grantType,
-    required final String authorizationUrl,
-    required final String accessTokenUrl,
-    required final String clientId,
-    required final String clientSecret,
-    final String? credentialsFilePath,
-    final String? redirectUrl,
-    final String? scope,
-    final String? state,
-    final String codeChallengeMethod,
-    final String? codeVerifier,
-    final String? codeChallenge,
-    final String? username,
-    final String? password,
-    final String? refreshToken,
-    final String? identityToken,
-    final String? accessToken,
-  }) = _$AuthOAuth2ModelImpl;
+/// @nodoc
+abstract mixin class _$AuthOAuth2ModelCopyWith<$Res>
+    implements $AuthOAuth2ModelCopyWith<$Res> {
+  factory _$AuthOAuth2ModelCopyWith(
+          _AuthOAuth2Model value, $Res Function(_AuthOAuth2Model) _then) =
+      __$AuthOAuth2ModelCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {OAuth2GrantType grantType,
+      String authorizationUrl,
+      String accessTokenUrl,
+      String clientId,
+      String clientSecret,
+      String? credentialsFilePath,
+      String? redirectUrl,
+      String? scope,
+      String? state,
+      String codeChallengeMethod,
+      String? codeVerifier,
+      String? codeChallenge,
+      String? username,
+      String? password,
+      String? refreshToken,
+      String? identityToken,
+      String? accessToken});
+}
 
-  factory _AuthOAuth2Model.fromJson(Map<String, dynamic> json) =
-      _$AuthOAuth2ModelImpl.fromJson;
+/// @nodoc
+class __$AuthOAuth2ModelCopyWithImpl<$Res>
+    implements _$AuthOAuth2ModelCopyWith<$Res> {
+  __$AuthOAuth2ModelCopyWithImpl(this._self, this._then);
 
-  @override
-  OAuth2GrantType get grantType;
-  @override
-  String get authorizationUrl;
-  @override
-  String get accessTokenUrl;
-  @override
-  String get clientId;
-  @override
-  String get clientSecret;
-  @override
-  String? get credentialsFilePath;
-  @override
-  String? get redirectUrl;
-  @override
-  String? get scope;
-  @override
-  String? get state;
-  @override
-  String get codeChallengeMethod;
-  @override
-  String? get codeVerifier;
-  @override
-  String? get codeChallenge;
-  @override
-  String? get username;
-  @override
-  String? get password;
-  @override
-  String? get refreshToken;
-  @override
-  String? get identityToken;
-  @override
-  String? get accessToken;
+  final _AuthOAuth2Model _self;
+  final $Res Function(_AuthOAuth2Model) _then;
 
   /// Create a copy of AuthOAuth2Model
   /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$AuthOAuth2ModelImplCopyWith<_$AuthOAuth2ModelImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? grantType = null,
+    Object? authorizationUrl = null,
+    Object? accessTokenUrl = null,
+    Object? clientId = null,
+    Object? clientSecret = null,
+    Object? credentialsFilePath = freezed,
+    Object? redirectUrl = freezed,
+    Object? scope = freezed,
+    Object? state = freezed,
+    Object? codeChallengeMethod = null,
+    Object? codeVerifier = freezed,
+    Object? codeChallenge = freezed,
+    Object? username = freezed,
+    Object? password = freezed,
+    Object? refreshToken = freezed,
+    Object? identityToken = freezed,
+    Object? accessToken = freezed,
+  }) {
+    return _then(_AuthOAuth2Model(
+      grantType: null == grantType
+          ? _self.grantType
+          : grantType // ignore: cast_nullable_to_non_nullable
+              as OAuth2GrantType,
+      authorizationUrl: null == authorizationUrl
+          ? _self.authorizationUrl
+          : authorizationUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      accessTokenUrl: null == accessTokenUrl
+          ? _self.accessTokenUrl
+          : accessTokenUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      clientId: null == clientId
+          ? _self.clientId
+          : clientId // ignore: cast_nullable_to_non_nullable
+              as String,
+      clientSecret: null == clientSecret
+          ? _self.clientSecret
+          : clientSecret // ignore: cast_nullable_to_non_nullable
+              as String,
+      credentialsFilePath: freezed == credentialsFilePath
+          ? _self.credentialsFilePath
+          : credentialsFilePath // ignore: cast_nullable_to_non_nullable
+              as String?,
+      redirectUrl: freezed == redirectUrl
+          ? _self.redirectUrl
+          : redirectUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+      scope: freezed == scope
+          ? _self.scope
+          : scope // ignore: cast_nullable_to_non_nullable
+              as String?,
+      state: freezed == state
+          ? _self.state
+          : state // ignore: cast_nullable_to_non_nullable
+              as String?,
+      codeChallengeMethod: null == codeChallengeMethod
+          ? _self.codeChallengeMethod
+          : codeChallengeMethod // ignore: cast_nullable_to_non_nullable
+              as String,
+      codeVerifier: freezed == codeVerifier
+          ? _self.codeVerifier
+          : codeVerifier // ignore: cast_nullable_to_non_nullable
+              as String?,
+      codeChallenge: freezed == codeChallenge
+          ? _self.codeChallenge
+          : codeChallenge // ignore: cast_nullable_to_non_nullable
+              as String?,
+      username: freezed == username
+          ? _self.username
+          : username // ignore: cast_nullable_to_non_nullable
+              as String?,
+      password: freezed == password
+          ? _self.password
+          : password // ignore: cast_nullable_to_non_nullable
+              as String?,
+      refreshToken: freezed == refreshToken
+          ? _self.refreshToken
+          : refreshToken // ignore: cast_nullable_to_non_nullable
+              as String?,
+      identityToken: freezed == identityToken
+          ? _self.identityToken
+          : identityToken // ignore: cast_nullable_to_non_nullable
+              as String?,
+      accessToken: freezed == accessToken
+          ? _self.accessToken
+          : accessToken // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
 }
+
+// dart format on

--- a/packages/better_networking/lib/models/auth/auth_oauth2_model.g.dart
+++ b/packages/better_networking/lib/models/auth/auth_oauth2_model.g.dart
@@ -6,51 +6,49 @@ part of 'auth_oauth2_model.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$AuthOAuth2ModelImpl _$$AuthOAuth2ModelImplFromJson(
-  Map<String, dynamic> json,
-) => _$AuthOAuth2ModelImpl(
-  grantType:
-      $enumDecodeNullable(_$OAuth2GrantTypeEnumMap, json['grantType']) ??
-      OAuth2GrantType.authorizationCode,
-  authorizationUrl: json['authorizationUrl'] as String,
-  accessTokenUrl: json['accessTokenUrl'] as String,
-  clientId: json['clientId'] as String,
-  clientSecret: json['clientSecret'] as String,
-  credentialsFilePath: json['credentialsFilePath'] as String?,
-  redirectUrl: json['redirectUrl'] as String?,
-  scope: json['scope'] as String?,
-  state: json['state'] as String?,
-  codeChallengeMethod: json['codeChallengeMethod'] as String? ?? "sha-256",
-  codeVerifier: json['codeVerifier'] as String?,
-  codeChallenge: json['codeChallenge'] as String?,
-  username: json['username'] as String?,
-  password: json['password'] as String?,
-  refreshToken: json['refreshToken'] as String?,
-  identityToken: json['identityToken'] as String?,
-  accessToken: json['accessToken'] as String?,
-);
+_AuthOAuth2Model _$AuthOAuth2ModelFromJson(Map<String, dynamic> json) =>
+    _AuthOAuth2Model(
+      grantType:
+          $enumDecodeNullable(_$OAuth2GrantTypeEnumMap, json['grantType']) ??
+              OAuth2GrantType.authorizationCode,
+      authorizationUrl: json['authorizationUrl'] as String,
+      accessTokenUrl: json['accessTokenUrl'] as String,
+      clientId: json['clientId'] as String,
+      clientSecret: json['clientSecret'] as String,
+      credentialsFilePath: json['credentialsFilePath'] as String?,
+      redirectUrl: json['redirectUrl'] as String?,
+      scope: json['scope'] as String?,
+      state: json['state'] as String?,
+      codeChallengeMethod: json['codeChallengeMethod'] as String? ?? "sha-256",
+      codeVerifier: json['codeVerifier'] as String?,
+      codeChallenge: json['codeChallenge'] as String?,
+      username: json['username'] as String?,
+      password: json['password'] as String?,
+      refreshToken: json['refreshToken'] as String?,
+      identityToken: json['identityToken'] as String?,
+      accessToken: json['accessToken'] as String?,
+    );
 
-Map<String, dynamic> _$$AuthOAuth2ModelImplToJson(
-  _$AuthOAuth2ModelImpl instance,
-) => <String, dynamic>{
-  'grantType': _$OAuth2GrantTypeEnumMap[instance.grantType]!,
-  'authorizationUrl': instance.authorizationUrl,
-  'accessTokenUrl': instance.accessTokenUrl,
-  'clientId': instance.clientId,
-  'clientSecret': instance.clientSecret,
-  'credentialsFilePath': instance.credentialsFilePath,
-  'redirectUrl': instance.redirectUrl,
-  'scope': instance.scope,
-  'state': instance.state,
-  'codeChallengeMethod': instance.codeChallengeMethod,
-  'codeVerifier': instance.codeVerifier,
-  'codeChallenge': instance.codeChallenge,
-  'username': instance.username,
-  'password': instance.password,
-  'refreshToken': instance.refreshToken,
-  'identityToken': instance.identityToken,
-  'accessToken': instance.accessToken,
-};
+Map<String, dynamic> _$AuthOAuth2ModelToJson(_AuthOAuth2Model instance) =>
+    <String, dynamic>{
+      'grantType': _$OAuth2GrantTypeEnumMap[instance.grantType]!,
+      'authorizationUrl': instance.authorizationUrl,
+      'accessTokenUrl': instance.accessTokenUrl,
+      'clientId': instance.clientId,
+      'clientSecret': instance.clientSecret,
+      'credentialsFilePath': instance.credentialsFilePath,
+      'redirectUrl': instance.redirectUrl,
+      'scope': instance.scope,
+      'state': instance.state,
+      'codeChallengeMethod': instance.codeChallengeMethod,
+      'codeVerifier': instance.codeVerifier,
+      'codeChallenge': instance.codeChallenge,
+      'username': instance.username,
+      'password': instance.password,
+      'refreshToken': instance.refreshToken,
+      'identityToken': instance.identityToken,
+      'accessToken': instance.accessToken,
+    };
 
 const _$OAuth2GrantTypeEnumMap = {
   OAuth2GrantType.authorizationCode: 'authorizationCode',

--- a/packages/better_networking/lib/models/http_request_model.dart
+++ b/packages/better_networking/lib/models/http_request_model.dart
@@ -45,12 +45,16 @@ class HttpRequestModel with _$HttpRequestModel {
   bool get hasFormDataContentType => bodyContentType == ContentType.formdata;
   bool get hasJsonContentType => bodyContentType == ContentType.json;
   bool get hasTextContentType => bodyContentType == ContentType.text;
+  bool get hasFormUrlEncodedContentType =>
+      bodyContentType == ContentType.formUrlEncoded;
   int get contentLength => utf8.encode(body ?? "").length;
-  bool get hasBody => hasJsonData || hasTextData || hasFormData;
+  bool get hasBody =>
+      hasJsonData || hasTextData || hasFormData || hasFormUrlEncodedData;
   bool get hasAnyBody =>
       (hasJsonContentType && contentLength > 0) ||
       (hasTextContentType && contentLength > 0) ||
-      (hasFormDataContentType && formDataMapList.isNotEmpty);
+      (hasFormDataContentType && formDataMapList.isNotEmpty) ||
+      (hasFormUrlEncodedContentType && formDataMapList.isNotEmpty);
   bool get hasJsonData =>
       kMethodsWithBody.contains(method) &&
       hasJsonContentType &&
@@ -63,6 +67,10 @@ class HttpRequestModel with _$HttpRequestModel {
       kMethodsWithBody.contains(method) &&
       hasFormDataContentType &&
       formDataMapList.isNotEmpty;
+  bool get hasFormUrlEncodedData =>
+      kMethodsWithBody.contains(method) &&
+      hasFormUrlEncodedContentType &&
+      formDataMapList.isNotEmpty;
   bool get hasQuery => query?.isNotEmpty ?? false;
   List<FormDataModel> get formDataList => formData ?? <FormDataModel>[];
   List<Map<String, String>> get formDataMapList =>
@@ -70,4 +78,9 @@ class HttpRequestModel with _$HttpRequestModel {
   bool get hasFileInFormData => formDataList
       .map((e) => e.type == FormDataType.file)
       .any((element) => element);
+  String get formUrlEncodedBody => formDataList
+      .where((e) => e.name.trim().isNotEmpty)
+      .map((e) =>
+          '${Uri.encodeComponent(e.name)}=${Uri.encodeComponent(e.value)}')
+      .join('&');
 }

--- a/packages/better_networking/lib/models/http_request_model.freezed.dart
+++ b/packages/better_networking/lib/models/http_request_model.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,73 +9,107 @@ part of 'http_request_model.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
-
-HttpRequestModel _$HttpRequestModelFromJson(Map<String, dynamic> json) {
-  return _HttpRequestModel.fromJson(json);
-}
 
 /// @nodoc
 mixin _$HttpRequestModel {
-  HTTPVerb get method => throw _privateConstructorUsedError;
-  String get url => throw _privateConstructorUsedError;
-  List<NameValueModel>? get headers => throw _privateConstructorUsedError;
-  List<NameValueModel>? get params => throw _privateConstructorUsedError;
-  AuthModel? get authModel => throw _privateConstructorUsedError;
-  List<bool>? get isHeaderEnabledList => throw _privateConstructorUsedError;
-  List<bool>? get isParamEnabledList => throw _privateConstructorUsedError;
-  ContentType get bodyContentType => throw _privateConstructorUsedError;
-  String? get body => throw _privateConstructorUsedError;
-  String? get query => throw _privateConstructorUsedError;
-  List<FormDataModel>? get formData => throw _privateConstructorUsedError;
-
-  /// Serializes this HttpRequestModel to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  HTTPVerb get method;
+  String get url;
+  List<NameValueModel>? get headers;
+  List<NameValueModel>? get params;
+  AuthModel? get authModel;
+  List<bool>? get isHeaderEnabledList;
+  List<bool>? get isParamEnabledList;
+  ContentType get bodyContentType;
+  String? get body;
+  String? get query;
+  List<FormDataModel>? get formData;
 
   /// Create a copy of HttpRequestModel
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $HttpRequestModelCopyWith<HttpRequestModel> get copyWith =>
-      throw _privateConstructorUsedError;
+      _$HttpRequestModelCopyWithImpl<HttpRequestModel>(
+          this as HttpRequestModel, _$identity);
+
+  /// Serializes this HttpRequestModel to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is HttpRequestModel &&
+            (identical(other.method, method) || other.method == method) &&
+            (identical(other.url, url) || other.url == url) &&
+            const DeepCollectionEquality().equals(other.headers, headers) &&
+            const DeepCollectionEquality().equals(other.params, params) &&
+            (identical(other.authModel, authModel) ||
+                other.authModel == authModel) &&
+            const DeepCollectionEquality()
+                .equals(other.isHeaderEnabledList, isHeaderEnabledList) &&
+            const DeepCollectionEquality()
+                .equals(other.isParamEnabledList, isParamEnabledList) &&
+            (identical(other.bodyContentType, bodyContentType) ||
+                other.bodyContentType == bodyContentType) &&
+            (identical(other.body, body) || other.body == body) &&
+            (identical(other.query, query) || other.query == query) &&
+            const DeepCollectionEquality().equals(other.formData, formData));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      method,
+      url,
+      const DeepCollectionEquality().hash(headers),
+      const DeepCollectionEquality().hash(params),
+      authModel,
+      const DeepCollectionEquality().hash(isHeaderEnabledList),
+      const DeepCollectionEquality().hash(isParamEnabledList),
+      bodyContentType,
+      body,
+      query,
+      const DeepCollectionEquality().hash(formData));
+
+  @override
+  String toString() {
+    return 'HttpRequestModel(method: $method, url: $url, headers: $headers, params: $params, authModel: $authModel, isHeaderEnabledList: $isHeaderEnabledList, isParamEnabledList: $isParamEnabledList, bodyContentType: $bodyContentType, body: $body, query: $query, formData: $formData)';
+  }
 }
 
 /// @nodoc
-abstract class $HttpRequestModelCopyWith<$Res> {
+abstract mixin class $HttpRequestModelCopyWith<$Res> {
   factory $HttpRequestModelCopyWith(
-    HttpRequestModel value,
-    $Res Function(HttpRequestModel) then,
-  ) = _$HttpRequestModelCopyWithImpl<$Res, HttpRequestModel>;
+          HttpRequestModel value, $Res Function(HttpRequestModel) _then) =
+      _$HttpRequestModelCopyWithImpl;
   @useResult
-  $Res call({
-    HTTPVerb method,
-    String url,
-    List<NameValueModel>? headers,
-    List<NameValueModel>? params,
-    AuthModel? authModel,
-    List<bool>? isHeaderEnabledList,
-    List<bool>? isParamEnabledList,
-    ContentType bodyContentType,
-    String? body,
-    String? query,
-    List<FormDataModel>? formData,
-  });
+  $Res call(
+      {HTTPVerb method,
+      String url,
+      List<NameValueModel>? headers,
+      List<NameValueModel>? params,
+      AuthModel? authModel,
+      List<bool>? isHeaderEnabledList,
+      List<bool>? isParamEnabledList,
+      ContentType bodyContentType,
+      String? body,
+      String? query,
+      List<FormDataModel>? formData});
 
   $AuthModelCopyWith<$Res>? get authModel;
 }
 
 /// @nodoc
-class _$HttpRequestModelCopyWithImpl<$Res, $Val extends HttpRequestModel>
+class _$HttpRequestModelCopyWithImpl<$Res>
     implements $HttpRequestModelCopyWith<$Res> {
-  _$HttpRequestModelCopyWithImpl(this._value, this._then);
+  _$HttpRequestModelCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final HttpRequestModel _self;
+  final $Res Function(HttpRequestModel) _then;
 
   /// Create a copy of HttpRequestModel
   /// with the given fields replaced by the non-null parameter values.
@@ -94,55 +128,52 @@ class _$HttpRequestModelCopyWithImpl<$Res, $Val extends HttpRequestModel>
     Object? query = freezed,
     Object? formData = freezed,
   }) {
-    return _then(
-      _value.copyWith(
-            method: null == method
-                ? _value.method
-                : method // ignore: cast_nullable_to_non_nullable
-                      as HTTPVerb,
-            url: null == url
-                ? _value.url
-                : url // ignore: cast_nullable_to_non_nullable
-                      as String,
-            headers: freezed == headers
-                ? _value.headers
-                : headers // ignore: cast_nullable_to_non_nullable
-                      as List<NameValueModel>?,
-            params: freezed == params
-                ? _value.params
-                : params // ignore: cast_nullable_to_non_nullable
-                      as List<NameValueModel>?,
-            authModel: freezed == authModel
-                ? _value.authModel
-                : authModel // ignore: cast_nullable_to_non_nullable
-                      as AuthModel?,
-            isHeaderEnabledList: freezed == isHeaderEnabledList
-                ? _value.isHeaderEnabledList
-                : isHeaderEnabledList // ignore: cast_nullable_to_non_nullable
-                      as List<bool>?,
-            isParamEnabledList: freezed == isParamEnabledList
-                ? _value.isParamEnabledList
-                : isParamEnabledList // ignore: cast_nullable_to_non_nullable
-                      as List<bool>?,
-            bodyContentType: null == bodyContentType
-                ? _value.bodyContentType
-                : bodyContentType // ignore: cast_nullable_to_non_nullable
-                      as ContentType,
-            body: freezed == body
-                ? _value.body
-                : body // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            query: freezed == query
-                ? _value.query
-                : query // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            formData: freezed == formData
-                ? _value.formData
-                : formData // ignore: cast_nullable_to_non_nullable
-                      as List<FormDataModel>?,
-          )
-          as $Val,
-    );
+    return _then(_self.copyWith(
+      method: null == method
+          ? _self.method
+          : method // ignore: cast_nullable_to_non_nullable
+              as HTTPVerb,
+      url: null == url
+          ? _self.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String,
+      headers: freezed == headers
+          ? _self.headers
+          : headers // ignore: cast_nullable_to_non_nullable
+              as List<NameValueModel>?,
+      params: freezed == params
+          ? _self.params
+          : params // ignore: cast_nullable_to_non_nullable
+              as List<NameValueModel>?,
+      authModel: freezed == authModel
+          ? _self.authModel
+          : authModel // ignore: cast_nullable_to_non_nullable
+              as AuthModel?,
+      isHeaderEnabledList: freezed == isHeaderEnabledList
+          ? _self.isHeaderEnabledList
+          : isHeaderEnabledList // ignore: cast_nullable_to_non_nullable
+              as List<bool>?,
+      isParamEnabledList: freezed == isParamEnabledList
+          ? _self.isParamEnabledList
+          : isParamEnabledList // ignore: cast_nullable_to_non_nullable
+              as List<bool>?,
+      bodyContentType: null == bodyContentType
+          ? _self.bodyContentType
+          : bodyContentType // ignore: cast_nullable_to_non_nullable
+              as ContentType,
+      body: freezed == body
+          ? _self.body
+          : body // ignore: cast_nullable_to_non_nullable
+              as String?,
+      query: freezed == query
+          ? _self.query
+          : query // ignore: cast_nullable_to_non_nullable
+              as String?,
+      formData: freezed == formData
+          ? _self.formData
+          : formData // ignore: cast_nullable_to_non_nullable
+              as List<FormDataModel>?,
+    ));
   }
 
   /// Create a copy of HttpRequestModel
@@ -150,145 +181,266 @@ class _$HttpRequestModelCopyWithImpl<$Res, $Val extends HttpRequestModel>
   @override
   @pragma('vm:prefer-inline')
   $AuthModelCopyWith<$Res>? get authModel {
-    if (_value.authModel == null) {
+    if (_self.authModel == null) {
       return null;
     }
 
-    return $AuthModelCopyWith<$Res>(_value.authModel!, (value) {
-      return _then(_value.copyWith(authModel: value) as $Val);
+    return $AuthModelCopyWith<$Res>(_self.authModel!, (value) {
+      return _then(_self.copyWith(authModel: value));
     });
   }
 }
 
-/// @nodoc
-abstract class _$$HttpRequestModelImplCopyWith<$Res>
-    implements $HttpRequestModelCopyWith<$Res> {
-  factory _$$HttpRequestModelImplCopyWith(
-    _$HttpRequestModelImpl value,
-    $Res Function(_$HttpRequestModelImpl) then,
-  ) = __$$HttpRequestModelImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({
-    HTTPVerb method,
-    String url,
-    List<NameValueModel>? headers,
-    List<NameValueModel>? params,
-    AuthModel? authModel,
-    List<bool>? isHeaderEnabledList,
-    List<bool>? isParamEnabledList,
-    ContentType bodyContentType,
-    String? body,
-    String? query,
-    List<FormDataModel>? formData,
-  });
+/// Adds pattern-matching-related methods to [HttpRequestModel].
+extension HttpRequestModelPatterns on HttpRequestModel {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
 
-  @override
-  $AuthModelCopyWith<$Res>? get authModel;
-}
-
-/// @nodoc
-class __$$HttpRequestModelImplCopyWithImpl<$Res>
-    extends _$HttpRequestModelCopyWithImpl<$Res, _$HttpRequestModelImpl>
-    implements _$$HttpRequestModelImplCopyWith<$Res> {
-  __$$HttpRequestModelImplCopyWithImpl(
-    _$HttpRequestModelImpl _value,
-    $Res Function(_$HttpRequestModelImpl) _then,
-  ) : super(_value, _then);
-
-  /// Create a copy of HttpRequestModel
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? method = null,
-    Object? url = null,
-    Object? headers = freezed,
-    Object? params = freezed,
-    Object? authModel = freezed,
-    Object? isHeaderEnabledList = freezed,
-    Object? isParamEnabledList = freezed,
-    Object? bodyContentType = null,
-    Object? body = freezed,
-    Object? query = freezed,
-    Object? formData = freezed,
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_HttpRequestModel value)? $default, {
+    required TResult orElse(),
   }) {
-    return _then(
-      _$HttpRequestModelImpl(
-        method: null == method
-            ? _value.method
-            : method // ignore: cast_nullable_to_non_nullable
-                  as HTTPVerb,
-        url: null == url
-            ? _value.url
-            : url // ignore: cast_nullable_to_non_nullable
-                  as String,
-        headers: freezed == headers
-            ? _value._headers
-            : headers // ignore: cast_nullable_to_non_nullable
-                  as List<NameValueModel>?,
-        params: freezed == params
-            ? _value._params
-            : params // ignore: cast_nullable_to_non_nullable
-                  as List<NameValueModel>?,
-        authModel: freezed == authModel
-            ? _value.authModel
-            : authModel // ignore: cast_nullable_to_non_nullable
-                  as AuthModel?,
-        isHeaderEnabledList: freezed == isHeaderEnabledList
-            ? _value._isHeaderEnabledList
-            : isHeaderEnabledList // ignore: cast_nullable_to_non_nullable
-                  as List<bool>?,
-        isParamEnabledList: freezed == isParamEnabledList
-            ? _value._isParamEnabledList
-            : isParamEnabledList // ignore: cast_nullable_to_non_nullable
-                  as List<bool>?,
-        bodyContentType: null == bodyContentType
-            ? _value.bodyContentType
-            : bodyContentType // ignore: cast_nullable_to_non_nullable
-                  as ContentType,
-        body: freezed == body
-            ? _value.body
-            : body // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        query: freezed == query
-            ? _value.query
-            : query // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        formData: freezed == formData
-            ? _value._formData
-            : formData // ignore: cast_nullable_to_non_nullable
-                  as List<FormDataModel>?,
-      ),
-    );
+    final _that = this;
+    switch (_that) {
+      case _HttpRequestModel() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_HttpRequestModel value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _HttpRequestModel():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_HttpRequestModel value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _HttpRequestModel() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            HTTPVerb method,
+            String url,
+            List<NameValueModel>? headers,
+            List<NameValueModel>? params,
+            AuthModel? authModel,
+            List<bool>? isHeaderEnabledList,
+            List<bool>? isParamEnabledList,
+            ContentType bodyContentType,
+            String? body,
+            String? query,
+            List<FormDataModel>? formData)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _HttpRequestModel() when $default != null:
+        return $default(
+            _that.method,
+            _that.url,
+            _that.headers,
+            _that.params,
+            _that.authModel,
+            _that.isHeaderEnabledList,
+            _that.isParamEnabledList,
+            _that.bodyContentType,
+            _that.body,
+            _that.query,
+            _that.formData);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            HTTPVerb method,
+            String url,
+            List<NameValueModel>? headers,
+            List<NameValueModel>? params,
+            AuthModel? authModel,
+            List<bool>? isHeaderEnabledList,
+            List<bool>? isParamEnabledList,
+            ContentType bodyContentType,
+            String? body,
+            String? query,
+            List<FormDataModel>? formData)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _HttpRequestModel():
+        return $default(
+            _that.method,
+            _that.url,
+            _that.headers,
+            _that.params,
+            _that.authModel,
+            _that.isHeaderEnabledList,
+            _that.isParamEnabledList,
+            _that.bodyContentType,
+            _that.body,
+            _that.query,
+            _that.formData);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            HTTPVerb method,
+            String url,
+            List<NameValueModel>? headers,
+            List<NameValueModel>? params,
+            AuthModel? authModel,
+            List<bool>? isHeaderEnabledList,
+            List<bool>? isParamEnabledList,
+            ContentType bodyContentType,
+            String? body,
+            String? query,
+            List<FormDataModel>? formData)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _HttpRequestModel() when $default != null:
+        return $default(
+            _that.method,
+            _that.url,
+            _that.headers,
+            _that.params,
+            _that.authModel,
+            _that.isHeaderEnabledList,
+            _that.isParamEnabledList,
+            _that.bodyContentType,
+            _that.body,
+            _that.query,
+            _that.formData);
+      case _:
+        return null;
+    }
   }
 }
 
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true, anyMap: true)
-class _$HttpRequestModelImpl extends _HttpRequestModel {
-  const _$HttpRequestModelImpl({
-    this.method = HTTPVerb.get,
-    this.url = "",
-    final List<NameValueModel>? headers,
-    final List<NameValueModel>? params,
-    this.authModel = const AuthModel(type: APIAuthType.none),
-    final List<bool>? isHeaderEnabledList,
-    final List<bool>? isParamEnabledList,
-    this.bodyContentType = ContentType.json,
-    this.body,
-    this.query,
-    final List<FormDataModel>? formData,
-  }) : _headers = headers,
-       _params = params,
-       _isHeaderEnabledList = isHeaderEnabledList,
-       _isParamEnabledList = isParamEnabledList,
-       _formData = formData,
-       super._();
-
-  factory _$HttpRequestModelImpl.fromJson(Map<String, dynamic> json) =>
-      _$$HttpRequestModelImplFromJson(json);
+class _HttpRequestModel extends HttpRequestModel {
+  const _HttpRequestModel(
+      {this.method = HTTPVerb.get,
+      this.url = "",
+      final List<NameValueModel>? headers,
+      final List<NameValueModel>? params,
+      this.authModel = const AuthModel(type: APIAuthType.none),
+      final List<bool>? isHeaderEnabledList,
+      final List<bool>? isParamEnabledList,
+      this.bodyContentType = ContentType.json,
+      this.body,
+      this.query,
+      final List<FormDataModel>? formData})
+      : _headers = headers,
+        _params = params,
+        _isHeaderEnabledList = isHeaderEnabledList,
+        _isParamEnabledList = isParamEnabledList,
+        _formData = formData,
+        super._();
+  factory _HttpRequestModel.fromJson(Map<String, dynamic> json) =>
+      _$HttpRequestModelFromJson(json);
 
   @override
   @JsonKey()
@@ -358,30 +510,36 @@ class _$HttpRequestModelImpl extends _HttpRequestModel {
     return EqualUnmodifiableListView(value);
   }
 
+  /// Create a copy of HttpRequestModel
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'HttpRequestModel(method: $method, url: $url, headers: $headers, params: $params, authModel: $authModel, isHeaderEnabledList: $isHeaderEnabledList, isParamEnabledList: $isParamEnabledList, bodyContentType: $bodyContentType, body: $body, query: $query, formData: $formData)';
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$HttpRequestModelCopyWith<_HttpRequestModel> get copyWith =>
+      __$HttpRequestModelCopyWithImpl<_HttpRequestModel>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$HttpRequestModelToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$HttpRequestModelImpl &&
+            other is _HttpRequestModel &&
             (identical(other.method, method) || other.method == method) &&
             (identical(other.url, url) || other.url == url) &&
             const DeepCollectionEquality().equals(other._headers, _headers) &&
             const DeepCollectionEquality().equals(other._params, _params) &&
             (identical(other.authModel, authModel) ||
                 other.authModel == authModel) &&
-            const DeepCollectionEquality().equals(
-              other._isHeaderEnabledList,
-              _isHeaderEnabledList,
-            ) &&
-            const DeepCollectionEquality().equals(
-              other._isParamEnabledList,
-              _isParamEnabledList,
-            ) &&
+            const DeepCollectionEquality()
+                .equals(other._isHeaderEnabledList, _isHeaderEnabledList) &&
+            const DeepCollectionEquality()
+                .equals(other._isParamEnabledList, _isParamEnabledList) &&
             (identical(other.bodyContentType, bodyContentType) ||
                 other.bodyContentType == bodyContentType) &&
             (identical(other.body, body) || other.body == body) &&
@@ -392,83 +550,136 @@ class _$HttpRequestModelImpl extends _HttpRequestModel {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
-    runtimeType,
-    method,
-    url,
-    const DeepCollectionEquality().hash(_headers),
-    const DeepCollectionEquality().hash(_params),
-    authModel,
-    const DeepCollectionEquality().hash(_isHeaderEnabledList),
-    const DeepCollectionEquality().hash(_isParamEnabledList),
-    bodyContentType,
-    body,
-    query,
-    const DeepCollectionEquality().hash(_formData),
-  );
-
-  /// Create a copy of HttpRequestModel
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$HttpRequestModelImplCopyWith<_$HttpRequestModelImpl> get copyWith =>
-      __$$HttpRequestModelImplCopyWithImpl<_$HttpRequestModelImpl>(
-        this,
-        _$identity,
-      );
+      runtimeType,
+      method,
+      url,
+      const DeepCollectionEquality().hash(_headers),
+      const DeepCollectionEquality().hash(_params),
+      authModel,
+      const DeepCollectionEquality().hash(_isHeaderEnabledList),
+      const DeepCollectionEquality().hash(_isParamEnabledList),
+      bodyContentType,
+      body,
+      query,
+      const DeepCollectionEquality().hash(_formData));
 
   @override
-  Map<String, dynamic> toJson() {
-    return _$$HttpRequestModelImplToJson(this);
+  String toString() {
+    return 'HttpRequestModel(method: $method, url: $url, headers: $headers, params: $params, authModel: $authModel, isHeaderEnabledList: $isHeaderEnabledList, isParamEnabledList: $isParamEnabledList, bodyContentType: $bodyContentType, body: $body, query: $query, formData: $formData)';
   }
 }
 
-abstract class _HttpRequestModel extends HttpRequestModel {
-  const factory _HttpRequestModel({
-    final HTTPVerb method,
-    final String url,
-    final List<NameValueModel>? headers,
-    final List<NameValueModel>? params,
-    final AuthModel? authModel,
-    final List<bool>? isHeaderEnabledList,
-    final List<bool>? isParamEnabledList,
-    final ContentType bodyContentType,
-    final String? body,
-    final String? query,
-    final List<FormDataModel>? formData,
-  }) = _$HttpRequestModelImpl;
-  const _HttpRequestModel._() : super._();
+/// @nodoc
+abstract mixin class _$HttpRequestModelCopyWith<$Res>
+    implements $HttpRequestModelCopyWith<$Res> {
+  factory _$HttpRequestModelCopyWith(
+          _HttpRequestModel value, $Res Function(_HttpRequestModel) _then) =
+      __$HttpRequestModelCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {HTTPVerb method,
+      String url,
+      List<NameValueModel>? headers,
+      List<NameValueModel>? params,
+      AuthModel? authModel,
+      List<bool>? isHeaderEnabledList,
+      List<bool>? isParamEnabledList,
+      ContentType bodyContentType,
+      String? body,
+      String? query,
+      List<FormDataModel>? formData});
 
-  factory _HttpRequestModel.fromJson(Map<String, dynamic> json) =
-      _$HttpRequestModelImpl.fromJson;
+  @override
+  $AuthModelCopyWith<$Res>? get authModel;
+}
 
-  @override
-  HTTPVerb get method;
-  @override
-  String get url;
-  @override
-  List<NameValueModel>? get headers;
-  @override
-  List<NameValueModel>? get params;
-  @override
-  AuthModel? get authModel;
-  @override
-  List<bool>? get isHeaderEnabledList;
-  @override
-  List<bool>? get isParamEnabledList;
-  @override
-  ContentType get bodyContentType;
-  @override
-  String? get body;
-  @override
-  String? get query;
-  @override
-  List<FormDataModel>? get formData;
+/// @nodoc
+class __$HttpRequestModelCopyWithImpl<$Res>
+    implements _$HttpRequestModelCopyWith<$Res> {
+  __$HttpRequestModelCopyWithImpl(this._self, this._then);
+
+  final _HttpRequestModel _self;
+  final $Res Function(_HttpRequestModel) _then;
 
   /// Create a copy of HttpRequestModel
   /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$HttpRequestModelImplCopyWith<_$HttpRequestModelImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? method = null,
+    Object? url = null,
+    Object? headers = freezed,
+    Object? params = freezed,
+    Object? authModel = freezed,
+    Object? isHeaderEnabledList = freezed,
+    Object? isParamEnabledList = freezed,
+    Object? bodyContentType = null,
+    Object? body = freezed,
+    Object? query = freezed,
+    Object? formData = freezed,
+  }) {
+    return _then(_HttpRequestModel(
+      method: null == method
+          ? _self.method
+          : method // ignore: cast_nullable_to_non_nullable
+              as HTTPVerb,
+      url: null == url
+          ? _self.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String,
+      headers: freezed == headers
+          ? _self._headers
+          : headers // ignore: cast_nullable_to_non_nullable
+              as List<NameValueModel>?,
+      params: freezed == params
+          ? _self._params
+          : params // ignore: cast_nullable_to_non_nullable
+              as List<NameValueModel>?,
+      authModel: freezed == authModel
+          ? _self.authModel
+          : authModel // ignore: cast_nullable_to_non_nullable
+              as AuthModel?,
+      isHeaderEnabledList: freezed == isHeaderEnabledList
+          ? _self._isHeaderEnabledList
+          : isHeaderEnabledList // ignore: cast_nullable_to_non_nullable
+              as List<bool>?,
+      isParamEnabledList: freezed == isParamEnabledList
+          ? _self._isParamEnabledList
+          : isParamEnabledList // ignore: cast_nullable_to_non_nullable
+              as List<bool>?,
+      bodyContentType: null == bodyContentType
+          ? _self.bodyContentType
+          : bodyContentType // ignore: cast_nullable_to_non_nullable
+              as ContentType,
+      body: freezed == body
+          ? _self.body
+          : body // ignore: cast_nullable_to_non_nullable
+              as String?,
+      query: freezed == query
+          ? _self.query
+          : query // ignore: cast_nullable_to_non_nullable
+              as String?,
+      formData: freezed == formData
+          ? _self._formData
+          : formData // ignore: cast_nullable_to_non_nullable
+              as List<FormDataModel>?,
+    ));
+  }
+
+  /// Create a copy of HttpRequestModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $AuthModelCopyWith<$Res>? get authModel {
+    if (_self.authModel == null) {
+      return null;
+    }
+
+    return $AuthModelCopyWith<$Res>(_self.authModel!, (value) {
+      return _then(_self.copyWith(authModel: value));
+    });
+  }
 }
+
+// dart format on

--- a/packages/better_networking/lib/models/http_request_model.g.dart
+++ b/packages/better_networking/lib/models/http_request_model.g.dart
@@ -6,52 +6,53 @@ part of 'http_request_model.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$HttpRequestModelImpl _$$HttpRequestModelImplFromJson(
-  Map json,
-) => _$HttpRequestModelImpl(
-  method:
-      $enumDecodeNullable(_$HTTPVerbEnumMap, json['method']) ?? HTTPVerb.get,
-  url: json['url'] as String? ?? "",
-  headers: (json['headers'] as List<dynamic>?)
-      ?.map((e) => NameValueModel.fromJson(Map<String, Object?>.from(e as Map)))
-      .toList(),
-  params: (json['params'] as List<dynamic>?)
-      ?.map((e) => NameValueModel.fromJson(Map<String, Object?>.from(e as Map)))
-      .toList(),
-  authModel: json['authModel'] == null
-      ? const AuthModel(type: APIAuthType.none)
-      : AuthModel.fromJson(Map<String, dynamic>.from(json['authModel'] as Map)),
-  isHeaderEnabledList: (json['isHeaderEnabledList'] as List<dynamic>?)
-      ?.map((e) => e as bool)
-      .toList(),
-  isParamEnabledList: (json['isParamEnabledList'] as List<dynamic>?)
-      ?.map((e) => e as bool)
-      .toList(),
-  bodyContentType:
-      $enumDecodeNullable(_$ContentTypeEnumMap, json['bodyContentType']) ??
-      ContentType.json,
-  body: json['body'] as String?,
-  query: json['query'] as String?,
-  formData: (json['formData'] as List<dynamic>?)
-      ?.map((e) => FormDataModel.fromJson(Map<String, Object?>.from(e as Map)))
-      .toList(),
-);
+_HttpRequestModel _$HttpRequestModelFromJson(Map json) => _HttpRequestModel(
+      method: $enumDecodeNullable(_$HTTPVerbEnumMap, json['method']) ??
+          HTTPVerb.get,
+      url: json['url'] as String? ?? "",
+      headers: (json['headers'] as List<dynamic>?)
+          ?.map((e) =>
+              NameValueModel.fromJson(Map<String, Object?>.from(e as Map)))
+          .toList(),
+      params: (json['params'] as List<dynamic>?)
+          ?.map((e) =>
+              NameValueModel.fromJson(Map<String, Object?>.from(e as Map)))
+          .toList(),
+      authModel: json['authModel'] == null
+          ? const AuthModel(type: APIAuthType.none)
+          : AuthModel.fromJson(
+              Map<String, dynamic>.from(json['authModel'] as Map)),
+      isHeaderEnabledList: (json['isHeaderEnabledList'] as List<dynamic>?)
+          ?.map((e) => e as bool)
+          .toList(),
+      isParamEnabledList: (json['isParamEnabledList'] as List<dynamic>?)
+          ?.map((e) => e as bool)
+          .toList(),
+      bodyContentType:
+          $enumDecodeNullable(_$ContentTypeEnumMap, json['bodyContentType']) ??
+              ContentType.json,
+      body: json['body'] as String?,
+      query: json['query'] as String?,
+      formData: (json['formData'] as List<dynamic>?)
+          ?.map((e) =>
+              FormDataModel.fromJson(Map<String, Object?>.from(e as Map)))
+          .toList(),
+    );
 
-Map<String, dynamic> _$$HttpRequestModelImplToJson(
-  _$HttpRequestModelImpl instance,
-) => <String, dynamic>{
-  'method': _$HTTPVerbEnumMap[instance.method]!,
-  'url': instance.url,
-  'headers': instance.headers?.map((e) => e.toJson()).toList(),
-  'params': instance.params?.map((e) => e.toJson()).toList(),
-  'authModel': instance.authModel?.toJson(),
-  'isHeaderEnabledList': instance.isHeaderEnabledList,
-  'isParamEnabledList': instance.isParamEnabledList,
-  'bodyContentType': _$ContentTypeEnumMap[instance.bodyContentType]!,
-  'body': instance.body,
-  'query': instance.query,
-  'formData': instance.formData?.map((e) => e.toJson()).toList(),
-};
+Map<String, dynamic> _$HttpRequestModelToJson(_HttpRequestModel instance) =>
+    <String, dynamic>{
+      'method': _$HTTPVerbEnumMap[instance.method]!,
+      'url': instance.url,
+      'headers': instance.headers?.map((e) => e.toJson()).toList(),
+      'params': instance.params?.map((e) => e.toJson()).toList(),
+      'authModel': instance.authModel?.toJson(),
+      'isHeaderEnabledList': instance.isHeaderEnabledList,
+      'isParamEnabledList': instance.isParamEnabledList,
+      'bodyContentType': _$ContentTypeEnumMap[instance.bodyContentType]!,
+      'body': instance.body,
+      'query': instance.query,
+      'formData': instance.formData?.map((e) => e.toJson()).toList(),
+    };
 
 const _$HTTPVerbEnumMap = {
   HTTPVerb.get: 'get',
@@ -67,4 +68,5 @@ const _$ContentTypeEnumMap = {
   ContentType.json: 'json',
   ContentType.text: 'text',
   ContentType.formdata: 'formdata',
+  ContentType.formUrlEncoded: 'formUrlEncoded',
 };

--- a/packages/better_networking/lib/models/http_response_model.freezed.dart
+++ b/packages/better_networking/lib/models/http_response_model.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,151 +9,94 @@ part of 'http_response_model.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
-
-HttpResponseModel _$HttpResponseModelFromJson(Map<String, dynamic> json) {
-  return _HttpResponseModel.fromJson(json);
-}
 
 /// @nodoc
 mixin _$HttpResponseModel {
-  int? get statusCode => throw _privateConstructorUsedError;
-  Map<String, String>? get headers => throw _privateConstructorUsedError;
-  Map<String, String>? get requestHeaders => throw _privateConstructorUsedError;
-  String? get body => throw _privateConstructorUsedError;
-  String? get formattedBody => throw _privateConstructorUsedError;
+  int? get statusCode;
+  Map<String, String>? get headers;
+  Map<String, String>? get requestHeaders;
+  String? get body;
+  String? get formattedBody;
   @Uint8ListConverter()
-  Uint8List? get bodyBytes => throw _privateConstructorUsedError;
+  Uint8List? get bodyBytes;
   @DurationConverter()
-  Duration? get time => throw _privateConstructorUsedError;
-  List<String>? get sseOutput => throw _privateConstructorUsedError;
-
-  /// Serializes this HttpResponseModel to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  Duration? get time;
+  List<String>? get sseOutput;
 
   /// Create a copy of HttpResponseModel
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $HttpResponseModelCopyWith<HttpResponseModel> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $HttpResponseModelCopyWith<$Res> {
-  factory $HttpResponseModelCopyWith(
-    HttpResponseModel value,
-    $Res Function(HttpResponseModel) then,
-  ) = _$HttpResponseModelCopyWithImpl<$Res, HttpResponseModel>;
-  @useResult
-  $Res call({
-    int? statusCode,
-    Map<String, String>? headers,
-    Map<String, String>? requestHeaders,
-    String? body,
-    String? formattedBody,
-    @Uint8ListConverter() Uint8List? bodyBytes,
-    @DurationConverter() Duration? time,
-    List<String>? sseOutput,
-  });
-}
-
-/// @nodoc
-class _$HttpResponseModelCopyWithImpl<$Res, $Val extends HttpResponseModel>
-    implements $HttpResponseModelCopyWith<$Res> {
-  _$HttpResponseModelCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of HttpResponseModel
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
+  $HttpResponseModelCopyWith<HttpResponseModel> get copyWith =>
+      _$HttpResponseModelCopyWithImpl<HttpResponseModel>(
+          this as HttpResponseModel, _$identity);
+
+  /// Serializes this HttpResponseModel to a JSON map.
+  Map<String, dynamic> toJson();
+
   @override
-  $Res call({
-    Object? statusCode = freezed,
-    Object? headers = freezed,
-    Object? requestHeaders = freezed,
-    Object? body = freezed,
-    Object? formattedBody = freezed,
-    Object? bodyBytes = freezed,
-    Object? time = freezed,
-    Object? sseOutput = freezed,
-  }) {
-    return _then(
-      _value.copyWith(
-            statusCode: freezed == statusCode
-                ? _value.statusCode
-                : statusCode // ignore: cast_nullable_to_non_nullable
-                      as int?,
-            headers: freezed == headers
-                ? _value.headers
-                : headers // ignore: cast_nullable_to_non_nullable
-                      as Map<String, String>?,
-            requestHeaders: freezed == requestHeaders
-                ? _value.requestHeaders
-                : requestHeaders // ignore: cast_nullable_to_non_nullable
-                      as Map<String, String>?,
-            body: freezed == body
-                ? _value.body
-                : body // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            formattedBody: freezed == formattedBody
-                ? _value.formattedBody
-                : formattedBody // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            bodyBytes: freezed == bodyBytes
-                ? _value.bodyBytes
-                : bodyBytes // ignore: cast_nullable_to_non_nullable
-                      as Uint8List?,
-            time: freezed == time
-                ? _value.time
-                : time // ignore: cast_nullable_to_non_nullable
-                      as Duration?,
-            sseOutput: freezed == sseOutput
-                ? _value.sseOutput
-                : sseOutput // ignore: cast_nullable_to_non_nullable
-                      as List<String>?,
-          )
-          as $Val,
-    );
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is HttpResponseModel &&
+            (identical(other.statusCode, statusCode) ||
+                other.statusCode == statusCode) &&
+            const DeepCollectionEquality().equals(other.headers, headers) &&
+            const DeepCollectionEquality()
+                .equals(other.requestHeaders, requestHeaders) &&
+            (identical(other.body, body) || other.body == body) &&
+            (identical(other.formattedBody, formattedBody) ||
+                other.formattedBody == formattedBody) &&
+            const DeepCollectionEquality().equals(other.bodyBytes, bodyBytes) &&
+            (identical(other.time, time) || other.time == time) &&
+            const DeepCollectionEquality().equals(other.sseOutput, sseOutput));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      statusCode,
+      const DeepCollectionEquality().hash(headers),
+      const DeepCollectionEquality().hash(requestHeaders),
+      body,
+      formattedBody,
+      const DeepCollectionEquality().hash(bodyBytes),
+      time,
+      const DeepCollectionEquality().hash(sseOutput));
+
+  @override
+  String toString() {
+    return 'HttpResponseModel(statusCode: $statusCode, headers: $headers, requestHeaders: $requestHeaders, body: $body, formattedBody: $formattedBody, bodyBytes: $bodyBytes, time: $time, sseOutput: $sseOutput)';
   }
 }
 
 /// @nodoc
-abstract class _$$HttpResponseModelImplCopyWith<$Res>
-    implements $HttpResponseModelCopyWith<$Res> {
-  factory _$$HttpResponseModelImplCopyWith(
-    _$HttpResponseModelImpl value,
-    $Res Function(_$HttpResponseModelImpl) then,
-  ) = __$$HttpResponseModelImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $HttpResponseModelCopyWith<$Res> {
+  factory $HttpResponseModelCopyWith(
+          HttpResponseModel value, $Res Function(HttpResponseModel) _then) =
+      _$HttpResponseModelCopyWithImpl;
   @useResult
-  $Res call({
-    int? statusCode,
-    Map<String, String>? headers,
-    Map<String, String>? requestHeaders,
-    String? body,
-    String? formattedBody,
-    @Uint8ListConverter() Uint8List? bodyBytes,
-    @DurationConverter() Duration? time,
-    List<String>? sseOutput,
-  });
+  $Res call(
+      {int? statusCode,
+      Map<String, String>? headers,
+      Map<String, String>? requestHeaders,
+      String? body,
+      String? formattedBody,
+      @Uint8ListConverter() Uint8List? bodyBytes,
+      @DurationConverter() Duration? time,
+      List<String>? sseOutput});
 }
 
 /// @nodoc
-class __$$HttpResponseModelImplCopyWithImpl<$Res>
-    extends _$HttpResponseModelCopyWithImpl<$Res, _$HttpResponseModelImpl>
-    implements _$$HttpResponseModelImplCopyWith<$Res> {
-  __$$HttpResponseModelImplCopyWithImpl(
-    _$HttpResponseModelImpl _value,
-    $Res Function(_$HttpResponseModelImpl) _then,
-  ) : super(_value, _then);
+class _$HttpResponseModelCopyWithImpl<$Res>
+    implements $HttpResponseModelCopyWith<$Res> {
+  _$HttpResponseModelCopyWithImpl(this._self, this._then);
+
+  final HttpResponseModel _self;
+  final $Res Function(HttpResponseModel) _then;
 
   /// Create a copy of HttpResponseModel
   /// with the given fields replaced by the non-null parameter values.
@@ -169,65 +112,270 @@ class __$$HttpResponseModelImplCopyWithImpl<$Res>
     Object? time = freezed,
     Object? sseOutput = freezed,
   }) {
-    return _then(
-      _$HttpResponseModelImpl(
-        statusCode: freezed == statusCode
-            ? _value.statusCode
-            : statusCode // ignore: cast_nullable_to_non_nullable
-                  as int?,
-        headers: freezed == headers
-            ? _value._headers
-            : headers // ignore: cast_nullable_to_non_nullable
-                  as Map<String, String>?,
-        requestHeaders: freezed == requestHeaders
-            ? _value._requestHeaders
-            : requestHeaders // ignore: cast_nullable_to_non_nullable
-                  as Map<String, String>?,
-        body: freezed == body
-            ? _value.body
-            : body // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        formattedBody: freezed == formattedBody
-            ? _value.formattedBody
-            : formattedBody // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        bodyBytes: freezed == bodyBytes
-            ? _value.bodyBytes
-            : bodyBytes // ignore: cast_nullable_to_non_nullable
-                  as Uint8List?,
-        time: freezed == time
-            ? _value.time
-            : time // ignore: cast_nullable_to_non_nullable
-                  as Duration?,
-        sseOutput: freezed == sseOutput
-            ? _value._sseOutput
-            : sseOutput // ignore: cast_nullable_to_non_nullable
-                  as List<String>?,
-      ),
-    );
+    return _then(_self.copyWith(
+      statusCode: freezed == statusCode
+          ? _self.statusCode
+          : statusCode // ignore: cast_nullable_to_non_nullable
+              as int?,
+      headers: freezed == headers
+          ? _self.headers
+          : headers // ignore: cast_nullable_to_non_nullable
+              as Map<String, String>?,
+      requestHeaders: freezed == requestHeaders
+          ? _self.requestHeaders
+          : requestHeaders // ignore: cast_nullable_to_non_nullable
+              as Map<String, String>?,
+      body: freezed == body
+          ? _self.body
+          : body // ignore: cast_nullable_to_non_nullable
+              as String?,
+      formattedBody: freezed == formattedBody
+          ? _self.formattedBody
+          : formattedBody // ignore: cast_nullable_to_non_nullable
+              as String?,
+      bodyBytes: freezed == bodyBytes
+          ? _self.bodyBytes
+          : bodyBytes // ignore: cast_nullable_to_non_nullable
+              as Uint8List?,
+      time: freezed == time
+          ? _self.time
+          : time // ignore: cast_nullable_to_non_nullable
+              as Duration?,
+      sseOutput: freezed == sseOutput
+          ? _self.sseOutput
+          : sseOutput // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [HttpResponseModel].
+extension HttpResponseModelPatterns on HttpResponseModel {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_HttpResponseModel value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _HttpResponseModel() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_HttpResponseModel value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _HttpResponseModel():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_HttpResponseModel value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _HttpResponseModel() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            int? statusCode,
+            Map<String, String>? headers,
+            Map<String, String>? requestHeaders,
+            String? body,
+            String? formattedBody,
+            @Uint8ListConverter() Uint8List? bodyBytes,
+            @DurationConverter() Duration? time,
+            List<String>? sseOutput)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _HttpResponseModel() when $default != null:
+        return $default(
+            _that.statusCode,
+            _that.headers,
+            _that.requestHeaders,
+            _that.body,
+            _that.formattedBody,
+            _that.bodyBytes,
+            _that.time,
+            _that.sseOutput);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            int? statusCode,
+            Map<String, String>? headers,
+            Map<String, String>? requestHeaders,
+            String? body,
+            String? formattedBody,
+            @Uint8ListConverter() Uint8List? bodyBytes,
+            @DurationConverter() Duration? time,
+            List<String>? sseOutput)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _HttpResponseModel():
+        return $default(
+            _that.statusCode,
+            _that.headers,
+            _that.requestHeaders,
+            _that.body,
+            _that.formattedBody,
+            _that.bodyBytes,
+            _that.time,
+            _that.sseOutput);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            int? statusCode,
+            Map<String, String>? headers,
+            Map<String, String>? requestHeaders,
+            String? body,
+            String? formattedBody,
+            @Uint8ListConverter() Uint8List? bodyBytes,
+            @DurationConverter() Duration? time,
+            List<String>? sseOutput)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _HttpResponseModel() when $default != null:
+        return $default(
+            _that.statusCode,
+            _that.headers,
+            _that.requestHeaders,
+            _that.body,
+            _that.formattedBody,
+            _that.bodyBytes,
+            _that.time,
+            _that.sseOutput);
+      case _:
+        return null;
+    }
   }
 }
 
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true, anyMap: true)
-class _$HttpResponseModelImpl extends _HttpResponseModel {
-  const _$HttpResponseModelImpl({
-    this.statusCode,
-    final Map<String, String>? headers,
-    final Map<String, String>? requestHeaders,
-    this.body,
-    this.formattedBody,
-    @Uint8ListConverter() this.bodyBytes,
-    @DurationConverter() this.time,
-    final List<String>? sseOutput,
-  }) : _headers = headers,
-       _requestHeaders = requestHeaders,
-       _sseOutput = sseOutput,
-       super._();
-
-  factory _$HttpResponseModelImpl.fromJson(Map<String, dynamic> json) =>
-      _$$HttpResponseModelImplFromJson(json);
+class _HttpResponseModel extends HttpResponseModel {
+  const _HttpResponseModel(
+      {this.statusCode,
+      final Map<String, String>? headers,
+      final Map<String, String>? requestHeaders,
+      this.body,
+      this.formattedBody,
+      @Uint8ListConverter() this.bodyBytes,
+      @DurationConverter() this.time,
+      final List<String>? sseOutput})
+      : _headers = headers,
+        _requestHeaders = requestHeaders,
+        _sseOutput = sseOutput,
+        super._();
+  factory _HttpResponseModel.fromJson(Map<String, dynamic> json) =>
+      _$HttpResponseModelFromJson(json);
 
   @override
   final int? statusCode;
@@ -271,104 +419,135 @@ class _$HttpResponseModelImpl extends _HttpResponseModel {
     return EqualUnmodifiableListView(value);
   }
 
+  /// Create a copy of HttpResponseModel
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'HttpResponseModel(statusCode: $statusCode, headers: $headers, requestHeaders: $requestHeaders, body: $body, formattedBody: $formattedBody, bodyBytes: $bodyBytes, time: $time, sseOutput: $sseOutput)';
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$HttpResponseModelCopyWith<_HttpResponseModel> get copyWith =>
+      __$HttpResponseModelCopyWithImpl<_HttpResponseModel>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$HttpResponseModelToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$HttpResponseModelImpl &&
+            other is _HttpResponseModel &&
             (identical(other.statusCode, statusCode) ||
                 other.statusCode == statusCode) &&
             const DeepCollectionEquality().equals(other._headers, _headers) &&
-            const DeepCollectionEquality().equals(
-              other._requestHeaders,
-              _requestHeaders,
-            ) &&
+            const DeepCollectionEquality()
+                .equals(other._requestHeaders, _requestHeaders) &&
             (identical(other.body, body) || other.body == body) &&
             (identical(other.formattedBody, formattedBody) ||
                 other.formattedBody == formattedBody) &&
             const DeepCollectionEquality().equals(other.bodyBytes, bodyBytes) &&
             (identical(other.time, time) || other.time == time) &&
-            const DeepCollectionEquality().equals(
-              other._sseOutput,
-              _sseOutput,
-            ));
+            const DeepCollectionEquality()
+                .equals(other._sseOutput, _sseOutput));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
-    runtimeType,
-    statusCode,
-    const DeepCollectionEquality().hash(_headers),
-    const DeepCollectionEquality().hash(_requestHeaders),
-    body,
-    formattedBody,
-    const DeepCollectionEquality().hash(bodyBytes),
-    time,
-    const DeepCollectionEquality().hash(_sseOutput),
-  );
-
-  /// Create a copy of HttpResponseModel
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$HttpResponseModelImplCopyWith<_$HttpResponseModelImpl> get copyWith =>
-      __$$HttpResponseModelImplCopyWithImpl<_$HttpResponseModelImpl>(
-        this,
-        _$identity,
-      );
+      runtimeType,
+      statusCode,
+      const DeepCollectionEquality().hash(_headers),
+      const DeepCollectionEquality().hash(_requestHeaders),
+      body,
+      formattedBody,
+      const DeepCollectionEquality().hash(bodyBytes),
+      time,
+      const DeepCollectionEquality().hash(_sseOutput));
 
   @override
-  Map<String, dynamic> toJson() {
-    return _$$HttpResponseModelImplToJson(this);
+  String toString() {
+    return 'HttpResponseModel(statusCode: $statusCode, headers: $headers, requestHeaders: $requestHeaders, body: $body, formattedBody: $formattedBody, bodyBytes: $bodyBytes, time: $time, sseOutput: $sseOutput)';
   }
 }
 
-abstract class _HttpResponseModel extends HttpResponseModel {
-  const factory _HttpResponseModel({
-    final int? statusCode,
-    final Map<String, String>? headers,
-    final Map<String, String>? requestHeaders,
-    final String? body,
-    final String? formattedBody,
-    @Uint8ListConverter() final Uint8List? bodyBytes,
-    @DurationConverter() final Duration? time,
-    final List<String>? sseOutput,
-  }) = _$HttpResponseModelImpl;
-  const _HttpResponseModel._() : super._();
+/// @nodoc
+abstract mixin class _$HttpResponseModelCopyWith<$Res>
+    implements $HttpResponseModelCopyWith<$Res> {
+  factory _$HttpResponseModelCopyWith(
+          _HttpResponseModel value, $Res Function(_HttpResponseModel) _then) =
+      __$HttpResponseModelCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {int? statusCode,
+      Map<String, String>? headers,
+      Map<String, String>? requestHeaders,
+      String? body,
+      String? formattedBody,
+      @Uint8ListConverter() Uint8List? bodyBytes,
+      @DurationConverter() Duration? time,
+      List<String>? sseOutput});
+}
 
-  factory _HttpResponseModel.fromJson(Map<String, dynamic> json) =
-      _$HttpResponseModelImpl.fromJson;
+/// @nodoc
+class __$HttpResponseModelCopyWithImpl<$Res>
+    implements _$HttpResponseModelCopyWith<$Res> {
+  __$HttpResponseModelCopyWithImpl(this._self, this._then);
 
-  @override
-  int? get statusCode;
-  @override
-  Map<String, String>? get headers;
-  @override
-  Map<String, String>? get requestHeaders;
-  @override
-  String? get body;
-  @override
-  String? get formattedBody;
-  @override
-  @Uint8ListConverter()
-  Uint8List? get bodyBytes;
-  @override
-  @DurationConverter()
-  Duration? get time;
-  @override
-  List<String>? get sseOutput;
+  final _HttpResponseModel _self;
+  final $Res Function(_HttpResponseModel) _then;
 
   /// Create a copy of HttpResponseModel
   /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$HttpResponseModelImplCopyWith<_$HttpResponseModelImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? statusCode = freezed,
+    Object? headers = freezed,
+    Object? requestHeaders = freezed,
+    Object? body = freezed,
+    Object? formattedBody = freezed,
+    Object? bodyBytes = freezed,
+    Object? time = freezed,
+    Object? sseOutput = freezed,
+  }) {
+    return _then(_HttpResponseModel(
+      statusCode: freezed == statusCode
+          ? _self.statusCode
+          : statusCode // ignore: cast_nullable_to_non_nullable
+              as int?,
+      headers: freezed == headers
+          ? _self._headers
+          : headers // ignore: cast_nullable_to_non_nullable
+              as Map<String, String>?,
+      requestHeaders: freezed == requestHeaders
+          ? _self._requestHeaders
+          : requestHeaders // ignore: cast_nullable_to_non_nullable
+              as Map<String, String>?,
+      body: freezed == body
+          ? _self.body
+          : body // ignore: cast_nullable_to_non_nullable
+              as String?,
+      formattedBody: freezed == formattedBody
+          ? _self.formattedBody
+          : formattedBody // ignore: cast_nullable_to_non_nullable
+              as String?,
+      bodyBytes: freezed == bodyBytes
+          ? _self.bodyBytes
+          : bodyBytes // ignore: cast_nullable_to_non_nullable
+              as Uint8List?,
+      time: freezed == time
+          ? _self.time
+          : time // ignore: cast_nullable_to_non_nullable
+              as Duration?,
+      sseOutput: freezed == sseOutput
+          ? _self._sseOutput
+          : sseOutput // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+    ));
+  }
 }
+
+// dart format on

--- a/packages/better_networking/lib/models/http_response_model.g.dart
+++ b/packages/better_networking/lib/models/http_response_model.g.dart
@@ -6,8 +6,7 @@ part of 'http_response_model.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$HttpResponseModelImpl _$$HttpResponseModelImplFromJson(Map json) =>
-    _$HttpResponseModelImpl(
+_HttpResponseModel _$HttpResponseModelFromJson(Map json) => _HttpResponseModel(
       statusCode: (json['statusCode'] as num?)?.toInt(),
       headers: (json['headers'] as Map?)?.map(
         (k, e) => MapEntry(k as String, e as String),
@@ -17,24 +16,22 @@ _$HttpResponseModelImpl _$$HttpResponseModelImplFromJson(Map json) =>
       ),
       body: json['body'] as String?,
       formattedBody: json['formattedBody'] as String?,
-      bodyBytes: const Uint8ListConverter().fromJson(
-        json['bodyBytes'] as List<int>?,
-      ),
+      bodyBytes:
+          const Uint8ListConverter().fromJson(json['bodyBytes'] as List<int>?),
       time: const DurationConverter().fromJson((json['time'] as num?)?.toInt()),
       sseOutput: (json['sseOutput'] as List<dynamic>?)
           ?.map((e) => e as String)
           .toList(),
     );
 
-Map<String, dynamic> _$$HttpResponseModelImplToJson(
-  _$HttpResponseModelImpl instance,
-) => <String, dynamic>{
-  'statusCode': instance.statusCode,
-  'headers': instance.headers,
-  'requestHeaders': instance.requestHeaders,
-  'body': instance.body,
-  'formattedBody': instance.formattedBody,
-  'bodyBytes': const Uint8ListConverter().toJson(instance.bodyBytes),
-  'time': const DurationConverter().toJson(instance.time),
-  'sseOutput': instance.sseOutput,
-};
+Map<String, dynamic> _$HttpResponseModelToJson(_HttpResponseModel instance) =>
+    <String, dynamic>{
+      'statusCode': instance.statusCode,
+      'headers': instance.headers,
+      'requestHeaders': instance.requestHeaders,
+      'body': instance.body,
+      'formattedBody': instance.formattedBody,
+      'bodyBytes': const Uint8ListConverter().toJson(instance.bodyBytes),
+      'time': const DurationConverter().toJson(instance.time),
+      'sseOutput': instance.sseOutput,
+    };

--- a/packages/better_networking/lib/services/http_service.dart
+++ b/packages/better_networking/lib/services/http_service.dart
@@ -60,18 +60,30 @@ Future<(HttpResponse?, Duration?, String?)> sendHttpRequestV1(
       if (apiType == APIType.rest) {
         var isMultiPartRequest =
             requestModel.bodyContentType == ContentType.formdata;
+        var isFormUrlEncoded =
+            requestModel.bodyContentType == ContentType.formUrlEncoded;
 
         if (kMethodsWithBody.contains(authenticatedRequestModel.method)) {
-          var requestBody = authenticatedRequestModel.body;
-          if (requestBody != null &&
-              !isMultiPartRequest &&
-              requestBody.isNotEmpty) {
-            body = requestBody;
+          if (isFormUrlEncoded) {
+            body = authenticatedRequestModel.formUrlEncodedBody;
             if (authenticatedRequestModel.hasContentTypeHeader) {
               overrideContentType = true;
             } else {
               headers[HttpHeaders.contentTypeHeader] =
-                  authenticatedRequestModel.bodyContentType.header;
+                  ContentType.formUrlEncoded.header;
+            }
+          } else {
+            var requestBody = authenticatedRequestModel.body;
+            if (requestBody != null &&
+                !isMultiPartRequest &&
+                requestBody.isNotEmpty) {
+              body = requestBody;
+              if (authenticatedRequestModel.hasContentTypeHeader) {
+                overrideContentType = true;
+              } else {
+                headers[HttpHeaders.contentTypeHeader] =
+                    authenticatedRequestModel.bodyContentType.header;
+              }
             }
           }
           if (isMultiPartRequest) {
@@ -351,6 +363,8 @@ Future<http.StreamedResponse> makeStreamedRequest({
   final headers = requestModel.enabledHeadersMap;
   final hasBody = kMethodsWithBody.contains(requestModel.method);
   final isMultipart = requestModel.bodyContentType == ContentType.formdata;
+  final isFormUrlEncoded =
+      requestModel.bodyContentType == ContentType.formUrlEncoded;
 
   http.StreamedResponse streamedResponse;
 
@@ -393,7 +407,15 @@ Future<http.StreamedResponse> makeStreamedRequest({
     //Handling regular REST Requests
     String? body;
     bool overrideContentType = false;
-    if (hasBody && requestModel.body?.isNotEmpty == true) {
+    if (hasBody && isFormUrlEncoded) {
+      body = requestModel.formUrlEncodedBody;
+      if (!requestModel.hasContentTypeHeader) {
+        headers[HttpHeaders.contentTypeHeader] =
+            ContentType.formUrlEncoded.header;
+      } else {
+        overrideContentType = true;
+      }
+    } else if (hasBody && requestModel.body?.isNotEmpty == true) {
       body = requestModel.body;
       if (!requestModel.hasContentTypeHeader) {
         headers[HttpHeaders.contentTypeHeader] =

--- a/packages/better_networking/lib/utils/content_type_utils.dart
+++ b/packages/better_networking/lib/utils/content_type_utils.dart
@@ -35,6 +35,9 @@ ContentType? getContentTypeFromMediaType(MediaType? mediaType) {
     } else if (mediaType.type == kTypeMultipart &&
         mediaType.subtype == kSubTypeFormData) {
       return ContentType.formdata;
+    } else if (mediaType.type == kTypeApplication &&
+        mediaType.subtype == kSubTypeXWwwFormUrlencoded) {
+      return ContentType.formUrlEncoded;
     }
     return ContentType.text;
   }

--- a/packages/better_networking/test/models/http_request_model_test.dart
+++ b/packages/better_networking/test/models/http_request_model_test.dart
@@ -83,5 +83,95 @@ void main() {
       expect(model.formDataMapList.length, 2);
       expect(model.hasFileInFormData, true);
     });
+
+    test('formUrlEncoded content type check', () {
+      const model =
+          HttpRequestModel(bodyContentType: ContentType.formUrlEncoded);
+      expect(model.hasFormUrlEncodedContentType, true);
+      expect(model.hasFormDataContentType, false);
+      expect(model.hasJsonContentType, false);
+      expect(model.hasTextContentType, false);
+    });
+
+    test('hasFormUrlEncodedData with POST and form data', () {
+      const formData = [
+        FormDataModel(name: 'user', value: 'john', type: FormDataType.text),
+        FormDataModel(name: 'pass', value: 'secret', type: FormDataType.text),
+      ];
+
+      const model = HttpRequestModel(
+        method: HTTPVerb.post,
+        bodyContentType: ContentType.formUrlEncoded,
+        formData: formData,
+      );
+
+      expect(model.hasFormUrlEncodedData, true);
+      expect(model.hasBody, true);
+      expect(model.hasAnyBody, true);
+      expect(model.hasFormData, false);
+      expect(model.hasJsonData, false);
+    });
+
+    test('formUrlEncodedBody encodes key-value pairs correctly', () {
+      const formData = [
+        FormDataModel(name: 'user', value: 'john', type: FormDataType.text),
+        FormDataModel(name: 'pass', value: 'secret', type: FormDataType.text),
+      ];
+
+      const model = HttpRequestModel(
+        method: HTTPVerb.post,
+        bodyContentType: ContentType.formUrlEncoded,
+        formData: formData,
+      );
+
+      expect(model.formUrlEncodedBody, 'user=john&pass=secret');
+    });
+
+    test('formUrlEncodedBody percent-encodes special characters', () {
+      const formData = [
+        FormDataModel(
+            name: 'query', value: 'hello world', type: FormDataType.text),
+        FormDataModel(
+            name: 'url', value: 'https://example.com', type: FormDataType.text),
+      ];
+
+      const model = HttpRequestModel(
+        method: HTTPVerb.post,
+        bodyContentType: ContentType.formUrlEncoded,
+        formData: formData,
+      );
+
+      expect(model.formUrlEncodedBody,
+          'query=hello%20world&url=https%3A%2F%2Fexample.com');
+    });
+
+    test('formUrlEncodedBody skips empty field names', () {
+      const formData = [
+        FormDataModel(name: '', value: 'empty', type: FormDataType.text),
+        FormDataModel(name: 'key', value: 'val', type: FormDataType.text),
+      ];
+
+      const model = HttpRequestModel(
+        method: HTTPVerb.post,
+        bodyContentType: ContentType.formUrlEncoded,
+        formData: formData,
+      );
+
+      expect(model.formUrlEncodedBody, 'key=val');
+    });
+
+    test('formUrlEncoded JSON serialization round-trip', () {
+      const model = HttpRequestModel(
+        method: HTTPVerb.post,
+        url: 'https://example.com',
+        bodyContentType: ContentType.formUrlEncoded,
+      );
+
+      final json = model.toJson();
+      final fromJson = HttpRequestModel.fromJson(json);
+
+      expect(fromJson.bodyContentType, ContentType.formUrlEncoded);
+      expect(fromJson.hasFormUrlEncodedContentType, true);
+    });
   });
 }


### PR DESCRIPTION
## PR Description

This PR implements the `application/x-www-form-urlencoded` request body type, closing issue #337. 

Previously, API Dash only supported generic multipart form data for key-value entry. This PR unblocks users who need to submit form data via the strictly standard URL-encoded string payload.

**Changes Made:**
- Added `ContentType.formUrlEncoded` enum mapping perfectly to `application/x-www-form-urlencoded`.
- Updated [HttpRequestModel](cci:2://file:///c:/Users/think/OneDrive/Desktop/open-source/apidash/packages/better_networking/lib/models/http_request_model.dart:11:0-85:1) extensively with `hasFormUrlEncodedContentType`, `hasFormUrlEncodedData`, and added a new getter `formUrlEncodedBody` which safely applies `Uri.encodeComponent` mappings to key-value pairs (ignoring empty keys).
- Updated [http_service.dart](cci:7://file:///c:/Users/think/OneDrive/Desktop/open-source/apidash/packages/better_networking/lib/services/http_service.dart:0:0-0:0) to intercept the new content type and send the request naturally with the strictly encoded data string as the body (fully bypassing the multipart logic).
- Updated the existing form-data UI Editor views in both the main editor ([request_body.dart](cci:7://file:///c:/Users/think/OneDrive/Desktop/open-source/apidash/lib/screens/home_page/editor_pane/details_card/request_pane/request_body.dart:0:0-0:0)) and the history panel ([his_request_pane.dart](cci:7://file:///c:/Users/think/OneDrive/Desktop/open-source/apidash/lib/screens/history/history_widgets/his_request_pane.dart:0:0-0:0)) to intelligently render for the new Content Type.
- Fixed [dio.dart](cci:7://file:///c:/Users/think/OneDrive/Desktop/open-source/apidash/lib/codegen/dart/dio.dart:0:0-0:0) code generation exhaustive switch errors.
- Added comprehensive unit tests in [http_request_model_test.dart](cci:7://file:///c:/Users/think/OneDrive/Desktop/open-source/apidash/test/models/http_request_model_test.dart:0:0-0:0) to verify behavior including query parameters with special characters and empty payloads.

## Related Issues

* Closes #337

### Checklist

* [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
* [x] I have updated my branch and synced it with project [main](cci:1://file:///c:/Users/think/OneDrive/Desktop/open-source/apidash/lib/main.dart:11:0-42:1) branch before making this PR
* [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
* [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

* [x] Yes, added 6 unit tests to [test/models/http_request_model_test.dart](cci:7://file:///c:/Users/think/OneDrive/Desktop/open-source/apidash/packages/better_networking/test/models/http_request_model_test.dart:0:0-0:0) asserting that the new `hasFormUrlEncodedContentType`, `hasFormUrlEncodedData`, and `formUrlEncodedBody` getters function correctly (including parsing special characters, empty payloads, and proper object serialization).
* [ ] No


## OS on which you have developed and tested the feature?

* [x] Windows
* [ ] macOS
* [ ] Linux

---
