### PR TITLE
[Fix] AI Model Selector overflow and [FEAT] enhance Postman v2.1 importer auth & variables handling (#1330)

### DIFF
--- a/lib/screens/common_widgets/ai/ai_model_selector_dialog.dart
+++ b/lib/screens/common_widgets/ai/ai_model_selector_dialog.dart
@@ -33,7 +33,9 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
   @override
   Widget build(BuildContext context) {
     // ref.watch(aiApiCredentialProvider);
-    final width = MediaQuery.of(context).size.width * 0.8;
+    final mediaQuery = MediaQuery.of(context);
+    final width = mediaQuery.size.width * 0.8;
+    final maxContentHeight = mediaQuery.size.height * 0.75;
     return FutureBuilder(
       future: aM,
       builder: (context, snapshot) {
@@ -43,59 +45,13 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
           final data = snapshot.data!;
           final mappedData = data.map;
           if (context.isMediumWindow) {
-            return Container(
-              padding: kP20,
+            return SizedBox(
               width: width,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  ElevatedButton(
-                    onPressed: null,
-                    // TODO: Add update model logic
-                    //() async {
-                    // await LLMManager.fetchAvailableLLMs();
-                    // setState(() {});
-                    //},
-                    child: Text(kLabelUpdateModels),
-                  ),
-                  kVSpacer10,
-                  Row(
-                    children: [
-                      Text(kLabelSelectModelProvider),
-                      kHSpacer20,
-                      Expanded(
-                        child: ADDropdownButton<ModelAPIProvider>(
-                          onChanged: (x) {
-                            setState(() {
-                              selectedProvider = x;
-                              newAIRequestModel = mappedData[selectedProvider]
-                                  ?.toAiRequestModel();
-                            });
-                          },
-                          value: selectedProvider,
-                          values: data.modelProviders.map(
-                            (e) => (e.providerId!, e.providerName),
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                  kVSpacer10,
-                  _buildModelSelector(mappedData[selectedProvider]),
-                ],
-              ),
-            );
-          }
-
-          return Container(
-            padding: kP20,
-            width: width,
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Flexible(
-                  flex: 1,
-                  child: SingleChildScrollView(
+              child: ConstrainedBox(
+                constraints: BoxConstraints(maxHeight: maxContentHeight),
+                child: SingleChildScrollView(
+                  child: Padding(
+                    padding: kP20,
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
@@ -108,35 +64,99 @@ class _AIModelSelectorDialogState extends ConsumerState<AIModelSelectorDialog> {
                           //},
                           child: Text(kLabelUpdateModels),
                         ),
-                        SizedBox(height: 20),
-                        ...data.modelProviders.map(
-                          (x) => ListTile(
-                            title: Text(x.providerName ?? ""),
-                            trailing: selectedProvider != x.providerId
-                                ? null
-                                : CircleAvatar(
-                                    radius: 5,
-                                    backgroundColor: Colors.green,
-                                  ),
-                            onTap: () {
-                              setState(() {
-                                selectedProvider = x.providerId;
-                                newAIRequestModel = mappedData[selectedProvider]
-                                    ?.toAiRequestModel();
-                              });
-                            },
-                          ),
+                        kVSpacer10,
+                        Row(
+                          children: [
+                            Text(kLabelSelectModelProvider),
+                            kHSpacer20,
+                            Expanded(
+                              child: ADDropdownButton<ModelAPIProvider>(
+                                onChanged: (x) {
+                                  setState(() {
+                                    selectedProvider = x;
+                                    newAIRequestModel =
+                                        mappedData[selectedProvider]
+                                            ?.toAiRequestModel();
+                                  });
+                                },
+                                value: selectedProvider,
+                                values: data.modelProviders.map(
+                                  (e) => (e.providerId!, e.providerName),
+                                ),
+                              ),
+                            ),
+                          ],
                         ),
+                        kVSpacer10,
+                        _buildModelSelector(mappedData[selectedProvider]),
                       ],
                     ),
                   ),
                 ),
-                SizedBox(width: 40),
-                Flexible(
-                  flex: 3,
-                  child: _buildModelSelector(mappedData[selectedProvider]),
+              ),
+            );
+          }
+
+          return SizedBox(
+            width: width,
+            child: ConstrainedBox(
+              constraints: BoxConstraints(maxHeight: maxContentHeight),
+              child: Padding(
+                padding: kP20,
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Flexible(
+                      flex: 1,
+                      child: SingleChildScrollView(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            ElevatedButton(
+                              onPressed: null,
+                              // TODO: Add update model logic
+                              //() async {
+                              // await LLMManager.fetchAvailableLLMs();
+                              // setState(() {});
+                              //},
+                              child: Text(kLabelUpdateModels),
+                            ),
+                            SizedBox(height: 20),
+                            ...data.modelProviders.map(
+                              (x) => ListTile(
+                                title: Text(x.providerName ?? ""),
+                                trailing: selectedProvider != x.providerId
+                                    ? null
+                                    : CircleAvatar(
+                                        radius: 5,
+                                        backgroundColor: Colors.green,
+                                      ),
+                                onTap: () {
+                                  setState(() {
+                                    selectedProvider = x.providerId;
+                                    newAIRequestModel =
+                                        mappedData[selectedProvider]
+                                            ?.toAiRequestModel();
+                                  });
+                                },
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    SizedBox(width: 40),
+                    Flexible(
+                      flex: 3,
+                      child: SingleChildScrollView(
+                        child: _buildModelSelector(
+                          mappedData[selectedProvider],
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
-              ],
+              ),
             ),
           );
         }

--- a/packages/apidash_core/lib/import_export/postman_io.dart
+++ b/packages/apidash_core/lib/import_export/postman_io.dart
@@ -6,16 +6,23 @@ class PostmanIO {
     content = content.trim();
     try {
       final pc = pm.postmanCollectionFromJsonStr(content);
+      final variableMap = pm.buildVariableMap(pc.variable);
       final requests = pm.getRequestsFromPostmanCollection(pc);
       return requests
-          .map((req) => (req.$1, postmanRequestToHttpRequestModel(req.$2)))
+          .map((req) => (
+                req.$1,
+                postmanRequestToHttpRequestModel(req.$2, variableMap),
+              ))
           .toList();
     } catch (e) {
       return null;
     }
   }
 
-  HttpRequestModel postmanRequestToHttpRequestModel(pm.Request request) {
+  HttpRequestModel postmanRequestToHttpRequestModel(
+    pm.Request request, [
+    Map<String, String> variableMap = const {},
+  ]) {
     HTTPVerb method;
 
     try {
@@ -23,7 +30,8 @@ class PostmanIO {
     } catch (e) {
       method = kDefaultHttpMethod;
     }
-    String url = stripUrlParams(request.url?.raw ?? "");
+    String url =
+        stripUrlParams(_substitute(request.url?.raw ?? '', variableMap));
     List<NameValueModel> headers = [];
     List<bool> isHeaderEnabledList = [];
 
@@ -32,7 +40,7 @@ class PostmanIO {
 
     for (var header in request.header ?? <pm.Header>[]) {
       var name = header.key ?? "";
-      var value = header.value;
+      var value = _substituteNullable(header.value, variableMap);
       var activeHeader = header.disabled ?? false;
       headers.add(NameValueModel(name: name, value: value));
       isHeaderEnabledList.add(!activeHeader);
@@ -40,7 +48,7 @@ class PostmanIO {
 
     for (var query in request.url?.query ?? <pm.Query>[]) {
       var name = query.key ?? "";
-      var value = query.value;
+      var value = _substituteNullable(query.value, variableMap);
       var activeQuery = query.disabled ?? false;
       params.add(NameValueModel(name: name, value: value));
       isParamEnabledList.add(!activeQuery);
@@ -57,7 +65,7 @@ class PostmanIO {
         } catch (e) {
           bodyContentType = kDefaultContentType;
         }
-        body = request.body?.raw;
+        body = _substituteNullable(request.body?.raw, variableMap);
       }
       if (request.body?.mode == 'formdata') {
         bodyContentType = ContentType.formdata;
@@ -71,8 +79,8 @@ class PostmanIO {
             formDataType = FormDataType.text;
           }
           var value = switch (formDataType) {
-            FormDataType.text => fd.value ?? "",
-            FormDataType.file => fd.src ?? ""
+            FormDataType.text => _substitute(fd.value ?? '', variableMap),
+            FormDataType.file => _substitute(fd.src ?? '', variableMap)
           };
           formData.add(FormDataModel(
             name: name,
@@ -81,7 +89,25 @@ class PostmanIO {
           ));
         }
       }
+      if (request.body?.mode == 'urlencoded') {
+        bodyContentType = ContentType.formdata;
+        formData = [];
+        for (var u in request.body?.urlencoded ?? <pm.Urlencoded>[]) {
+          if (u.disabled ?? false) {
+            continue;
+          }
+          formData.add(
+            FormDataModel(
+              name: u.key ?? '',
+              value: _substitute(u.value ?? '', variableMap),
+              type: FormDataType.text,
+            ),
+          );
+        }
+      }
     }
+
+    final authModel = _mapAuthModel(request.auth, variableMap);
 
     return HttpRequestModel(
       method: method,
@@ -90,9 +116,76 @@ class PostmanIO {
       params: params,
       isHeaderEnabledList: isHeaderEnabledList,
       isParamEnabledList: isParamEnabledList,
+      authModel: authModel,
       body: body,
       bodyContentType: bodyContentType,
       formData: formData,
     );
+  }
+
+  String _substitute(String input, Map<String, String> variableMap) {
+    if (variableMap.isEmpty) {
+      return input;
+    }
+    return pm.substituteVariables(input, variableMap);
+  }
+
+  String? _substituteNullable(String? input, Map<String, String> variableMap) {
+    if (input == null) {
+      return null;
+    }
+    return _substitute(input, variableMap);
+  }
+
+  AuthModel _mapAuthModel(
+    pm.PostmanAuth? auth,
+    Map<String, String> variableMap,
+  ) {
+    if (auth == null) {
+      return const AuthModel(type: APIAuthType.none);
+    }
+    switch ((auth.type ?? '').toLowerCase()) {
+      case 'bearer':
+        return AuthModel(
+          type: APIAuthType.bearer,
+          bearer: AuthBearerModel(
+            token: _substitute(
+                _getAuthValue(auth.bearer, 'token') ?? '', variableMap),
+          ),
+        );
+      case 'basic':
+        return AuthModel(
+          type: APIAuthType.basic,
+          basic: AuthBasicAuthModel(
+            username: _substitute(
+                _getAuthValue(auth.basic, 'username') ?? '', variableMap),
+            password: _substitute(
+                _getAuthValue(auth.basic, 'password') ?? '', variableMap),
+          ),
+        );
+      case 'apikey':
+        return AuthModel(
+          type: APIAuthType.apiKey,
+          apikey: AuthApiKeyModel(
+            key: _substitute(
+                _getAuthValue(auth.apikey, 'value') ?? '', variableMap),
+            name: _substitute(
+                _getAuthValue(auth.apikey, 'key') ?? 'x-api-key', variableMap),
+            location: _substitute(
+                _getAuthValue(auth.apikey, 'in') ?? 'header', variableMap),
+          ),
+        );
+      default:
+        return const AuthModel(type: APIAuthType.none);
+    }
+  }
+
+  String? _getAuthValue(List<pm.AuthKeyValue>? values, String key) {
+    for (final value in values ?? <pm.AuthKeyValue>[]) {
+      if ((value.key ?? '').toLowerCase() == key.toLowerCase()) {
+        return value.value;
+      }
+    }
+    return null;
   }
 }

--- a/packages/apidash_core/test/import_export/postman_io_test.dart
+++ b/packages/apidash_core/test/import_export/postman_io_test.dart
@@ -1,0 +1,251 @@
+import 'package:apidash_core/apidash_core.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('PostmanIO import conversion', () {
+    final postmanIO = PostmanIO();
+
+    test('maps bearer auth from Postman auth block', () {
+      const content = r'''
+{
+  "info": {
+    "name": "Bearer",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Bearer Request",
+      "request": {
+        "method": "GET",
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "my-bearer-token"
+            }
+          ]
+        },
+        "url": {
+          "raw": "https://api.example.com/data"
+        }
+      }
+    }
+  ]
+}
+''';
+
+      final requests = postmanIO.getHttpRequestModelList(content);
+      final request = requests!.first.$2;
+
+      expect(request.authModel?.type, APIAuthType.bearer);
+      expect(request.authModel?.bearer?.token, 'my-bearer-token');
+    });
+
+    test('maps basic and apikey auth from Postman auth block', () {
+      const content = r'''
+{
+  "info": {
+    "name": "Basic + API Key",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Basic Request",
+      "request": {
+        "method": "GET",
+        "auth": {
+          "type": "basic",
+          "basic": [
+            {
+              "key": "username",
+              "value": "john"
+            },
+            {
+              "key": "password",
+              "value": "secret"
+            }
+          ]
+        },
+        "url": {
+          "raw": "https://api.example.com/basic"
+        }
+      }
+    },
+    {
+      "name": "ApiKey Request",
+      "request": {
+        "method": "GET",
+        "auth": {
+          "type": "apikey",
+          "apikey": [
+            {
+              "key": "key",
+              "value": "X-API-Key"
+            },
+            {
+              "key": "value",
+              "value": "abcdef"
+            },
+            {
+              "key": "in",
+              "value": "header"
+            }
+          ]
+        },
+        "url": {
+          "raw": "https://api.example.com/apikey"
+        }
+      }
+    }
+  ]
+}
+''';
+
+      final requests = postmanIO.getHttpRequestModelList(content)!;
+      final basicRequest = requests[0].$2;
+      final apiKeyRequest = requests[1].$2;
+
+      expect(basicRequest.authModel?.type, APIAuthType.basic);
+      expect(basicRequest.authModel?.basic?.username, 'john');
+      expect(basicRequest.authModel?.basic?.password, 'secret');
+
+      expect(apiKeyRequest.authModel?.type, APIAuthType.apiKey);
+      expect(apiKeyRequest.authModel?.apikey?.name, 'X-API-Key');
+      expect(apiKeyRequest.authModel?.apikey?.key, 'abcdef');
+      expect(apiKeyRequest.authModel?.apikey?.location, 'header');
+    });
+
+    test('falls back to none for unsupported auth type', () {
+      const content = r'''
+{
+  "info": {
+    "name": "Unsupported Auth",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Digest Request",
+      "request": {
+        "method": "GET",
+        "auth": {
+          "type": "digest"
+        },
+        "url": {
+          "raw": "https://api.example.com/digest"
+        }
+      }
+    }
+  ]
+}
+''';
+
+      final requests = postmanIO.getHttpRequestModelList(content);
+      final request = requests!.first.$2;
+
+      expect(request.authModel?.type, APIAuthType.none);
+    });
+
+    test('maps urlencoded body entries into form data rows', () {
+      const content = r'''
+{
+  "info": {
+    "name": "urlencoded",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Token Request",
+      "request": {
+        "method": "POST",
+        "body": {
+          "mode": "urlencoded",
+          "urlencoded": [
+            {
+              "key": "grant_type",
+              "value": "client_credentials",
+              "type": "text"
+            },
+            {
+              "key": "disabled_field",
+              "value": "ignore-me",
+              "type": "text",
+              "disabled": true
+            }
+          ]
+        },
+        "url": {
+          "raw": "https://api.example.com/oauth/token"
+        }
+      }
+    }
+  ]
+}
+''';
+
+      final requests = postmanIO.getHttpRequestModelList(content);
+      final request = requests!.first.$2;
+
+      expect(request.bodyContentType, ContentType.formdata);
+      expect(request.formData, isNotNull);
+      expect(request.formData!.length, 1);
+      expect(request.formData!.first.name, 'grant_type');
+      expect(request.formData!.first.value, 'client_credentials');
+      expect(request.formData!.first.type, FormDataType.text);
+    });
+
+    test('resolves collection variables in url, headers and body', () {
+      const content = r'''
+{
+  "info": {
+    "name": "Variables",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "https://api.example.com"
+    },
+    {
+      "key": "api_key",
+      "value": "top-secret"
+    }
+  ],
+  "item": [
+    {
+      "name": "Variable Request",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{api_key}}"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"token\":\"{{api_key}}\"}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{base_url}}/v1/data"
+        }
+      }
+    }
+  ]
+}
+''';
+
+      final requests = postmanIO.getHttpRequestModelList(content);
+      final request = requests!.first.$2;
+
+      expect(request.url, 'https://api.example.com/v1/data');
+      expect(request.headers?.first.value, 'Bearer top-secret');
+      expect(request.body, '{"token":"top-secret"}');
+    });
+  });
+}

--- a/packages/postman/lib/models/postman_collection.dart
+++ b/packages/postman/lib/models/postman_collection.dart
@@ -14,7 +14,7 @@ String postmanCollectionToJsonStr(PostmanCollection data) =>
     JsonEncoder.withIndent('  ').convert(data);
 
 @freezed
-class PostmanCollection with _$PostmanCollection {
+sealed class PostmanCollection with _$PostmanCollection {
   @JsonSerializable(
     explicitToJson: true,
     anyMap: true,
@@ -23,6 +23,7 @@ class PostmanCollection with _$PostmanCollection {
   const factory PostmanCollection({
     Info? info,
     List<Item>? item,
+    List<Variable>? variable,
   }) = _PostmanCollection;
 
   factory PostmanCollection.fromJson(Map<String, dynamic> json) =>
@@ -30,7 +31,7 @@ class PostmanCollection with _$PostmanCollection {
 }
 
 @freezed
-class Info with _$Info {
+sealed class Info with _$Info {
   @JsonSerializable(
     explicitToJson: true,
     anyMap: true,
@@ -47,7 +48,7 @@ class Info with _$Info {
 }
 
 @freezed
-class Item with _$Item {
+sealed class Item with _$Item {
   @JsonSerializable(
     explicitToJson: true,
     anyMap: true,
@@ -64,7 +65,7 @@ class Item with _$Item {
 }
 
 @freezed
-class Request with _$Request {
+sealed class Request with _$Request {
   @JsonSerializable(
     explicitToJson: true,
     anyMap: true,
@@ -75,6 +76,7 @@ class Request with _$Request {
     List<Header>? header,
     Body? body,
     Url? url,
+    PostmanAuth? auth,
   }) = _Request;
 
   factory Request.fromJson(Map<String, dynamic> json) =>
@@ -82,7 +84,7 @@ class Request with _$Request {
 }
 
 @freezed
-class Header with _$Header {
+sealed class Header with _$Header {
   @JsonSerializable(
     explicitToJson: true,
     anyMap: true,
@@ -99,7 +101,7 @@ class Header with _$Header {
 }
 
 @freezed
-class Url with _$Url {
+sealed class Url with _$Url {
   @JsonSerializable(
     explicitToJson: true,
     anyMap: true,
@@ -117,7 +119,7 @@ class Url with _$Url {
 }
 
 @freezed
-class Query with _$Query {
+sealed class Query with _$Query {
   @JsonSerializable(
     explicitToJson: true,
     anyMap: true,
@@ -133,7 +135,7 @@ class Query with _$Query {
 }
 
 @freezed
-class Body with _$Body {
+sealed class Body with _$Body {
   @JsonSerializable(
     explicitToJson: true,
     anyMap: true,
@@ -144,13 +146,14 @@ class Body with _$Body {
     String? raw,
     Options? options,
     List<Formdatum>? formdata,
+    List<Urlencoded>? urlencoded,
   }) = _Body;
 
   factory Body.fromJson(Map<String, dynamic> json) => _$BodyFromJson(json);
 }
 
 @freezed
-class Options with _$Options {
+sealed class Options with _$Options {
   @JsonSerializable(
     explicitToJson: true,
     anyMap: true,
@@ -165,7 +168,7 @@ class Options with _$Options {
 }
 
 @freezed
-class Raw with _$Raw {
+sealed class Raw with _$Raw {
   @JsonSerializable(
     explicitToJson: true,
     anyMap: true,
@@ -179,7 +182,7 @@ class Raw with _$Raw {
 }
 
 @freezed
-class Formdatum with _$Formdatum {
+sealed class Formdatum with _$Formdatum {
   @JsonSerializable(
     explicitToJson: true,
     anyMap: true,
@@ -194,4 +197,74 @@ class Formdatum with _$Formdatum {
 
   factory Formdatum.fromJson(Map<String, dynamic> json) =>
       _$FormdatumFromJson(json);
+}
+
+@freezed
+sealed class Urlencoded with _$Urlencoded {
+  @JsonSerializable(
+    explicitToJson: true,
+    anyMap: true,
+    includeIfNull: false,
+  )
+  const factory Urlencoded({
+    String? key,
+    String? value,
+    String? type,
+    bool? disabled,
+  }) = _Urlencoded;
+
+  factory Urlencoded.fromJson(Map<String, dynamic> json) =>
+      _$UrlencodedFromJson(json);
+}
+
+@freezed
+sealed class PostmanAuth with _$PostmanAuth {
+  @JsonSerializable(
+    explicitToJson: true,
+    anyMap: true,
+    includeIfNull: false,
+  )
+  const factory PostmanAuth({
+    String? type,
+    List<AuthKeyValue>? bearer,
+    List<AuthKeyValue>? basic,
+    List<AuthKeyValue>? apikey,
+  }) = _PostmanAuth;
+
+  factory PostmanAuth.fromJson(Map<String, dynamic> json) =>
+      _$PostmanAuthFromJson(json);
+}
+
+@freezed
+sealed class AuthKeyValue with _$AuthKeyValue {
+  @JsonSerializable(
+    explicitToJson: true,
+    anyMap: true,
+    includeIfNull: false,
+  )
+  const factory AuthKeyValue({
+    String? key,
+    String? value,
+    String? type,
+  }) = _AuthKeyValue;
+
+  factory AuthKeyValue.fromJson(Map<String, dynamic> json) =>
+      _$AuthKeyValueFromJson(json);
+}
+
+@freezed
+sealed class Variable with _$Variable {
+  @JsonSerializable(
+    explicitToJson: true,
+    anyMap: true,
+    includeIfNull: false,
+  )
+  const factory Variable({
+    String? key,
+    String? value,
+    String? type,
+  }) = _Variable;
+
+  factory Variable.fromJson(Map<String, dynamic> json) =>
+      _$VariableFromJson(json);
 }

--- a/packages/postman/lib/models/postman_collection.freezed.dart
+++ b/packages/postman/lib/models/postman_collection.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,50 +9,68 @@ part of 'postman_collection.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-PostmanCollection _$PostmanCollectionFromJson(Map<String, dynamic> json) {
-  return _PostmanCollection.fromJson(json);
-}
 
 /// @nodoc
 mixin _$PostmanCollection {
-  Info? get info => throw _privateConstructorUsedError;
-  List<Item>? get item => throw _privateConstructorUsedError;
-
-  /// Serializes this PostmanCollection to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  Info? get info;
+  List<Item>? get item;
+  List<Variable>? get variable;
 
   /// Create a copy of PostmanCollection
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $PostmanCollectionCopyWith<PostmanCollection> get copyWith =>
-      throw _privateConstructorUsedError;
+      _$PostmanCollectionCopyWithImpl<PostmanCollection>(
+          this as PostmanCollection, _$identity);
+
+  /// Serializes this PostmanCollection to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is PostmanCollection &&
+            (identical(other.info, info) || other.info == info) &&
+            const DeepCollectionEquality().equals(other.item, item) &&
+            const DeepCollectionEquality().equals(other.variable, variable));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      info,
+      const DeepCollectionEquality().hash(item),
+      const DeepCollectionEquality().hash(variable));
+
+  @override
+  String toString() {
+    return 'PostmanCollection(info: $info, item: $item, variable: $variable)';
+  }
 }
 
 /// @nodoc
-abstract class $PostmanCollectionCopyWith<$Res> {
+abstract mixin class $PostmanCollectionCopyWith<$Res> {
   factory $PostmanCollectionCopyWith(
-          PostmanCollection value, $Res Function(PostmanCollection) then) =
-      _$PostmanCollectionCopyWithImpl<$Res, PostmanCollection>;
+          PostmanCollection value, $Res Function(PostmanCollection) _then) =
+      _$PostmanCollectionCopyWithImpl;
   @useResult
-  $Res call({Info? info, List<Item>? item});
+  $Res call({Info? info, List<Item>? item, List<Variable>? variable});
 
   $InfoCopyWith<$Res>? get info;
 }
 
 /// @nodoc
-class _$PostmanCollectionCopyWithImpl<$Res, $Val extends PostmanCollection>
+class _$PostmanCollectionCopyWithImpl<$Res>
     implements $PostmanCollectionCopyWith<$Res> {
-  _$PostmanCollectionCopyWithImpl(this._value, this._then);
+  _$PostmanCollectionCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final PostmanCollection _self;
+  final $Res Function(PostmanCollection) _then;
 
   /// Create a copy of PostmanCollection
   /// with the given fields replaced by the non-null parameter values.
@@ -61,17 +79,22 @@ class _$PostmanCollectionCopyWithImpl<$Res, $Val extends PostmanCollection>
   $Res call({
     Object? info = freezed,
     Object? item = freezed,
+    Object? variable = freezed,
   }) {
-    return _then(_value.copyWith(
+    return _then(_self.copyWith(
       info: freezed == info
-          ? _value.info
+          ? _self.info
           : info // ignore: cast_nullable_to_non_nullable
               as Info?,
       item: freezed == item
-          ? _value.item
+          ? _self.item
           : item // ignore: cast_nullable_to_non_nullable
               as List<Item>?,
-    ) as $Val);
+      variable: freezed == variable
+          ? _self.variable
+          : variable // ignore: cast_nullable_to_non_nullable
+              as List<Variable>?,
+    ));
   }
 
   /// Create a copy of PostmanCollection
@@ -79,68 +102,186 @@ class _$PostmanCollectionCopyWithImpl<$Res, $Val extends PostmanCollection>
   @override
   @pragma('vm:prefer-inline')
   $InfoCopyWith<$Res>? get info {
-    if (_value.info == null) {
+    if (_self.info == null) {
       return null;
     }
 
-    return $InfoCopyWith<$Res>(_value.info!, (value) {
-      return _then(_value.copyWith(info: value) as $Val);
+    return $InfoCopyWith<$Res>(_self.info!, (value) {
+      return _then(_self.copyWith(info: value));
     });
   }
 }
 
-/// @nodoc
-abstract class _$$PostmanCollectionImplCopyWith<$Res>
-    implements $PostmanCollectionCopyWith<$Res> {
-  factory _$$PostmanCollectionImplCopyWith(_$PostmanCollectionImpl value,
-          $Res Function(_$PostmanCollectionImpl) then) =
-      __$$PostmanCollectionImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({Info? info, List<Item>? item});
+/// Adds pattern-matching-related methods to [PostmanCollection].
+extension PostmanCollectionPatterns on PostmanCollection {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
 
-  @override
-  $InfoCopyWith<$Res>? get info;
-}
-
-/// @nodoc
-class __$$PostmanCollectionImplCopyWithImpl<$Res>
-    extends _$PostmanCollectionCopyWithImpl<$Res, _$PostmanCollectionImpl>
-    implements _$$PostmanCollectionImplCopyWith<$Res> {
-  __$$PostmanCollectionImplCopyWithImpl(_$PostmanCollectionImpl _value,
-      $Res Function(_$PostmanCollectionImpl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of PostmanCollection
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? info = freezed,
-    Object? item = freezed,
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_PostmanCollection value)? $default, {
+    required TResult orElse(),
   }) {
-    return _then(_$PostmanCollectionImpl(
-      info: freezed == info
-          ? _value.info
-          : info // ignore: cast_nullable_to_non_nullable
-              as Info?,
-      item: freezed == item
-          ? _value._item
-          : item // ignore: cast_nullable_to_non_nullable
-              as List<Item>?,
-    ));
+    final _that = this;
+    switch (_that) {
+      case _PostmanCollection() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_PostmanCollection value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _PostmanCollection():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_PostmanCollection value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _PostmanCollection() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(Info? info, List<Item>? item, List<Variable>? variable)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _PostmanCollection() when $default != null:
+        return $default(_that.info, _that.item, _that.variable);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(Info? info, List<Item>? item, List<Variable>? variable)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _PostmanCollection():
+        return $default(_that.info, _that.item, _that.variable);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(Info? info, List<Item>? item, List<Variable>? variable)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _PostmanCollection() when $default != null:
+        return $default(_that.info, _that.item, _that.variable);
+      case _:
+        return null;
+    }
   }
 }
 
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
-class _$PostmanCollectionImpl implements _PostmanCollection {
-  const _$PostmanCollectionImpl({this.info, final List<Item>? item})
-      : _item = item;
-
-  factory _$PostmanCollectionImpl.fromJson(Map<String, dynamic> json) =>
-      _$$PostmanCollectionImplFromJson(json);
+class _PostmanCollection implements PostmanCollection {
+  const _PostmanCollection(
+      {this.info, final List<Item>? item, final List<Variable>? variable})
+      : _item = item,
+        _variable = variable;
+  factory _PostmanCollection.fromJson(Map<String, dynamic> json) =>
+      _$PostmanCollectionFromJson(json);
 
   @override
   final Info? info;
@@ -154,223 +295,141 @@ class _$PostmanCollectionImpl implements _PostmanCollection {
     return EqualUnmodifiableListView(value);
   }
 
+  final List<Variable>? _variable;
   @override
-  String toString() {
-    return 'PostmanCollection(info: $info, item: $item)';
+  List<Variable>? get variable {
+    final value = _variable;
+    if (value == null) return null;
+    if (_variable is EqualUnmodifiableListView) return _variable;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  /// Create a copy of PostmanCollection
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$PostmanCollectionCopyWith<_PostmanCollection> get copyWith =>
+      __$PostmanCollectionCopyWithImpl<_PostmanCollection>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$PostmanCollectionToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PostmanCollectionImpl &&
+            other is _PostmanCollection &&
             (identical(other.info, info) || other.info == info) &&
-            const DeepCollectionEquality().equals(other._item, _item));
+            const DeepCollectionEquality().equals(other._item, _item) &&
+            const DeepCollectionEquality().equals(other._variable, _variable));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(
-      runtimeType, info, const DeepCollectionEquality().hash(_item));
-
-  /// Create a copy of PostmanCollection
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$PostmanCollectionImplCopyWith<_$PostmanCollectionImpl> get copyWith =>
-      __$$PostmanCollectionImplCopyWithImpl<_$PostmanCollectionImpl>(
-          this, _$identity);
+      runtimeType,
+      info,
+      const DeepCollectionEquality().hash(_item),
+      const DeepCollectionEquality().hash(_variable));
 
   @override
-  Map<String, dynamic> toJson() {
-    return _$$PostmanCollectionImplToJson(
-      this,
-    );
+  String toString() {
+    return 'PostmanCollection(info: $info, item: $item, variable: $variable)';
   }
 }
 
-abstract class _PostmanCollection implements PostmanCollection {
-  const factory _PostmanCollection({final Info? info, final List<Item>? item}) =
-      _$PostmanCollectionImpl;
-
-  factory _PostmanCollection.fromJson(Map<String, dynamic> json) =
-      _$PostmanCollectionImpl.fromJson;
+/// @nodoc
+abstract mixin class _$PostmanCollectionCopyWith<$Res>
+    implements $PostmanCollectionCopyWith<$Res> {
+  factory _$PostmanCollectionCopyWith(
+          _PostmanCollection value, $Res Function(_PostmanCollection) _then) =
+      __$PostmanCollectionCopyWithImpl;
+  @override
+  @useResult
+  $Res call({Info? info, List<Item>? item, List<Variable>? variable});
 
   @override
-  Info? get info;
-  @override
-  List<Item>? get item;
+  $InfoCopyWith<$Res>? get info;
+}
+
+/// @nodoc
+class __$PostmanCollectionCopyWithImpl<$Res>
+    implements _$PostmanCollectionCopyWith<$Res> {
+  __$PostmanCollectionCopyWithImpl(this._self, this._then);
+
+  final _PostmanCollection _self;
+  final $Res Function(_PostmanCollection) _then;
 
   /// Create a copy of PostmanCollection
   /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$PostmanCollectionImplCopyWith<_$PostmanCollectionImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? info = freezed,
+    Object? item = freezed,
+    Object? variable = freezed,
+  }) {
+    return _then(_PostmanCollection(
+      info: freezed == info
+          ? _self.info
+          : info // ignore: cast_nullable_to_non_nullable
+              as Info?,
+      item: freezed == item
+          ? _self._item
+          : item // ignore: cast_nullable_to_non_nullable
+              as List<Item>?,
+      variable: freezed == variable
+          ? _self._variable
+          : variable // ignore: cast_nullable_to_non_nullable
+              as List<Variable>?,
+    ));
+  }
 
-Info _$InfoFromJson(Map<String, dynamic> json) {
-  return _Info.fromJson(json);
+  /// Create a copy of PostmanCollection
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $InfoCopyWith<$Res>? get info {
+    if (_self.info == null) {
+      return null;
+    }
+
+    return $InfoCopyWith<$Res>(_self.info!, (value) {
+      return _then(_self.copyWith(info: value));
+    });
+  }
 }
 
 /// @nodoc
 mixin _$Info {
   @JsonKey(name: '_postman_id')
-  String? get postmanId => throw _privateConstructorUsedError;
-  String? get name => throw _privateConstructorUsedError;
-  String? get schema => throw _privateConstructorUsedError;
+  String? get postmanId;
+  String? get name;
+  String? get schema;
   @JsonKey(name: '_exporter_id')
-  String? get exporterId => throw _privateConstructorUsedError;
-
-  /// Serializes this Info to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  String? get exporterId;
 
   /// Create a copy of Info
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $InfoCopyWith<Info> get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $InfoCopyWith<$Res> {
-  factory $InfoCopyWith(Info value, $Res Function(Info) then) =
-      _$InfoCopyWithImpl<$Res, Info>;
-  @useResult
-  $Res call(
-      {@JsonKey(name: '_postman_id') String? postmanId,
-      String? name,
-      String? schema,
-      @JsonKey(name: '_exporter_id') String? exporterId});
-}
-
-/// @nodoc
-class _$InfoCopyWithImpl<$Res, $Val extends Info>
-    implements $InfoCopyWith<$Res> {
-  _$InfoCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of Info
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? postmanId = freezed,
-    Object? name = freezed,
-    Object? schema = freezed,
-    Object? exporterId = freezed,
-  }) {
-    return _then(_value.copyWith(
-      postmanId: freezed == postmanId
-          ? _value.postmanId
-          : postmanId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      name: freezed == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String?,
-      schema: freezed == schema
-          ? _value.schema
-          : schema // ignore: cast_nullable_to_non_nullable
-              as String?,
-      exporterId: freezed == exporterId
-          ? _value.exporterId
-          : exporterId // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ) as $Val);
-  }
-}
+  $InfoCopyWith<Info> get copyWith =>
+      _$InfoCopyWithImpl<Info>(this as Info, _$identity);
 
-/// @nodoc
-abstract class _$$InfoImplCopyWith<$Res> implements $InfoCopyWith<$Res> {
-  factory _$$InfoImplCopyWith(
-          _$InfoImpl value, $Res Function(_$InfoImpl) then) =
-      __$$InfoImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: '_postman_id') String? postmanId,
-      String? name,
-      String? schema,
-      @JsonKey(name: '_exporter_id') String? exporterId});
-}
-
-/// @nodoc
-class __$$InfoImplCopyWithImpl<$Res>
-    extends _$InfoCopyWithImpl<$Res, _$InfoImpl>
-    implements _$$InfoImplCopyWith<$Res> {
-  __$$InfoImplCopyWithImpl(_$InfoImpl _value, $Res Function(_$InfoImpl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of Info
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? postmanId = freezed,
-    Object? name = freezed,
-    Object? schema = freezed,
-    Object? exporterId = freezed,
-  }) {
-    return _then(_$InfoImpl(
-      postmanId: freezed == postmanId
-          ? _value.postmanId
-          : postmanId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      name: freezed == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String?,
-      schema: freezed == schema
-          ? _value.schema
-          : schema // ignore: cast_nullable_to_non_nullable
-              as String?,
-      exporterId: freezed == exporterId
-          ? _value.exporterId
-          : exporterId // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
-}
-
-/// @nodoc
-
-@JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
-class _$InfoImpl implements _Info {
-  const _$InfoImpl(
-      {@JsonKey(name: '_postman_id') this.postmanId,
-      this.name,
-      this.schema,
-      @JsonKey(name: '_exporter_id') this.exporterId});
-
-  factory _$InfoImpl.fromJson(Map<String, dynamic> json) =>
-      _$$InfoImplFromJson(json);
-
-  @override
-  @JsonKey(name: '_postman_id')
-  final String? postmanId;
-  @override
-  final String? name;
-  @override
-  final String? schema;
-  @override
-  @JsonKey(name: '_exporter_id')
-  final String? exporterId;
-
-  @override
-  String toString() {
-    return 'Info(postmanId: $postmanId, name: $name, schema: $schema, exporterId: $exporterId)';
-  }
+  /// Serializes this Info to a JSON map.
+  Map<String, dynamic> toJson();
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$InfoImpl &&
+            other is Info &&
             (identical(other.postmanId, postmanId) ||
                 other.postmanId == postmanId) &&
             (identical(other.name, name) || other.name == name) &&
@@ -384,74 +443,396 @@ class _$InfoImpl implements _Info {
   int get hashCode =>
       Object.hash(runtimeType, postmanId, name, schema, exporterId);
 
-  /// Create a copy of Info
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$InfoImplCopyWith<_$InfoImpl> get copyWith =>
-      __$$InfoImplCopyWithImpl<_$InfoImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$InfoImplToJson(
-      this,
-    );
+  String toString() {
+    return 'Info(postmanId: $postmanId, name: $name, schema: $schema, exporterId: $exporterId)';
   }
 }
 
-abstract class _Info implements Info {
-  const factory _Info(
-      {@JsonKey(name: '_postman_id') final String? postmanId,
-      final String? name,
-      final String? schema,
-      @JsonKey(name: '_exporter_id') final String? exporterId}) = _$InfoImpl;
+/// @nodoc
+abstract mixin class $InfoCopyWith<$Res> {
+  factory $InfoCopyWith(Info value, $Res Function(Info) _then) =
+      _$InfoCopyWithImpl;
+  @useResult
+  $Res call(
+      {@JsonKey(name: '_postman_id') String? postmanId,
+      String? name,
+      String? schema,
+      @JsonKey(name: '_exporter_id') String? exporterId});
+}
 
-  factory _Info.fromJson(Map<String, dynamic> json) = _$InfoImpl.fromJson;
+/// @nodoc
+class _$InfoCopyWithImpl<$Res> implements $InfoCopyWith<$Res> {
+  _$InfoCopyWithImpl(this._self, this._then);
+
+  final Info _self;
+  final $Res Function(Info) _then;
+
+  /// Create a copy of Info
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? postmanId = freezed,
+    Object? name = freezed,
+    Object? schema = freezed,
+    Object? exporterId = freezed,
+  }) {
+    return _then(_self.copyWith(
+      postmanId: freezed == postmanId
+          ? _self.postmanId
+          : postmanId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      name: freezed == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String?,
+      schema: freezed == schema
+          ? _self.schema
+          : schema // ignore: cast_nullable_to_non_nullable
+              as String?,
+      exporterId: freezed == exporterId
+          ? _self.exporterId
+          : exporterId // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Info].
+extension InfoPatterns on Info {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Info value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Info() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Info value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Info():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Info value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Info() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            @JsonKey(name: '_postman_id') String? postmanId,
+            String? name,
+            String? schema,
+            @JsonKey(name: '_exporter_id') String? exporterId)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Info() when $default != null:
+        return $default(
+            _that.postmanId, _that.name, _that.schema, _that.exporterId);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            @JsonKey(name: '_postman_id') String? postmanId,
+            String? name,
+            String? schema,
+            @JsonKey(name: '_exporter_id') String? exporterId)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Info():
+        return $default(
+            _that.postmanId, _that.name, _that.schema, _that.exporterId);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            @JsonKey(name: '_postman_id') String? postmanId,
+            String? name,
+            String? schema,
+            @JsonKey(name: '_exporter_id') String? exporterId)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Info() when $default != null:
+        return $default(
+            _that.postmanId, _that.name, _that.schema, _that.exporterId);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+@JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
+class _Info implements Info {
+  const _Info(
+      {@JsonKey(name: '_postman_id') this.postmanId,
+      this.name,
+      this.schema,
+      @JsonKey(name: '_exporter_id') this.exporterId});
+  factory _Info.fromJson(Map<String, dynamic> json) => _$InfoFromJson(json);
 
   @override
   @JsonKey(name: '_postman_id')
-  String? get postmanId;
+  final String? postmanId;
   @override
-  String? get name;
+  final String? name;
   @override
-  String? get schema;
+  final String? schema;
   @override
   @JsonKey(name: '_exporter_id')
-  String? get exporterId;
+  final String? exporterId;
 
   /// Create a copy of Info
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$InfoImplCopyWith<_$InfoImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  _$InfoCopyWith<_Info> get copyWith =>
+      __$InfoCopyWithImpl<_Info>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$InfoToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Info &&
+            (identical(other.postmanId, postmanId) ||
+                other.postmanId == postmanId) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.schema, schema) || other.schema == schema) &&
+            (identical(other.exporterId, exporterId) ||
+                other.exporterId == exporterId));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, postmanId, name, schema, exporterId);
+
+  @override
+  String toString() {
+    return 'Info(postmanId: $postmanId, name: $name, schema: $schema, exporterId: $exporterId)';
+  }
 }
 
-Item _$ItemFromJson(Map<String, dynamic> json) {
-  return _Item.fromJson(json);
+/// @nodoc
+abstract mixin class _$InfoCopyWith<$Res> implements $InfoCopyWith<$Res> {
+  factory _$InfoCopyWith(_Info value, $Res Function(_Info) _then) =
+      __$InfoCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: '_postman_id') String? postmanId,
+      String? name,
+      String? schema,
+      @JsonKey(name: '_exporter_id') String? exporterId});
+}
+
+/// @nodoc
+class __$InfoCopyWithImpl<$Res> implements _$InfoCopyWith<$Res> {
+  __$InfoCopyWithImpl(this._self, this._then);
+
+  final _Info _self;
+  final $Res Function(_Info) _then;
+
+  /// Create a copy of Info
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? postmanId = freezed,
+    Object? name = freezed,
+    Object? schema = freezed,
+    Object? exporterId = freezed,
+  }) {
+    return _then(_Info(
+      postmanId: freezed == postmanId
+          ? _self.postmanId
+          : postmanId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      name: freezed == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String?,
+      schema: freezed == schema
+          ? _self.schema
+          : schema // ignore: cast_nullable_to_non_nullable
+              as String?,
+      exporterId: freezed == exporterId
+          ? _self.exporterId
+          : exporterId // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
 }
 
 /// @nodoc
 mixin _$Item {
-  String? get name => throw _privateConstructorUsedError;
-  List<Item>? get item => throw _privateConstructorUsedError;
-  Request? get request => throw _privateConstructorUsedError;
-  List<dynamic>? get response => throw _privateConstructorUsedError;
-
-  /// Serializes this Item to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  String? get name;
+  List<Item>? get item;
+  Request? get request;
+  List<dynamic>? get response;
 
   /// Create a copy of Item
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $ItemCopyWith<Item> get copyWith => throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $ItemCopyWith<Item> get copyWith =>
+      _$ItemCopyWithImpl<Item>(this as Item, _$identity);
+
+  /// Serializes this Item to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Item &&
+            (identical(other.name, name) || other.name == name) &&
+            const DeepCollectionEquality().equals(other.item, item) &&
+            (identical(other.request, request) || other.request == request) &&
+            const DeepCollectionEquality().equals(other.response, response));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      name,
+      const DeepCollectionEquality().hash(item),
+      request,
+      const DeepCollectionEquality().hash(response));
+
+  @override
+  String toString() {
+    return 'Item(name: $name, item: $item, request: $request, response: $response)';
+  }
 }
 
 /// @nodoc
-abstract class $ItemCopyWith<$Res> {
-  factory $ItemCopyWith(Item value, $Res Function(Item) then) =
-      _$ItemCopyWithImpl<$Res, Item>;
+abstract mixin class $ItemCopyWith<$Res> {
+  factory $ItemCopyWith(Item value, $Res Function(Item) _then) =
+      _$ItemCopyWithImpl;
   @useResult
   $Res call(
       {String? name,
@@ -463,14 +844,11 @@ abstract class $ItemCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$ItemCopyWithImpl<$Res, $Val extends Item>
-    implements $ItemCopyWith<$Res> {
-  _$ItemCopyWithImpl(this._value, this._then);
+class _$ItemCopyWithImpl<$Res> implements $ItemCopyWith<$Res> {
+  _$ItemCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final Item _self;
+  final $Res Function(Item) _then;
 
   /// Create a copy of Item
   /// with the given fields replaced by the non-null parameter values.
@@ -482,24 +860,24 @@ class _$ItemCopyWithImpl<$Res, $Val extends Item>
     Object? request = freezed,
     Object? response = freezed,
   }) {
-    return _then(_value.copyWith(
+    return _then(_self.copyWith(
       name: freezed == name
-          ? _value.name
+          ? _self.name
           : name // ignore: cast_nullable_to_non_nullable
               as String?,
       item: freezed == item
-          ? _value.item
+          ? _self.item
           : item // ignore: cast_nullable_to_non_nullable
               as List<Item>?,
       request: freezed == request
-          ? _value.request
+          ? _self.request
           : request // ignore: cast_nullable_to_non_nullable
               as Request?,
       response: freezed == response
-          ? _value.response
+          ? _self.response
           : response // ignore: cast_nullable_to_non_nullable
               as List<dynamic>?,
-    ) as $Val);
+    ));
   }
 
   /// Create a copy of Item
@@ -507,85 +885,191 @@ class _$ItemCopyWithImpl<$Res, $Val extends Item>
   @override
   @pragma('vm:prefer-inline')
   $RequestCopyWith<$Res>? get request {
-    if (_value.request == null) {
+    if (_self.request == null) {
       return null;
     }
 
-    return $RequestCopyWith<$Res>(_value.request!, (value) {
-      return _then(_value.copyWith(request: value) as $Val);
+    return $RequestCopyWith<$Res>(_self.request!, (value) {
+      return _then(_self.copyWith(request: value));
     });
   }
 }
 
-/// @nodoc
-abstract class _$$ItemImplCopyWith<$Res> implements $ItemCopyWith<$Res> {
-  factory _$$ItemImplCopyWith(
-          _$ItemImpl value, $Res Function(_$ItemImpl) then) =
-      __$$ItemImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {String? name,
-      List<Item>? item,
-      Request? request,
-      List<dynamic>? response});
+/// Adds pattern-matching-related methods to [Item].
+extension ItemPatterns on Item {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
 
-  @override
-  $RequestCopyWith<$Res>? get request;
-}
-
-/// @nodoc
-class __$$ItemImplCopyWithImpl<$Res>
-    extends _$ItemCopyWithImpl<$Res, _$ItemImpl>
-    implements _$$ItemImplCopyWith<$Res> {
-  __$$ItemImplCopyWithImpl(_$ItemImpl _value, $Res Function(_$ItemImpl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of Item
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? name = freezed,
-    Object? item = freezed,
-    Object? request = freezed,
-    Object? response = freezed,
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Item value)? $default, {
+    required TResult orElse(),
   }) {
-    return _then(_$ItemImpl(
-      name: freezed == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String?,
-      item: freezed == item
-          ? _value._item
-          : item // ignore: cast_nullable_to_non_nullable
-              as List<Item>?,
-      request: freezed == request
-          ? _value.request
-          : request // ignore: cast_nullable_to_non_nullable
-              as Request?,
-      response: freezed == response
-          ? _value._response
-          : response // ignore: cast_nullable_to_non_nullable
-              as List<dynamic>?,
-    ));
+    final _that = this;
+    switch (_that) {
+      case _Item() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Item value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Item():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Item value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Item() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String? name, List<Item>? item, Request? request,
+            List<dynamic>? response)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Item() when $default != null:
+        return $default(_that.name, _that.item, _that.request, _that.response);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String? name, List<Item>? item, Request? request,
+            List<dynamic>? response)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Item():
+        return $default(_that.name, _that.item, _that.request, _that.response);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String? name, List<Item>? item, Request? request,
+            List<dynamic>? response)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Item() when $default != null:
+        return $default(_that.name, _that.item, _that.request, _that.response);
+      case _:
+        return null;
+    }
   }
 }
 
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
-class _$ItemImpl implements _Item {
-  const _$ItemImpl(
+class _Item implements Item {
+  const _Item(
       {this.name,
       final List<Item>? item,
       this.request,
       final List<dynamic>? response})
       : _item = item,
         _response = response;
-
-  factory _$ItemImpl.fromJson(Map<String, dynamic> json) =>
-      _$$ItemImplFromJson(json);
+  factory _Item.fromJson(Map<String, dynamic> json) => _$ItemFromJson(json);
 
   @override
   final String? name;
@@ -611,16 +1095,26 @@ class _$ItemImpl implements _Item {
     return EqualUnmodifiableListView(value);
   }
 
+  /// Create a copy of Item
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'Item(name: $name, item: $item, request: $request, response: $response)';
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ItemCopyWith<_Item> get copyWith =>
+      __$ItemCopyWithImpl<_Item>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ItemToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ItemImpl &&
+            other is _Item &&
             (identical(other.name, name) || other.name == name) &&
             const DeepCollectionEquality().equals(other._item, _item) &&
             (identical(other.request, request) || other.request == request) &&
@@ -636,88 +1130,144 @@ class _$ItemImpl implements _Item {
       request,
       const DeepCollectionEquality().hash(_response));
 
-  /// Create a copy of Item
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$ItemImplCopyWith<_$ItemImpl> get copyWith =>
-      __$$ItemImplCopyWithImpl<_$ItemImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$ItemImplToJson(
-      this,
-    );
+  String toString() {
+    return 'Item(name: $name, item: $item, request: $request, response: $response)';
   }
 }
 
-abstract class _Item implements Item {
-  const factory _Item(
-      {final String? name,
-      final List<Item>? item,
-      final Request? request,
-      final List<dynamic>? response}) = _$ItemImpl;
+/// @nodoc
+abstract mixin class _$ItemCopyWith<$Res> implements $ItemCopyWith<$Res> {
+  factory _$ItemCopyWith(_Item value, $Res Function(_Item) _then) =
+      __$ItemCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String? name,
+      List<Item>? item,
+      Request? request,
+      List<dynamic>? response});
 
-  factory _Item.fromJson(Map<String, dynamic> json) = _$ItemImpl.fromJson;
+  @override
+  $RequestCopyWith<$Res>? get request;
+}
 
-  @override
-  String? get name;
-  @override
-  List<Item>? get item;
-  @override
-  Request? get request;
-  @override
-  List<dynamic>? get response;
+/// @nodoc
+class __$ItemCopyWithImpl<$Res> implements _$ItemCopyWith<$Res> {
+  __$ItemCopyWithImpl(this._self, this._then);
+
+  final _Item _self;
+  final $Res Function(_Item) _then;
 
   /// Create a copy of Item
   /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$ItemImplCopyWith<_$ItemImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? name = freezed,
+    Object? item = freezed,
+    Object? request = freezed,
+    Object? response = freezed,
+  }) {
+    return _then(_Item(
+      name: freezed == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String?,
+      item: freezed == item
+          ? _self._item
+          : item // ignore: cast_nullable_to_non_nullable
+              as List<Item>?,
+      request: freezed == request
+          ? _self.request
+          : request // ignore: cast_nullable_to_non_nullable
+              as Request?,
+      response: freezed == response
+          ? _self._response
+          : response // ignore: cast_nullable_to_non_nullable
+              as List<dynamic>?,
+    ));
+  }
 
-Request _$RequestFromJson(Map<String, dynamic> json) {
-  return _Request.fromJson(json);
+  /// Create a copy of Item
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $RequestCopyWith<$Res>? get request {
+    if (_self.request == null) {
+      return null;
+    }
+
+    return $RequestCopyWith<$Res>(_self.request!, (value) {
+      return _then(_self.copyWith(request: value));
+    });
+  }
 }
 
 /// @nodoc
 mixin _$Request {
-  String? get method => throw _privateConstructorUsedError;
-  List<Header>? get header => throw _privateConstructorUsedError;
-  Body? get body => throw _privateConstructorUsedError;
-  Url? get url => throw _privateConstructorUsedError;
-
-  /// Serializes this Request to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  String? get method;
+  List<Header>? get header;
+  Body? get body;
+  Url? get url;
+  PostmanAuth? get auth;
 
   /// Create a copy of Request
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $RequestCopyWith<Request> get copyWith => throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $RequestCopyWith<Request> get copyWith =>
+      _$RequestCopyWithImpl<Request>(this as Request, _$identity);
+
+  /// Serializes this Request to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Request &&
+            (identical(other.method, method) || other.method == method) &&
+            const DeepCollectionEquality().equals(other.header, header) &&
+            (identical(other.body, body) || other.body == body) &&
+            (identical(other.url, url) || other.url == url) &&
+            (identical(other.auth, auth) || other.auth == auth));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, method,
+      const DeepCollectionEquality().hash(header), body, url, auth);
+
+  @override
+  String toString() {
+    return 'Request(method: $method, header: $header, body: $body, url: $url, auth: $auth)';
+  }
 }
 
 /// @nodoc
-abstract class $RequestCopyWith<$Res> {
-  factory $RequestCopyWith(Request value, $Res Function(Request) then) =
-      _$RequestCopyWithImpl<$Res, Request>;
+abstract mixin class $RequestCopyWith<$Res> {
+  factory $RequestCopyWith(Request value, $Res Function(Request) _then) =
+      _$RequestCopyWithImpl;
   @useResult
-  $Res call({String? method, List<Header>? header, Body? body, Url? url});
+  $Res call(
+      {String? method,
+      List<Header>? header,
+      Body? body,
+      Url? url,
+      PostmanAuth? auth});
 
   $BodyCopyWith<$Res>? get body;
   $UrlCopyWith<$Res>? get url;
+  $PostmanAuthCopyWith<$Res>? get auth;
 }
 
 /// @nodoc
-class _$RequestCopyWithImpl<$Res, $Val extends Request>
-    implements $RequestCopyWith<$Res> {
-  _$RequestCopyWithImpl(this._value, this._then);
+class _$RequestCopyWithImpl<$Res> implements $RequestCopyWith<$Res> {
+  _$RequestCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final Request _self;
+  final $Res Function(Request) _then;
 
   /// Create a copy of Request
   /// with the given fields replaced by the non-null parameter values.
@@ -728,25 +1278,30 @@ class _$RequestCopyWithImpl<$Res, $Val extends Request>
     Object? header = freezed,
     Object? body = freezed,
     Object? url = freezed,
+    Object? auth = freezed,
   }) {
-    return _then(_value.copyWith(
+    return _then(_self.copyWith(
       method: freezed == method
-          ? _value.method
+          ? _self.method
           : method // ignore: cast_nullable_to_non_nullable
               as String?,
       header: freezed == header
-          ? _value.header
+          ? _self.header
           : header // ignore: cast_nullable_to_non_nullable
               as List<Header>?,
       body: freezed == body
-          ? _value.body
+          ? _self.body
           : body // ignore: cast_nullable_to_non_nullable
               as Body?,
       url: freezed == url
-          ? _value.url
+          ? _self.url
           : url // ignore: cast_nullable_to_non_nullable
               as Url?,
-    ) as $Val);
+      auth: freezed == auth
+          ? _self.auth
+          : auth // ignore: cast_nullable_to_non_nullable
+              as PostmanAuth?,
+    ));
   }
 
   /// Create a copy of Request
@@ -754,12 +1309,12 @@ class _$RequestCopyWithImpl<$Res, $Val extends Request>
   @override
   @pragma('vm:prefer-inline')
   $BodyCopyWith<$Res>? get body {
-    if (_value.body == null) {
+    if (_self.body == null) {
       return null;
     }
 
-    return $BodyCopyWith<$Res>(_value.body!, (value) {
-      return _then(_value.copyWith(body: value) as $Val);
+    return $BodyCopyWith<$Res>(_self.body!, (value) {
+      return _then(_self.copyWith(body: value));
     });
   }
 
@@ -768,80 +1323,205 @@ class _$RequestCopyWithImpl<$Res, $Val extends Request>
   @override
   @pragma('vm:prefer-inline')
   $UrlCopyWith<$Res>? get url {
-    if (_value.url == null) {
+    if (_self.url == null) {
       return null;
     }
 
-    return $UrlCopyWith<$Res>(_value.url!, (value) {
-      return _then(_value.copyWith(url: value) as $Val);
+    return $UrlCopyWith<$Res>(_self.url!, (value) {
+      return _then(_self.copyWith(url: value));
+    });
+  }
+
+  /// Create a copy of Request
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $PostmanAuthCopyWith<$Res>? get auth {
+    if (_self.auth == null) {
+      return null;
+    }
+
+    return $PostmanAuthCopyWith<$Res>(_self.auth!, (value) {
+      return _then(_self.copyWith(auth: value));
     });
   }
 }
 
-/// @nodoc
-abstract class _$$RequestImplCopyWith<$Res> implements $RequestCopyWith<$Res> {
-  factory _$$RequestImplCopyWith(
-          _$RequestImpl value, $Res Function(_$RequestImpl) then) =
-      __$$RequestImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String? method, List<Header>? header, Body? body, Url? url});
+/// Adds pattern-matching-related methods to [Request].
+extension RequestPatterns on Request {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
 
-  @override
-  $BodyCopyWith<$Res>? get body;
-  @override
-  $UrlCopyWith<$Res>? get url;
-}
-
-/// @nodoc
-class __$$RequestImplCopyWithImpl<$Res>
-    extends _$RequestCopyWithImpl<$Res, _$RequestImpl>
-    implements _$$RequestImplCopyWith<$Res> {
-  __$$RequestImplCopyWithImpl(
-      _$RequestImpl _value, $Res Function(_$RequestImpl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of Request
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? method = freezed,
-    Object? header = freezed,
-    Object? body = freezed,
-    Object? url = freezed,
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Request value)? $default, {
+    required TResult orElse(),
   }) {
-    return _then(_$RequestImpl(
-      method: freezed == method
-          ? _value.method
-          : method // ignore: cast_nullable_to_non_nullable
-              as String?,
-      header: freezed == header
-          ? _value._header
-          : header // ignore: cast_nullable_to_non_nullable
-              as List<Header>?,
-      body: freezed == body
-          ? _value.body
-          : body // ignore: cast_nullable_to_non_nullable
-              as Body?,
-      url: freezed == url
-          ? _value.url
-          : url // ignore: cast_nullable_to_non_nullable
-              as Url?,
-    ));
+    final _that = this;
+    switch (_that) {
+      case _Request() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Request value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Request():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Request value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Request() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String? method, List<Header>? header, Body? body, Url? url,
+            PostmanAuth? auth)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Request() when $default != null:
+        return $default(
+            _that.method, _that.header, _that.body, _that.url, _that.auth);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String? method, List<Header>? header, Body? body, Url? url,
+            PostmanAuth? auth)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Request():
+        return $default(
+            _that.method, _that.header, _that.body, _that.url, _that.auth);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String? method, List<Header>? header, Body? body,
+            Url? url, PostmanAuth? auth)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Request() when $default != null:
+        return $default(
+            _that.method, _that.header, _that.body, _that.url, _that.auth);
+      case _:
+        return null;
+    }
   }
 }
 
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
-class _$RequestImpl implements _Request {
-  const _$RequestImpl(
-      {this.method, final List<Header>? header, this.body, this.url})
+class _Request implements Request {
+  const _Request(
+      {this.method, final List<Header>? header, this.body, this.url, this.auth})
       : _header = header;
-
-  factory _$RequestImpl.fromJson(Map<String, dynamic> json) =>
-      _$$RequestImplFromJson(json);
+  factory _Request.fromJson(Map<String, dynamic> json) =>
+      _$RequestFromJson(json);
 
   @override
   final String? method;
@@ -859,216 +1539,175 @@ class _$RequestImpl implements _Request {
   final Body? body;
   @override
   final Url? url;
+  @override
+  final PostmanAuth? auth;
+
+  /// Create a copy of Request
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$RequestCopyWith<_Request> get copyWith =>
+      __$RequestCopyWithImpl<_Request>(this, _$identity);
 
   @override
-  String toString() {
-    return 'Request(method: $method, header: $header, body: $body, url: $url)';
+  Map<String, dynamic> toJson() {
+    return _$RequestToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$RequestImpl &&
+            other is _Request &&
             (identical(other.method, method) || other.method == method) &&
             const DeepCollectionEquality().equals(other._header, _header) &&
             (identical(other.body, body) || other.body == body) &&
-            (identical(other.url, url) || other.url == url));
+            (identical(other.url, url) || other.url == url) &&
+            (identical(other.auth, auth) || other.auth == auth));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, method,
-      const DeepCollectionEquality().hash(_header), body, url);
-
-  /// Create a copy of Request
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$RequestImplCopyWith<_$RequestImpl> get copyWith =>
-      __$$RequestImplCopyWithImpl<_$RequestImpl>(this, _$identity);
+      const DeepCollectionEquality().hash(_header), body, url, auth);
 
   @override
-  Map<String, dynamic> toJson() {
-    return _$$RequestImplToJson(
-      this,
-    );
+  String toString() {
+    return 'Request(method: $method, header: $header, body: $body, url: $url, auth: $auth)';
   }
 }
 
-abstract class _Request implements Request {
-  const factory _Request(
-      {final String? method,
-      final List<Header>? header,
-      final Body? body,
-      final Url? url}) = _$RequestImpl;
+/// @nodoc
+abstract mixin class _$RequestCopyWith<$Res> implements $RequestCopyWith<$Res> {
+  factory _$RequestCopyWith(_Request value, $Res Function(_Request) _then) =
+      __$RequestCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String? method,
+      List<Header>? header,
+      Body? body,
+      Url? url,
+      PostmanAuth? auth});
 
-  factory _Request.fromJson(Map<String, dynamic> json) = _$RequestImpl.fromJson;
+  @override
+  $BodyCopyWith<$Res>? get body;
+  @override
+  $UrlCopyWith<$Res>? get url;
+  @override
+  $PostmanAuthCopyWith<$Res>? get auth;
+}
 
-  @override
-  String? get method;
-  @override
-  List<Header>? get header;
-  @override
-  Body? get body;
-  @override
-  Url? get url;
+/// @nodoc
+class __$RequestCopyWithImpl<$Res> implements _$RequestCopyWith<$Res> {
+  __$RequestCopyWithImpl(this._self, this._then);
+
+  final _Request _self;
+  final $Res Function(_Request) _then;
 
   /// Create a copy of Request
   /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$RequestImplCopyWith<_$RequestImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? method = freezed,
+    Object? header = freezed,
+    Object? body = freezed,
+    Object? url = freezed,
+    Object? auth = freezed,
+  }) {
+    return _then(_Request(
+      method: freezed == method
+          ? _self.method
+          : method // ignore: cast_nullable_to_non_nullable
+              as String?,
+      header: freezed == header
+          ? _self._header
+          : header // ignore: cast_nullable_to_non_nullable
+              as List<Header>?,
+      body: freezed == body
+          ? _self.body
+          : body // ignore: cast_nullable_to_non_nullable
+              as Body?,
+      url: freezed == url
+          ? _self.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as Url?,
+      auth: freezed == auth
+          ? _self.auth
+          : auth // ignore: cast_nullable_to_non_nullable
+              as PostmanAuth?,
+    ));
+  }
 
-Header _$HeaderFromJson(Map<String, dynamic> json) {
-  return _Header.fromJson(json);
+  /// Create a copy of Request
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $BodyCopyWith<$Res>? get body {
+    if (_self.body == null) {
+      return null;
+    }
+
+    return $BodyCopyWith<$Res>(_self.body!, (value) {
+      return _then(_self.copyWith(body: value));
+    });
+  }
+
+  /// Create a copy of Request
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $UrlCopyWith<$Res>? get url {
+    if (_self.url == null) {
+      return null;
+    }
+
+    return $UrlCopyWith<$Res>(_self.url!, (value) {
+      return _then(_self.copyWith(url: value));
+    });
+  }
+
+  /// Create a copy of Request
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $PostmanAuthCopyWith<$Res>? get auth {
+    if (_self.auth == null) {
+      return null;
+    }
+
+    return $PostmanAuthCopyWith<$Res>(_self.auth!, (value) {
+      return _then(_self.copyWith(auth: value));
+    });
+  }
 }
 
 /// @nodoc
 mixin _$Header {
-  String? get key => throw _privateConstructorUsedError;
-  String? get value => throw _privateConstructorUsedError;
-  String? get type => throw _privateConstructorUsedError;
-  bool? get disabled => throw _privateConstructorUsedError;
-
-  /// Serializes this Header to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  String? get key;
+  String? get value;
+  String? get type;
+  bool? get disabled;
 
   /// Create a copy of Header
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $HeaderCopyWith<Header> get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $HeaderCopyWith<$Res> {
-  factory $HeaderCopyWith(Header value, $Res Function(Header) then) =
-      _$HeaderCopyWithImpl<$Res, Header>;
-  @useResult
-  $Res call({String? key, String? value, String? type, bool? disabled});
-}
-
-/// @nodoc
-class _$HeaderCopyWithImpl<$Res, $Val extends Header>
-    implements $HeaderCopyWith<$Res> {
-  _$HeaderCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of Header
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? key = freezed,
-    Object? value = freezed,
-    Object? type = freezed,
-    Object? disabled = freezed,
-  }) {
-    return _then(_value.copyWith(
-      key: freezed == key
-          ? _value.key
-          : key // ignore: cast_nullable_to_non_nullable
-              as String?,
-      value: freezed == value
-          ? _value.value
-          : value // ignore: cast_nullable_to_non_nullable
-              as String?,
-      type: freezed == type
-          ? _value.type
-          : type // ignore: cast_nullable_to_non_nullable
-              as String?,
-      disabled: freezed == disabled
-          ? _value.disabled
-          : disabled // ignore: cast_nullable_to_non_nullable
-              as bool?,
-    ) as $Val);
-  }
-}
+  $HeaderCopyWith<Header> get copyWith =>
+      _$HeaderCopyWithImpl<Header>(this as Header, _$identity);
 
-/// @nodoc
-abstract class _$$HeaderImplCopyWith<$Res> implements $HeaderCopyWith<$Res> {
-  factory _$$HeaderImplCopyWith(
-          _$HeaderImpl value, $Res Function(_$HeaderImpl) then) =
-      __$$HeaderImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String? key, String? value, String? type, bool? disabled});
-}
-
-/// @nodoc
-class __$$HeaderImplCopyWithImpl<$Res>
-    extends _$HeaderCopyWithImpl<$Res, _$HeaderImpl>
-    implements _$$HeaderImplCopyWith<$Res> {
-  __$$HeaderImplCopyWithImpl(
-      _$HeaderImpl _value, $Res Function(_$HeaderImpl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of Header
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? key = freezed,
-    Object? value = freezed,
-    Object? type = freezed,
-    Object? disabled = freezed,
-  }) {
-    return _then(_$HeaderImpl(
-      key: freezed == key
-          ? _value.key
-          : key // ignore: cast_nullable_to_non_nullable
-              as String?,
-      value: freezed == value
-          ? _value.value
-          : value // ignore: cast_nullable_to_non_nullable
-              as String?,
-      type: freezed == type
-          ? _value.type
-          : type // ignore: cast_nullable_to_non_nullable
-              as String?,
-      disabled: freezed == disabled
-          ? _value.disabled
-          : disabled // ignore: cast_nullable_to_non_nullable
-              as bool?,
-    ));
-  }
-}
-
-/// @nodoc
-
-@JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
-class _$HeaderImpl implements _Header {
-  const _$HeaderImpl({this.key, this.value, this.type, this.disabled});
-
-  factory _$HeaderImpl.fromJson(Map<String, dynamic> json) =>
-      _$$HeaderImplFromJson(json);
-
-  @override
-  final String? key;
-  @override
-  final String? value;
-  @override
-  final String? type;
-  @override
-  final bool? disabled;
-
-  @override
-  String toString() {
-    return 'Header(key: $key, value: $value, type: $type, disabled: $disabled)';
-  }
+  /// Serializes this Header to a JSON map.
+  Map<String, dynamic> toJson();
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$HeaderImpl &&
+            other is Header &&
             (identical(other.key, key) || other.key == key) &&
             (identical(other.value, value) || other.value == value) &&
             (identical(other.type, type) || other.type == type) &&
@@ -1080,188 +1719,591 @@ class _$HeaderImpl implements _Header {
   @override
   int get hashCode => Object.hash(runtimeType, key, value, type, disabled);
 
-  /// Create a copy of Header
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$HeaderImplCopyWith<_$HeaderImpl> get copyWith =>
-      __$$HeaderImplCopyWithImpl<_$HeaderImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$HeaderImplToJson(
-      this,
-    );
-  }
-}
-
-abstract class _Header implements Header {
-  const factory _Header(
-      {final String? key,
-      final String? value,
-      final String? type,
-      final bool? disabled}) = _$HeaderImpl;
-
-  factory _Header.fromJson(Map<String, dynamic> json) = _$HeaderImpl.fromJson;
-
-  @override
-  String? get key;
-  @override
-  String? get value;
-  @override
-  String? get type;
-  @override
-  bool? get disabled;
-
-  /// Create a copy of Header
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$HeaderImplCopyWith<_$HeaderImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-Url _$UrlFromJson(Map<String, dynamic> json) {
-  return _Url.fromJson(json);
-}
-
-/// @nodoc
-mixin _$Url {
-  String? get raw => throw _privateConstructorUsedError;
-  String? get protocol => throw _privateConstructorUsedError;
-  List<String>? get host => throw _privateConstructorUsedError;
-  List<String>? get path => throw _privateConstructorUsedError;
-  List<Query>? get query => throw _privateConstructorUsedError;
-
-  /// Serializes this Url to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of Url
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $UrlCopyWith<Url> get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $UrlCopyWith<$Res> {
-  factory $UrlCopyWith(Url value, $Res Function(Url) then) =
-      _$UrlCopyWithImpl<$Res, Url>;
-  @useResult
-  $Res call(
-      {String? raw,
-      String? protocol,
-      List<String>? host,
-      List<String>? path,
-      List<Query>? query});
-}
-
-/// @nodoc
-class _$UrlCopyWithImpl<$Res, $Val extends Url> implements $UrlCopyWith<$Res> {
-  _$UrlCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of Url
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? raw = freezed,
-    Object? protocol = freezed,
-    Object? host = freezed,
-    Object? path = freezed,
-    Object? query = freezed,
-  }) {
-    return _then(_value.copyWith(
-      raw: freezed == raw
-          ? _value.raw
-          : raw // ignore: cast_nullable_to_non_nullable
-              as String?,
-      protocol: freezed == protocol
-          ? _value.protocol
-          : protocol // ignore: cast_nullable_to_non_nullable
-              as String?,
-      host: freezed == host
-          ? _value.host
-          : host // ignore: cast_nullable_to_non_nullable
-              as List<String>?,
-      path: freezed == path
-          ? _value.path
-          : path // ignore: cast_nullable_to_non_nullable
-              as List<String>?,
-      query: freezed == query
-          ? _value.query
-          : query // ignore: cast_nullable_to_non_nullable
-              as List<Query>?,
-    ) as $Val);
+  String toString() {
+    return 'Header(key: $key, value: $value, type: $type, disabled: $disabled)';
   }
 }
 
 /// @nodoc
-abstract class _$$UrlImplCopyWith<$Res> implements $UrlCopyWith<$Res> {
-  factory _$$UrlImplCopyWith(_$UrlImpl value, $Res Function(_$UrlImpl) then) =
-      __$$UrlImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $HeaderCopyWith<$Res> {
+  factory $HeaderCopyWith(Header value, $Res Function(Header) _then) =
+      _$HeaderCopyWithImpl;
   @useResult
-  $Res call(
-      {String? raw,
-      String? protocol,
-      List<String>? host,
-      List<String>? path,
-      List<Query>? query});
+  $Res call({String? key, String? value, String? type, bool? disabled});
 }
 
 /// @nodoc
-class __$$UrlImplCopyWithImpl<$Res> extends _$UrlCopyWithImpl<$Res, _$UrlImpl>
-    implements _$$UrlImplCopyWith<$Res> {
-  __$$UrlImplCopyWithImpl(_$UrlImpl _value, $Res Function(_$UrlImpl) _then)
-      : super(_value, _then);
+class _$HeaderCopyWithImpl<$Res> implements $HeaderCopyWith<$Res> {
+  _$HeaderCopyWithImpl(this._self, this._then);
 
-  /// Create a copy of Url
+  final Header _self;
+  final $Res Function(Header) _then;
+
+  /// Create a copy of Header
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? raw = freezed,
-    Object? protocol = freezed,
-    Object? host = freezed,
-    Object? path = freezed,
-    Object? query = freezed,
+    Object? key = freezed,
+    Object? value = freezed,
+    Object? type = freezed,
+    Object? disabled = freezed,
   }) {
-    return _then(_$UrlImpl(
-      raw: freezed == raw
-          ? _value.raw
-          : raw // ignore: cast_nullable_to_non_nullable
+    return _then(_self.copyWith(
+      key: freezed == key
+          ? _self.key
+          : key // ignore: cast_nullable_to_non_nullable
               as String?,
-      protocol: freezed == protocol
-          ? _value.protocol
-          : protocol // ignore: cast_nullable_to_non_nullable
+      value: freezed == value
+          ? _self.value
+          : value // ignore: cast_nullable_to_non_nullable
               as String?,
-      host: freezed == host
-          ? _value._host
-          : host // ignore: cast_nullable_to_non_nullable
-              as List<String>?,
-      path: freezed == path
-          ? _value._path
-          : path // ignore: cast_nullable_to_non_nullable
-              as List<String>?,
-      query: freezed == query
-          ? _value._query
-          : query // ignore: cast_nullable_to_non_nullable
-              as List<Query>?,
+      type: freezed == type
+          ? _self.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String?,
+      disabled: freezed == disabled
+          ? _self.disabled
+          : disabled // ignore: cast_nullable_to_non_nullable
+              as bool?,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Header].
+extension HeaderPatterns on Header {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Header value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Header() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Header value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Header():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Header value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Header() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String? key, String? value, String? type, bool? disabled)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Header() when $default != null:
+        return $default(_that.key, _that.value, _that.type, _that.disabled);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String? key, String? value, String? type, bool? disabled)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Header():
+        return $default(_that.key, _that.value, _that.type, _that.disabled);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String? key, String? value, String? type, bool? disabled)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Header() when $default != null:
+        return $default(_that.key, _that.value, _that.type, _that.disabled);
+      case _:
+        return null;
+    }
   }
 }
 
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
-class _$UrlImpl implements _Url {
-  const _$UrlImpl(
+class _Header implements Header {
+  const _Header({this.key, this.value, this.type, this.disabled});
+  factory _Header.fromJson(Map<String, dynamic> json) => _$HeaderFromJson(json);
+
+  @override
+  final String? key;
+  @override
+  final String? value;
+  @override
+  final String? type;
+  @override
+  final bool? disabled;
+
+  /// Create a copy of Header
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$HeaderCopyWith<_Header> get copyWith =>
+      __$HeaderCopyWithImpl<_Header>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$HeaderToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Header &&
+            (identical(other.key, key) || other.key == key) &&
+            (identical(other.value, value) || other.value == value) &&
+            (identical(other.type, type) || other.type == type) &&
+            (identical(other.disabled, disabled) ||
+                other.disabled == disabled));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, key, value, type, disabled);
+
+  @override
+  String toString() {
+    return 'Header(key: $key, value: $value, type: $type, disabled: $disabled)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$HeaderCopyWith<$Res> implements $HeaderCopyWith<$Res> {
+  factory _$HeaderCopyWith(_Header value, $Res Function(_Header) _then) =
+      __$HeaderCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String? key, String? value, String? type, bool? disabled});
+}
+
+/// @nodoc
+class __$HeaderCopyWithImpl<$Res> implements _$HeaderCopyWith<$Res> {
+  __$HeaderCopyWithImpl(this._self, this._then);
+
+  final _Header _self;
+  final $Res Function(_Header) _then;
+
+  /// Create a copy of Header
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? key = freezed,
+    Object? value = freezed,
+    Object? type = freezed,
+    Object? disabled = freezed,
+  }) {
+    return _then(_Header(
+      key: freezed == key
+          ? _self.key
+          : key // ignore: cast_nullable_to_non_nullable
+              as String?,
+      value: freezed == value
+          ? _self.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as String?,
+      type: freezed == type
+          ? _self.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String?,
+      disabled: freezed == disabled
+          ? _self.disabled
+          : disabled // ignore: cast_nullable_to_non_nullable
+              as bool?,
+    ));
+  }
+}
+
+/// @nodoc
+mixin _$Url {
+  String? get raw;
+  String? get protocol;
+  List<String>? get host;
+  List<String>? get path;
+  List<Query>? get query;
+
+  /// Create a copy of Url
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $UrlCopyWith<Url> get copyWith =>
+      _$UrlCopyWithImpl<Url>(this as Url, _$identity);
+
+  /// Serializes this Url to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Url &&
+            (identical(other.raw, raw) || other.raw == raw) &&
+            (identical(other.protocol, protocol) ||
+                other.protocol == protocol) &&
+            const DeepCollectionEquality().equals(other.host, host) &&
+            const DeepCollectionEquality().equals(other.path, path) &&
+            const DeepCollectionEquality().equals(other.query, query));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      raw,
+      protocol,
+      const DeepCollectionEquality().hash(host),
+      const DeepCollectionEquality().hash(path),
+      const DeepCollectionEquality().hash(query));
+
+  @override
+  String toString() {
+    return 'Url(raw: $raw, protocol: $protocol, host: $host, path: $path, query: $query)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $UrlCopyWith<$Res> {
+  factory $UrlCopyWith(Url value, $Res Function(Url) _then) = _$UrlCopyWithImpl;
+  @useResult
+  $Res call(
+      {String? raw,
+      String? protocol,
+      List<String>? host,
+      List<String>? path,
+      List<Query>? query});
+}
+
+/// @nodoc
+class _$UrlCopyWithImpl<$Res> implements $UrlCopyWith<$Res> {
+  _$UrlCopyWithImpl(this._self, this._then);
+
+  final Url _self;
+  final $Res Function(Url) _then;
+
+  /// Create a copy of Url
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? raw = freezed,
+    Object? protocol = freezed,
+    Object? host = freezed,
+    Object? path = freezed,
+    Object? query = freezed,
+  }) {
+    return _then(_self.copyWith(
+      raw: freezed == raw
+          ? _self.raw
+          : raw // ignore: cast_nullable_to_non_nullable
+              as String?,
+      protocol: freezed == protocol
+          ? _self.protocol
+          : protocol // ignore: cast_nullable_to_non_nullable
+              as String?,
+      host: freezed == host
+          ? _self.host
+          : host // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+      path: freezed == path
+          ? _self.path
+          : path // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+      query: freezed == query
+          ? _self.query
+          : query // ignore: cast_nullable_to_non_nullable
+              as List<Query>?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Url].
+extension UrlPatterns on Url {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Url value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Url() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Url value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Url():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Url value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Url() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String? raw, String? protocol, List<String>? host,
+            List<String>? path, List<Query>? query)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Url() when $default != null:
+        return $default(
+            _that.raw, _that.protocol, _that.host, _that.path, _that.query);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String? raw, String? protocol, List<String>? host,
+            List<String>? path, List<Query>? query)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Url():
+        return $default(
+            _that.raw, _that.protocol, _that.host, _that.path, _that.query);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String? raw, String? protocol, List<String>? host,
+            List<String>? path, List<Query>? query)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Url() when $default != null:
+        return $default(
+            _that.raw, _that.protocol, _that.host, _that.path, _that.query);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+@JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
+class _Url implements Url {
+  const _Url(
       {this.raw,
       this.protocol,
       final List<String>? host,
@@ -1270,9 +2312,7 @@ class _$UrlImpl implements _Url {
       : _host = host,
         _path = path,
         _query = query;
-
-  factory _$UrlImpl.fromJson(Map<String, dynamic> json) =>
-      _$$UrlImplFromJson(json);
+  factory _Url.fromJson(Map<String, dynamic> json) => _$UrlFromJson(json);
 
   @override
   final String? raw;
@@ -1308,16 +2348,26 @@ class _$UrlImpl implements _Url {
     return EqualUnmodifiableListView(value);
   }
 
+  /// Create a copy of Url
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'Url(raw: $raw, protocol: $protocol, host: $host, path: $path, query: $query)';
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$UrlCopyWith<_Url> get copyWith =>
+      __$UrlCopyWithImpl<_Url>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$UrlToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$UrlImpl &&
+            other is _Url &&
             (identical(other.raw, raw) || other.raw == raw) &&
             (identical(other.protocol, protocol) ||
                 other.protocol == protocol) &&
@@ -1336,184 +2386,90 @@ class _$UrlImpl implements _Url {
       const DeepCollectionEquality().hash(_path),
       const DeepCollectionEquality().hash(_query));
 
-  /// Create a copy of Url
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$UrlImplCopyWith<_$UrlImpl> get copyWith =>
-      __$$UrlImplCopyWithImpl<_$UrlImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$UrlImplToJson(
-      this,
-    );
-  }
-}
-
-abstract class _Url implements Url {
-  const factory _Url(
-      {final String? raw,
-      final String? protocol,
-      final List<String>? host,
-      final List<String>? path,
-      final List<Query>? query}) = _$UrlImpl;
-
-  factory _Url.fromJson(Map<String, dynamic> json) = _$UrlImpl.fromJson;
-
-  @override
-  String? get raw;
-  @override
-  String? get protocol;
-  @override
-  List<String>? get host;
-  @override
-  List<String>? get path;
-  @override
-  List<Query>? get query;
-
-  /// Create a copy of Url
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$UrlImplCopyWith<_$UrlImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-Query _$QueryFromJson(Map<String, dynamic> json) {
-  return _Query.fromJson(json);
-}
-
-/// @nodoc
-mixin _$Query {
-  String? get key => throw _privateConstructorUsedError;
-  String? get value => throw _privateConstructorUsedError;
-  bool? get disabled => throw _privateConstructorUsedError;
-
-  /// Serializes this Query to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of Query
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $QueryCopyWith<Query> get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $QueryCopyWith<$Res> {
-  factory $QueryCopyWith(Query value, $Res Function(Query) then) =
-      _$QueryCopyWithImpl<$Res, Query>;
-  @useResult
-  $Res call({String? key, String? value, bool? disabled});
-}
-
-/// @nodoc
-class _$QueryCopyWithImpl<$Res, $Val extends Query>
-    implements $QueryCopyWith<$Res> {
-  _$QueryCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of Query
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? key = freezed,
-    Object? value = freezed,
-    Object? disabled = freezed,
-  }) {
-    return _then(_value.copyWith(
-      key: freezed == key
-          ? _value.key
-          : key // ignore: cast_nullable_to_non_nullable
-              as String?,
-      value: freezed == value
-          ? _value.value
-          : value // ignore: cast_nullable_to_non_nullable
-              as String?,
-      disabled: freezed == disabled
-          ? _value.disabled
-          : disabled // ignore: cast_nullable_to_non_nullable
-              as bool?,
-    ) as $Val);
+  String toString() {
+    return 'Url(raw: $raw, protocol: $protocol, host: $host, path: $path, query: $query)';
   }
 }
 
 /// @nodoc
-abstract class _$$QueryImplCopyWith<$Res> implements $QueryCopyWith<$Res> {
-  factory _$$QueryImplCopyWith(
-          _$QueryImpl value, $Res Function(_$QueryImpl) then) =
-      __$$QueryImplCopyWithImpl<$Res>;
+abstract mixin class _$UrlCopyWith<$Res> implements $UrlCopyWith<$Res> {
+  factory _$UrlCopyWith(_Url value, $Res Function(_Url) _then) =
+      __$UrlCopyWithImpl;
   @override
   @useResult
-  $Res call({String? key, String? value, bool? disabled});
+  $Res call(
+      {String? raw,
+      String? protocol,
+      List<String>? host,
+      List<String>? path,
+      List<Query>? query});
 }
 
 /// @nodoc
-class __$$QueryImplCopyWithImpl<$Res>
-    extends _$QueryCopyWithImpl<$Res, _$QueryImpl>
-    implements _$$QueryImplCopyWith<$Res> {
-  __$$QueryImplCopyWithImpl(
-      _$QueryImpl _value, $Res Function(_$QueryImpl) _then)
-      : super(_value, _then);
+class __$UrlCopyWithImpl<$Res> implements _$UrlCopyWith<$Res> {
+  __$UrlCopyWithImpl(this._self, this._then);
 
-  /// Create a copy of Query
+  final _Url _self;
+  final $Res Function(_Url) _then;
+
+  /// Create a copy of Url
   /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
   @override
+  @pragma('vm:prefer-inline')
   $Res call({
-    Object? key = freezed,
-    Object? value = freezed,
-    Object? disabled = freezed,
+    Object? raw = freezed,
+    Object? protocol = freezed,
+    Object? host = freezed,
+    Object? path = freezed,
+    Object? query = freezed,
   }) {
-    return _then(_$QueryImpl(
-      key: freezed == key
-          ? _value.key
-          : key // ignore: cast_nullable_to_non_nullable
+    return _then(_Url(
+      raw: freezed == raw
+          ? _self.raw
+          : raw // ignore: cast_nullable_to_non_nullable
               as String?,
-      value: freezed == value
-          ? _value.value
-          : value // ignore: cast_nullable_to_non_nullable
+      protocol: freezed == protocol
+          ? _self.protocol
+          : protocol // ignore: cast_nullable_to_non_nullable
               as String?,
-      disabled: freezed == disabled
-          ? _value.disabled
-          : disabled // ignore: cast_nullable_to_non_nullable
-              as bool?,
+      host: freezed == host
+          ? _self._host
+          : host // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+      path: freezed == path
+          ? _self._path
+          : path // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+      query: freezed == query
+          ? _self._query
+          : query // ignore: cast_nullable_to_non_nullable
+              as List<Query>?,
     ));
   }
 }
 
 /// @nodoc
+mixin _$Query {
+  String? get key;
+  String? get value;
+  bool? get disabled;
 
-@JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
-class _$QueryImpl implements _Query {
-  const _$QueryImpl({this.key, this.value, this.disabled});
+  /// Create a copy of Query
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $QueryCopyWith<Query> get copyWith =>
+      _$QueryCopyWithImpl<Query>(this as Query, _$identity);
 
-  factory _$QueryImpl.fromJson(Map<String, dynamic> json) =>
-      _$$QueryImplFromJson(json);
-
-  @override
-  final String? key;
-  @override
-  final String? value;
-  @override
-  final bool? disabled;
-
-  @override
-  String toString() {
-    return 'Query(key: $key, value: $value, disabled: $disabled)';
-  }
+  /// Serializes this Query to a JSON map.
+  Map<String, dynamic> toJson();
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$QueryImpl &&
+            other is Query &&
             (identical(other.key, key) || other.key == key) &&
             (identical(other.value, value) || other.value == value) &&
             (identical(other.disabled, disabled) ||
@@ -1524,85 +2480,370 @@ class _$QueryImpl implements _Query {
   @override
   int get hashCode => Object.hash(runtimeType, key, value, disabled);
 
-  /// Create a copy of Query
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$QueryImplCopyWith<_$QueryImpl> get copyWith =>
-      __$$QueryImplCopyWithImpl<_$QueryImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$QueryImplToJson(
-      this,
-    );
+  String toString() {
+    return 'Query(key: $key, value: $value, disabled: $disabled)';
   }
 }
 
-abstract class _Query implements Query {
-  const factory _Query(
-      {final String? key,
-      final String? value,
-      final bool? disabled}) = _$QueryImpl;
+/// @nodoc
+abstract mixin class $QueryCopyWith<$Res> {
+  factory $QueryCopyWith(Query value, $Res Function(Query) _then) =
+      _$QueryCopyWithImpl;
+  @useResult
+  $Res call({String? key, String? value, bool? disabled});
+}
 
-  factory _Query.fromJson(Map<String, dynamic> json) = _$QueryImpl.fromJson;
+/// @nodoc
+class _$QueryCopyWithImpl<$Res> implements $QueryCopyWith<$Res> {
+  _$QueryCopyWithImpl(this._self, this._then);
+
+  final Query _self;
+  final $Res Function(Query) _then;
+
+  /// Create a copy of Query
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? key = freezed,
+    Object? value = freezed,
+    Object? disabled = freezed,
+  }) {
+    return _then(_self.copyWith(
+      key: freezed == key
+          ? _self.key
+          : key // ignore: cast_nullable_to_non_nullable
+              as String?,
+      value: freezed == value
+          ? _self.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as String?,
+      disabled: freezed == disabled
+          ? _self.disabled
+          : disabled // ignore: cast_nullable_to_non_nullable
+              as bool?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Query].
+extension QueryPatterns on Query {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Query value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Query() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Query value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Query():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Query value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Query() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String? key, String? value, bool? disabled)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Query() when $default != null:
+        return $default(_that.key, _that.value, _that.disabled);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String? key, String? value, bool? disabled) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Query():
+        return $default(_that.key, _that.value, _that.disabled);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String? key, String? value, bool? disabled)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Query() when $default != null:
+        return $default(_that.key, _that.value, _that.disabled);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+@JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
+class _Query implements Query {
+  const _Query({this.key, this.value, this.disabled});
+  factory _Query.fromJson(Map<String, dynamic> json) => _$QueryFromJson(json);
 
   @override
-  String? get key;
+  final String? key;
   @override
-  String? get value;
+  final String? value;
   @override
-  bool? get disabled;
+  final bool? disabled;
 
   /// Create a copy of Query
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$QueryImplCopyWith<_$QueryImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  _$QueryCopyWith<_Query> get copyWith =>
+      __$QueryCopyWithImpl<_Query>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$QueryToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Query &&
+            (identical(other.key, key) || other.key == key) &&
+            (identical(other.value, value) || other.value == value) &&
+            (identical(other.disabled, disabled) ||
+                other.disabled == disabled));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, key, value, disabled);
+
+  @override
+  String toString() {
+    return 'Query(key: $key, value: $value, disabled: $disabled)';
+  }
 }
 
-Body _$BodyFromJson(Map<String, dynamic> json) {
-  return _Body.fromJson(json);
+/// @nodoc
+abstract mixin class _$QueryCopyWith<$Res> implements $QueryCopyWith<$Res> {
+  factory _$QueryCopyWith(_Query value, $Res Function(_Query) _then) =
+      __$QueryCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String? key, String? value, bool? disabled});
+}
+
+/// @nodoc
+class __$QueryCopyWithImpl<$Res> implements _$QueryCopyWith<$Res> {
+  __$QueryCopyWithImpl(this._self, this._then);
+
+  final _Query _self;
+  final $Res Function(_Query) _then;
+
+  /// Create a copy of Query
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? key = freezed,
+    Object? value = freezed,
+    Object? disabled = freezed,
+  }) {
+    return _then(_Query(
+      key: freezed == key
+          ? _self.key
+          : key // ignore: cast_nullable_to_non_nullable
+              as String?,
+      value: freezed == value
+          ? _self.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as String?,
+      disabled: freezed == disabled
+          ? _self.disabled
+          : disabled // ignore: cast_nullable_to_non_nullable
+              as bool?,
+    ));
+  }
 }
 
 /// @nodoc
 mixin _$Body {
-  String? get mode => throw _privateConstructorUsedError;
-  String? get raw => throw _privateConstructorUsedError;
-  Options? get options => throw _privateConstructorUsedError;
-  List<Formdatum>? get formdata => throw _privateConstructorUsedError;
-
-  /// Serializes this Body to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  String? get mode;
+  String? get raw;
+  Options? get options;
+  List<Formdatum>? get formdata;
+  List<Urlencoded>? get urlencoded;
 
   /// Create a copy of Body
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $BodyCopyWith<Body> get copyWith => throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $BodyCopyWith<Body> get copyWith =>
+      _$BodyCopyWithImpl<Body>(this as Body, _$identity);
+
+  /// Serializes this Body to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Body &&
+            (identical(other.mode, mode) || other.mode == mode) &&
+            (identical(other.raw, raw) || other.raw == raw) &&
+            (identical(other.options, options) || other.options == options) &&
+            const DeepCollectionEquality().equals(other.formdata, formdata) &&
+            const DeepCollectionEquality()
+                .equals(other.urlencoded, urlencoded));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      mode,
+      raw,
+      options,
+      const DeepCollectionEquality().hash(formdata),
+      const DeepCollectionEquality().hash(urlencoded));
+
+  @override
+  String toString() {
+    return 'Body(mode: $mode, raw: $raw, options: $options, formdata: $formdata, urlencoded: $urlencoded)';
+  }
 }
 
 /// @nodoc
-abstract class $BodyCopyWith<$Res> {
-  factory $BodyCopyWith(Body value, $Res Function(Body) then) =
-      _$BodyCopyWithImpl<$Res, Body>;
+abstract mixin class $BodyCopyWith<$Res> {
+  factory $BodyCopyWith(Body value, $Res Function(Body) _then) =
+      _$BodyCopyWithImpl;
   @useResult
   $Res call(
-      {String? mode, String? raw, Options? options, List<Formdatum>? formdata});
+      {String? mode,
+      String? raw,
+      Options? options,
+      List<Formdatum>? formdata,
+      List<Urlencoded>? urlencoded});
 
   $OptionsCopyWith<$Res>? get options;
 }
 
 /// @nodoc
-class _$BodyCopyWithImpl<$Res, $Val extends Body>
-    implements $BodyCopyWith<$Res> {
-  _$BodyCopyWithImpl(this._value, this._then);
+class _$BodyCopyWithImpl<$Res> implements $BodyCopyWith<$Res> {
+  _$BodyCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final Body _self;
+  final $Res Function(Body) _then;
 
   /// Create a copy of Body
   /// with the given fields replaced by the non-null parameter values.
@@ -1613,25 +2854,30 @@ class _$BodyCopyWithImpl<$Res, $Val extends Body>
     Object? raw = freezed,
     Object? options = freezed,
     Object? formdata = freezed,
+    Object? urlencoded = freezed,
   }) {
-    return _then(_value.copyWith(
+    return _then(_self.copyWith(
       mode: freezed == mode
-          ? _value.mode
+          ? _self.mode
           : mode // ignore: cast_nullable_to_non_nullable
               as String?,
       raw: freezed == raw
-          ? _value.raw
+          ? _self.raw
           : raw // ignore: cast_nullable_to_non_nullable
               as String?,
       options: freezed == options
-          ? _value.options
+          ? _self.options
           : options // ignore: cast_nullable_to_non_nullable
               as Options?,
       formdata: freezed == formdata
-          ? _value.formdata
+          ? _self.formdata
           : formdata // ignore: cast_nullable_to_non_nullable
               as List<Formdatum>?,
-    ) as $Val);
+      urlencoded: freezed == urlencoded
+          ? _self.urlencoded
+          : urlencoded // ignore: cast_nullable_to_non_nullable
+              as List<Urlencoded>?,
+    ));
   }
 
   /// Create a copy of Body
@@ -1639,78 +2885,195 @@ class _$BodyCopyWithImpl<$Res, $Val extends Body>
   @override
   @pragma('vm:prefer-inline')
   $OptionsCopyWith<$Res>? get options {
-    if (_value.options == null) {
+    if (_self.options == null) {
       return null;
     }
 
-    return $OptionsCopyWith<$Res>(_value.options!, (value) {
-      return _then(_value.copyWith(options: value) as $Val);
+    return $OptionsCopyWith<$Res>(_self.options!, (value) {
+      return _then(_self.copyWith(options: value));
     });
   }
 }
 
-/// @nodoc
-abstract class _$$BodyImplCopyWith<$Res> implements $BodyCopyWith<$Res> {
-  factory _$$BodyImplCopyWith(
-          _$BodyImpl value, $Res Function(_$BodyImpl) then) =
-      __$$BodyImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {String? mode, String? raw, Options? options, List<Formdatum>? formdata});
+/// Adds pattern-matching-related methods to [Body].
+extension BodyPatterns on Body {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
 
-  @override
-  $OptionsCopyWith<$Res>? get options;
-}
-
-/// @nodoc
-class __$$BodyImplCopyWithImpl<$Res>
-    extends _$BodyCopyWithImpl<$Res, _$BodyImpl>
-    implements _$$BodyImplCopyWith<$Res> {
-  __$$BodyImplCopyWithImpl(_$BodyImpl _value, $Res Function(_$BodyImpl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of Body
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? mode = freezed,
-    Object? raw = freezed,
-    Object? options = freezed,
-    Object? formdata = freezed,
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Body value)? $default, {
+    required TResult orElse(),
   }) {
-    return _then(_$BodyImpl(
-      mode: freezed == mode
-          ? _value.mode
-          : mode // ignore: cast_nullable_to_non_nullable
-              as String?,
-      raw: freezed == raw
-          ? _value.raw
-          : raw // ignore: cast_nullable_to_non_nullable
-              as String?,
-      options: freezed == options
-          ? _value.options
-          : options // ignore: cast_nullable_to_non_nullable
-              as Options?,
-      formdata: freezed == formdata
-          ? _value._formdata
-          : formdata // ignore: cast_nullable_to_non_nullable
-              as List<Formdatum>?,
-    ));
+    final _that = this;
+    switch (_that) {
+      case _Body() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Body value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Body():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Body value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Body() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String? mode, String? raw, Options? options,
+            List<Formdatum>? formdata, List<Urlencoded>? urlencoded)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Body() when $default != null:
+        return $default(_that.mode, _that.raw, _that.options, _that.formdata,
+            _that.urlencoded);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String? mode, String? raw, Options? options,
+            List<Formdatum>? formdata, List<Urlencoded>? urlencoded)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Body():
+        return $default(_that.mode, _that.raw, _that.options, _that.formdata,
+            _that.urlencoded);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String? mode, String? raw, Options? options,
+            List<Formdatum>? formdata, List<Urlencoded>? urlencoded)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Body() when $default != null:
+        return $default(_that.mode, _that.raw, _that.options, _that.formdata,
+            _that.urlencoded);
+      case _:
+        return null;
+    }
   }
 }
 
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
-class _$BodyImpl implements _Body {
-  const _$BodyImpl(
-      {this.mode, this.raw, this.options, final List<Formdatum>? formdata})
-      : _formdata = formdata;
-
-  factory _$BodyImpl.fromJson(Map<String, dynamic> json) =>
-      _$$BodyImplFromJson(json);
+class _Body implements Body {
+  const _Body(
+      {this.mode,
+      this.raw,
+      this.options,
+      final List<Formdatum>? formdata,
+      final List<Urlencoded>? urlencoded})
+      : _formdata = formdata,
+        _urlencoded = urlencoded;
+  factory _Body.fromJson(Map<String, dynamic> json) => _$BodyFromJson(json);
 
   @override
   final String? mode;
@@ -1728,195 +3091,153 @@ class _$BodyImpl implements _Body {
     return EqualUnmodifiableListView(value);
   }
 
+  final List<Urlencoded>? _urlencoded;
   @override
-  String toString() {
-    return 'Body(mode: $mode, raw: $raw, options: $options, formdata: $formdata)';
+  List<Urlencoded>? get urlencoded {
+    final value = _urlencoded;
+    if (value == null) return null;
+    if (_urlencoded is EqualUnmodifiableListView) return _urlencoded;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  /// Create a copy of Body
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$BodyCopyWith<_Body> get copyWith =>
+      __$BodyCopyWithImpl<_Body>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$BodyToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$BodyImpl &&
+            other is _Body &&
             (identical(other.mode, mode) || other.mode == mode) &&
             (identical(other.raw, raw) || other.raw == raw) &&
             (identical(other.options, options) || other.options == options) &&
-            const DeepCollectionEquality().equals(other._formdata, _formdata));
+            const DeepCollectionEquality().equals(other._formdata, _formdata) &&
+            const DeepCollectionEquality()
+                .equals(other._urlencoded, _urlencoded));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(runtimeType, mode, raw, options,
-      const DeepCollectionEquality().hash(_formdata));
-
-  /// Create a copy of Body
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$BodyImplCopyWith<_$BodyImpl> get copyWith =>
-      __$$BodyImplCopyWithImpl<_$BodyImpl>(this, _$identity);
+  int get hashCode => Object.hash(
+      runtimeType,
+      mode,
+      raw,
+      options,
+      const DeepCollectionEquality().hash(_formdata),
+      const DeepCollectionEquality().hash(_urlencoded));
 
   @override
-  Map<String, dynamic> toJson() {
-    return _$$BodyImplToJson(
-      this,
-    );
+  String toString() {
+    return 'Body(mode: $mode, raw: $raw, options: $options, formdata: $formdata, urlencoded: $urlencoded)';
   }
 }
 
-abstract class _Body implements Body {
-  const factory _Body(
-      {final String? mode,
-      final String? raw,
-      final Options? options,
-      final List<Formdatum>? formdata}) = _$BodyImpl;
-
-  factory _Body.fromJson(Map<String, dynamic> json) = _$BodyImpl.fromJson;
-
-  @override
-  String? get mode;
-  @override
-  String? get raw;
-  @override
-  Options? get options;
-  @override
-  List<Formdatum>? get formdata;
-
-  /// Create a copy of Body
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$BodyImplCopyWith<_$BodyImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-Options _$OptionsFromJson(Map<String, dynamic> json) {
-  return _Options.fromJson(json);
-}
-
 /// @nodoc
-mixin _$Options {
-  Raw? get raw => throw _privateConstructorUsedError;
-
-  /// Serializes this Options to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of Options
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $OptionsCopyWith<Options> get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $OptionsCopyWith<$Res> {
-  factory $OptionsCopyWith(Options value, $Res Function(Options) then) =
-      _$OptionsCopyWithImpl<$Res, Options>;
+abstract mixin class _$BodyCopyWith<$Res> implements $BodyCopyWith<$Res> {
+  factory _$BodyCopyWith(_Body value, $Res Function(_Body) _then) =
+      __$BodyCopyWithImpl;
+  @override
   @useResult
-  $Res call({Raw? raw});
+  $Res call(
+      {String? mode,
+      String? raw,
+      Options? options,
+      List<Formdatum>? formdata,
+      List<Urlencoded>? urlencoded});
 
-  $RawCopyWith<$Res>? get raw;
+  @override
+  $OptionsCopyWith<$Res>? get options;
 }
 
 /// @nodoc
-class _$OptionsCopyWithImpl<$Res, $Val extends Options>
-    implements $OptionsCopyWith<$Res> {
-  _$OptionsCopyWithImpl(this._value, this._then);
+class __$BodyCopyWithImpl<$Res> implements _$BodyCopyWith<$Res> {
+  __$BodyCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final _Body _self;
+  final $Res Function(_Body) _then;
 
-  /// Create a copy of Options
+  /// Create a copy of Body
   /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
   @override
+  @pragma('vm:prefer-inline')
   $Res call({
+    Object? mode = freezed,
     Object? raw = freezed,
+    Object? options = freezed,
+    Object? formdata = freezed,
+    Object? urlencoded = freezed,
   }) {
-    return _then(_value.copyWith(
+    return _then(_Body(
+      mode: freezed == mode
+          ? _self.mode
+          : mode // ignore: cast_nullable_to_non_nullable
+              as String?,
       raw: freezed == raw
-          ? _value.raw
+          ? _self.raw
           : raw // ignore: cast_nullable_to_non_nullable
-              as Raw?,
-    ) as $Val);
+              as String?,
+      options: freezed == options
+          ? _self.options
+          : options // ignore: cast_nullable_to_non_nullable
+              as Options?,
+      formdata: freezed == formdata
+          ? _self._formdata
+          : formdata // ignore: cast_nullable_to_non_nullable
+              as List<Formdatum>?,
+      urlencoded: freezed == urlencoded
+          ? _self._urlencoded
+          : urlencoded // ignore: cast_nullable_to_non_nullable
+              as List<Urlencoded>?,
+    ));
   }
 
-  /// Create a copy of Options
+  /// Create a copy of Body
   /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-  $RawCopyWith<$Res>? get raw {
-    if (_value.raw == null) {
+  $OptionsCopyWith<$Res>? get options {
+    if (_self.options == null) {
       return null;
     }
 
-    return $RawCopyWith<$Res>(_value.raw!, (value) {
-      return _then(_value.copyWith(raw: value) as $Val);
+    return $OptionsCopyWith<$Res>(_self.options!, (value) {
+      return _then(_self.copyWith(options: value));
     });
   }
 }
 
 /// @nodoc
-abstract class _$$OptionsImplCopyWith<$Res> implements $OptionsCopyWith<$Res> {
-  factory _$$OptionsImplCopyWith(
-          _$OptionsImpl value, $Res Function(_$OptionsImpl) then) =
-      __$$OptionsImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({Raw? raw});
-
-  @override
-  $RawCopyWith<$Res>? get raw;
-}
-
-/// @nodoc
-class __$$OptionsImplCopyWithImpl<$Res>
-    extends _$OptionsCopyWithImpl<$Res, _$OptionsImpl>
-    implements _$$OptionsImplCopyWith<$Res> {
-  __$$OptionsImplCopyWithImpl(
-      _$OptionsImpl _value, $Res Function(_$OptionsImpl) _then)
-      : super(_value, _then);
+mixin _$Options {
+  Raw? get raw;
 
   /// Create a copy of Options
   /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? raw = freezed,
-  }) {
-    return _then(_$OptionsImpl(
-      raw: freezed == raw
-          ? _value.raw
-          : raw // ignore: cast_nullable_to_non_nullable
-              as Raw?,
-    ));
-  }
-}
+  $OptionsCopyWith<Options> get copyWith =>
+      _$OptionsCopyWithImpl<Options>(this as Options, _$identity);
 
-/// @nodoc
-
-@JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
-class _$OptionsImpl implements _Options {
-  const _$OptionsImpl({this.raw});
-
-  factory _$OptionsImpl.fromJson(Map<String, dynamic> json) =>
-      _$$OptionsImplFromJson(json);
-
-  @override
-  final Raw? raw;
-
-  @override
-  String toString() {
-    return 'Options(raw: $raw)';
-  }
+  /// Serializes this Options to a JSON map.
+  Map<String, dynamic> toJson();
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$OptionsImpl &&
+            other is Options &&
             (identical(other.raw, raw) || other.raw == raw));
   }
 
@@ -1924,141 +3245,328 @@ class _$OptionsImpl implements _Options {
   @override
   int get hashCode => Object.hash(runtimeType, raw);
 
-  /// Create a copy of Options
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$OptionsImplCopyWith<_$OptionsImpl> get copyWith =>
-      __$$OptionsImplCopyWithImpl<_$OptionsImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$OptionsImplToJson(
-      this,
-    );
-  }
-}
-
-abstract class _Options implements Options {
-  const factory _Options({final Raw? raw}) = _$OptionsImpl;
-
-  factory _Options.fromJson(Map<String, dynamic> json) = _$OptionsImpl.fromJson;
-
-  @override
-  Raw? get raw;
-
-  /// Create a copy of Options
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$OptionsImplCopyWith<_$OptionsImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-Raw _$RawFromJson(Map<String, dynamic> json) {
-  return _Raw.fromJson(json);
-}
-
-/// @nodoc
-mixin _$Raw {
-  String? get language => throw _privateConstructorUsedError;
-
-  /// Serializes this Raw to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of Raw
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $RawCopyWith<Raw> get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $RawCopyWith<$Res> {
-  factory $RawCopyWith(Raw value, $Res Function(Raw) then) =
-      _$RawCopyWithImpl<$Res, Raw>;
-  @useResult
-  $Res call({String? language});
-}
-
-/// @nodoc
-class _$RawCopyWithImpl<$Res, $Val extends Raw> implements $RawCopyWith<$Res> {
-  _$RawCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of Raw
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? language = freezed,
-  }) {
-    return _then(_value.copyWith(
-      language: freezed == language
-          ? _value.language
-          : language // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ) as $Val);
+  String toString() {
+    return 'Options(raw: $raw)';
   }
 }
 
 /// @nodoc
-abstract class _$$RawImplCopyWith<$Res> implements $RawCopyWith<$Res> {
-  factory _$$RawImplCopyWith(_$RawImpl value, $Res Function(_$RawImpl) then) =
-      __$$RawImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $OptionsCopyWith<$Res> {
+  factory $OptionsCopyWith(Options value, $Res Function(Options) _then) =
+      _$OptionsCopyWithImpl;
   @useResult
-  $Res call({String? language});
+  $Res call({Raw? raw});
+
+  $RawCopyWith<$Res>? get raw;
 }
 
 /// @nodoc
-class __$$RawImplCopyWithImpl<$Res> extends _$RawCopyWithImpl<$Res, _$RawImpl>
-    implements _$$RawImplCopyWith<$Res> {
-  __$$RawImplCopyWithImpl(_$RawImpl _value, $Res Function(_$RawImpl) _then)
-      : super(_value, _then);
+class _$OptionsCopyWithImpl<$Res> implements $OptionsCopyWith<$Res> {
+  _$OptionsCopyWithImpl(this._self, this._then);
 
-  /// Create a copy of Raw
+  final Options _self;
+  final $Res Function(Options) _then;
+
+  /// Create a copy of Options
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? language = freezed,
+    Object? raw = freezed,
   }) {
-    return _then(_$RawImpl(
-      language: freezed == language
-          ? _value.language
-          : language // ignore: cast_nullable_to_non_nullable
-              as String?,
+    return _then(_self.copyWith(
+      raw: freezed == raw
+          ? _self.raw
+          : raw // ignore: cast_nullable_to_non_nullable
+              as Raw?,
     ));
+  }
+
+  /// Create a copy of Options
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $RawCopyWith<$Res>? get raw {
+    if (_self.raw == null) {
+      return null;
+    }
+
+    return $RawCopyWith<$Res>(_self.raw!, (value) {
+      return _then(_self.copyWith(raw: value));
+    });
+  }
+}
+
+/// Adds pattern-matching-related methods to [Options].
+extension OptionsPatterns on Options {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Options value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Options() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Options value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Options():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Options value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Options() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(Raw? raw)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Options() when $default != null:
+        return $default(_that.raw);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(Raw? raw) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Options():
+        return $default(_that.raw);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(Raw? raw)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Options() when $default != null:
+        return $default(_that.raw);
+      case _:
+        return null;
+    }
   }
 }
 
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
-class _$RawImpl implements _Raw {
-  const _$RawImpl({this.language});
-
-  factory _$RawImpl.fromJson(Map<String, dynamic> json) =>
-      _$$RawImplFromJson(json);
-
-  @override
-  final String? language;
+class _Options implements Options {
+  const _Options({this.raw});
+  factory _Options.fromJson(Map<String, dynamic> json) =>
+      _$OptionsFromJson(json);
 
   @override
-  String toString() {
-    return 'Raw(language: $language)';
+  final Raw? raw;
+
+  /// Create a copy of Options
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$OptionsCopyWith<_Options> get copyWith =>
+      __$OptionsCopyWithImpl<_Options>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$OptionsToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$RawImpl &&
+            other is _Options &&
+            (identical(other.raw, raw) || other.raw == raw));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, raw);
+
+  @override
+  String toString() {
+    return 'Options(raw: $raw)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$OptionsCopyWith<$Res> implements $OptionsCopyWith<$Res> {
+  factory _$OptionsCopyWith(_Options value, $Res Function(_Options) _then) =
+      __$OptionsCopyWithImpl;
+  @override
+  @useResult
+  $Res call({Raw? raw});
+
+  @override
+  $RawCopyWith<$Res>? get raw;
+}
+
+/// @nodoc
+class __$OptionsCopyWithImpl<$Res> implements _$OptionsCopyWith<$Res> {
+  __$OptionsCopyWithImpl(this._self, this._then);
+
+  final _Options _self;
+  final $Res Function(_Options) _then;
+
+  /// Create a copy of Options
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? raw = freezed,
+  }) {
+    return _then(_Options(
+      raw: freezed == raw
+          ? _self.raw
+          : raw // ignore: cast_nullable_to_non_nullable
+              as Raw?,
+    ));
+  }
+
+  /// Create a copy of Options
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $RawCopyWith<$Res>? get raw {
+    if (_self.raw == null) {
+      return null;
+    }
+
+    return $RawCopyWith<$Res>(_self.raw!, (value) {
+      return _then(_self.copyWith(raw: value));
+    });
+  }
+}
+
+/// @nodoc
+mixin _$Raw {
+  String? get language;
+
+  /// Create a copy of Raw
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $RawCopyWith<Raw> get copyWith =>
+      _$RawCopyWithImpl<Raw>(this as Raw, _$identity);
+
+  /// Serializes this Raw to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Raw &&
             (identical(other.language, language) ||
                 other.language == language));
   }
@@ -2067,186 +3575,297 @@ class _$RawImpl implements _Raw {
   @override
   int get hashCode => Object.hash(runtimeType, language);
 
-  /// Create a copy of Raw
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$RawImplCopyWith<_$RawImpl> get copyWith =>
-      __$$RawImplCopyWithImpl<_$RawImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$RawImplToJson(
-      this,
-    );
-  }
-}
-
-abstract class _Raw implements Raw {
-  const factory _Raw({final String? language}) = _$RawImpl;
-
-  factory _Raw.fromJson(Map<String, dynamic> json) = _$RawImpl.fromJson;
-
-  @override
-  String? get language;
-
-  /// Create a copy of Raw
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$RawImplCopyWith<_$RawImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-Formdatum _$FormdatumFromJson(Map<String, dynamic> json) {
-  return _Formdatum.fromJson(json);
-}
-
-/// @nodoc
-mixin _$Formdatum {
-  String? get key => throw _privateConstructorUsedError;
-  String? get value => throw _privateConstructorUsedError;
-  String? get type => throw _privateConstructorUsedError;
-  String? get src => throw _privateConstructorUsedError;
-
-  /// Serializes this Formdatum to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of Formdatum
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $FormdatumCopyWith<Formdatum> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $FormdatumCopyWith<$Res> {
-  factory $FormdatumCopyWith(Formdatum value, $Res Function(Formdatum) then) =
-      _$FormdatumCopyWithImpl<$Res, Formdatum>;
-  @useResult
-  $Res call({String? key, String? value, String? type, String? src});
-}
-
-/// @nodoc
-class _$FormdatumCopyWithImpl<$Res, $Val extends Formdatum>
-    implements $FormdatumCopyWith<$Res> {
-  _$FormdatumCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of Formdatum
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? key = freezed,
-    Object? value = freezed,
-    Object? type = freezed,
-    Object? src = freezed,
-  }) {
-    return _then(_value.copyWith(
-      key: freezed == key
-          ? _value.key
-          : key // ignore: cast_nullable_to_non_nullable
-              as String?,
-      value: freezed == value
-          ? _value.value
-          : value // ignore: cast_nullable_to_non_nullable
-              as String?,
-      type: freezed == type
-          ? _value.type
-          : type // ignore: cast_nullable_to_non_nullable
-              as String?,
-      src: freezed == src
-          ? _value.src
-          : src // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ) as $Val);
+  String toString() {
+    return 'Raw(language: $language)';
   }
 }
 
 /// @nodoc
-abstract class _$$FormdatumImplCopyWith<$Res>
-    implements $FormdatumCopyWith<$Res> {
-  factory _$$FormdatumImplCopyWith(
-          _$FormdatumImpl value, $Res Function(_$FormdatumImpl) then) =
-      __$$FormdatumImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $RawCopyWith<$Res> {
+  factory $RawCopyWith(Raw value, $Res Function(Raw) _then) = _$RawCopyWithImpl;
   @useResult
-  $Res call({String? key, String? value, String? type, String? src});
+  $Res call({String? language});
 }
 
 /// @nodoc
-class __$$FormdatumImplCopyWithImpl<$Res>
-    extends _$FormdatumCopyWithImpl<$Res, _$FormdatumImpl>
-    implements _$$FormdatumImplCopyWith<$Res> {
-  __$$FormdatumImplCopyWithImpl(
-      _$FormdatumImpl _value, $Res Function(_$FormdatumImpl) _then)
-      : super(_value, _then);
+class _$RawCopyWithImpl<$Res> implements $RawCopyWith<$Res> {
+  _$RawCopyWithImpl(this._self, this._then);
 
-  /// Create a copy of Formdatum
+  final Raw _self;
+  final $Res Function(Raw) _then;
+
+  /// Create a copy of Raw
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? key = freezed,
-    Object? value = freezed,
-    Object? type = freezed,
-    Object? src = freezed,
+    Object? language = freezed,
   }) {
-    return _then(_$FormdatumImpl(
-      key: freezed == key
-          ? _value.key
-          : key // ignore: cast_nullable_to_non_nullable
-              as String?,
-      value: freezed == value
-          ? _value.value
-          : value // ignore: cast_nullable_to_non_nullable
-              as String?,
-      type: freezed == type
-          ? _value.type
-          : type // ignore: cast_nullable_to_non_nullable
-              as String?,
-      src: freezed == src
-          ? _value.src
-          : src // ignore: cast_nullable_to_non_nullable
+    return _then(_self.copyWith(
+      language: freezed == language
+          ? _self.language
+          : language // ignore: cast_nullable_to_non_nullable
               as String?,
     ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Raw].
+extension RawPatterns on Raw {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Raw value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Raw() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Raw value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Raw():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Raw value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Raw() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String? language)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Raw() when $default != null:
+        return $default(_that.language);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String? language) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Raw():
+        return $default(_that.language);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String? language)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Raw() when $default != null:
+        return $default(_that.language);
+      case _:
+        return null;
+    }
   }
 }
 
 /// @nodoc
 
 @JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
-class _$FormdatumImpl implements _Formdatum {
-  const _$FormdatumImpl({this.key, this.value, this.type, this.src});
-
-  factory _$FormdatumImpl.fromJson(Map<String, dynamic> json) =>
-      _$$FormdatumImplFromJson(json);
+class _Raw implements Raw {
+  const _Raw({this.language});
+  factory _Raw.fromJson(Map<String, dynamic> json) => _$RawFromJson(json);
 
   @override
-  final String? key;
+  final String? language;
+
+  /// Create a copy of Raw
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  final String? value;
-  @override
-  final String? type;
-  @override
-  final String? src;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$RawCopyWith<_Raw> get copyWith =>
+      __$RawCopyWithImpl<_Raw>(this, _$identity);
 
   @override
-  String toString() {
-    return 'Formdatum(key: $key, value: $value, type: $type, src: $src)';
+  Map<String, dynamic> toJson() {
+    return _$RawToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$FormdatumImpl &&
+            other is _Raw &&
+            (identical(other.language, language) ||
+                other.language == language));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, language);
+
+  @override
+  String toString() {
+    return 'Raw(language: $language)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$RawCopyWith<$Res> implements $RawCopyWith<$Res> {
+  factory _$RawCopyWith(_Raw value, $Res Function(_Raw) _then) =
+      __$RawCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String? language});
+}
+
+/// @nodoc
+class __$RawCopyWithImpl<$Res> implements _$RawCopyWith<$Res> {
+  __$RawCopyWithImpl(this._self, this._then);
+
+  final _Raw _self;
+  final $Res Function(_Raw) _then;
+
+  /// Create a copy of Raw
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? language = freezed,
+  }) {
+    return _then(_Raw(
+      language: freezed == language
+          ? _self.language
+          : language // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+mixin _$Formdatum {
+  String? get key;
+  String? get value;
+  String? get type;
+  String? get src;
+
+  /// Create a copy of Formdatum
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $FormdatumCopyWith<Formdatum> get copyWith =>
+      _$FormdatumCopyWithImpl<Formdatum>(this as Formdatum, _$identity);
+
+  /// Serializes this Formdatum to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Formdatum &&
             (identical(other.key, key) || other.key == key) &&
             (identical(other.value, value) || other.value == value) &&
             (identical(other.type, type) || other.type == type) &&
@@ -2257,45 +3876,1723 @@ class _$FormdatumImpl implements _Formdatum {
   @override
   int get hashCode => Object.hash(runtimeType, key, value, type, src);
 
-  /// Create a copy of Formdatum
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$FormdatumImplCopyWith<_$FormdatumImpl> get copyWith =>
-      __$$FormdatumImplCopyWithImpl<_$FormdatumImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$FormdatumImplToJson(
-      this,
-    );
+  String toString() {
+    return 'Formdatum(key: $key, value: $value, type: $type, src: $src)';
   }
 }
 
-abstract class _Formdatum implements Formdatum {
-  const factory _Formdatum(
-      {final String? key,
-      final String? value,
-      final String? type,
-      final String? src}) = _$FormdatumImpl;
+/// @nodoc
+abstract mixin class $FormdatumCopyWith<$Res> {
+  factory $FormdatumCopyWith(Formdatum value, $Res Function(Formdatum) _then) =
+      _$FormdatumCopyWithImpl;
+  @useResult
+  $Res call({String? key, String? value, String? type, String? src});
+}
 
-  factory _Formdatum.fromJson(Map<String, dynamic> json) =
-      _$FormdatumImpl.fromJson;
+/// @nodoc
+class _$FormdatumCopyWithImpl<$Res> implements $FormdatumCopyWith<$Res> {
+  _$FormdatumCopyWithImpl(this._self, this._then);
+
+  final Formdatum _self;
+  final $Res Function(Formdatum) _then;
+
+  /// Create a copy of Formdatum
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? key = freezed,
+    Object? value = freezed,
+    Object? type = freezed,
+    Object? src = freezed,
+  }) {
+    return _then(_self.copyWith(
+      key: freezed == key
+          ? _self.key
+          : key // ignore: cast_nullable_to_non_nullable
+              as String?,
+      value: freezed == value
+          ? _self.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as String?,
+      type: freezed == type
+          ? _self.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String?,
+      src: freezed == src
+          ? _self.src
+          : src // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Formdatum].
+extension FormdatumPatterns on Formdatum {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Formdatum value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Formdatum() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Formdatum value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Formdatum():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Formdatum value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Formdatum() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String? key, String? value, String? type, String? src)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Formdatum() when $default != null:
+        return $default(_that.key, _that.value, _that.type, _that.src);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String? key, String? value, String? type, String? src)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Formdatum():
+        return $default(_that.key, _that.value, _that.type, _that.src);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String? key, String? value, String? type, String? src)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Formdatum() when $default != null:
+        return $default(_that.key, _that.value, _that.type, _that.src);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+@JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
+class _Formdatum implements Formdatum {
+  const _Formdatum({this.key, this.value, this.type, this.src});
+  factory _Formdatum.fromJson(Map<String, dynamic> json) =>
+      _$FormdatumFromJson(json);
 
   @override
-  String? get key;
+  final String? key;
   @override
-  String? get value;
+  final String? value;
   @override
-  String? get type;
+  final String? type;
   @override
-  String? get src;
+  final String? src;
 
   /// Create a copy of Formdatum
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$FormdatumImplCopyWith<_$FormdatumImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  _$FormdatumCopyWith<_Formdatum> get copyWith =>
+      __$FormdatumCopyWithImpl<_Formdatum>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$FormdatumToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Formdatum &&
+            (identical(other.key, key) || other.key == key) &&
+            (identical(other.value, value) || other.value == value) &&
+            (identical(other.type, type) || other.type == type) &&
+            (identical(other.src, src) || other.src == src));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, key, value, type, src);
+
+  @override
+  String toString() {
+    return 'Formdatum(key: $key, value: $value, type: $type, src: $src)';
+  }
 }
+
+/// @nodoc
+abstract mixin class _$FormdatumCopyWith<$Res>
+    implements $FormdatumCopyWith<$Res> {
+  factory _$FormdatumCopyWith(
+          _Formdatum value, $Res Function(_Formdatum) _then) =
+      __$FormdatumCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String? key, String? value, String? type, String? src});
+}
+
+/// @nodoc
+class __$FormdatumCopyWithImpl<$Res> implements _$FormdatumCopyWith<$Res> {
+  __$FormdatumCopyWithImpl(this._self, this._then);
+
+  final _Formdatum _self;
+  final $Res Function(_Formdatum) _then;
+
+  /// Create a copy of Formdatum
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? key = freezed,
+    Object? value = freezed,
+    Object? type = freezed,
+    Object? src = freezed,
+  }) {
+    return _then(_Formdatum(
+      key: freezed == key
+          ? _self.key
+          : key // ignore: cast_nullable_to_non_nullable
+              as String?,
+      value: freezed == value
+          ? _self.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as String?,
+      type: freezed == type
+          ? _self.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String?,
+      src: freezed == src
+          ? _self.src
+          : src // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+mixin _$Urlencoded {
+  String? get key;
+  String? get value;
+  String? get type;
+  bool? get disabled;
+
+  /// Create a copy of Urlencoded
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $UrlencodedCopyWith<Urlencoded> get copyWith =>
+      _$UrlencodedCopyWithImpl<Urlencoded>(this as Urlencoded, _$identity);
+
+  /// Serializes this Urlencoded to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Urlencoded &&
+            (identical(other.key, key) || other.key == key) &&
+            (identical(other.value, value) || other.value == value) &&
+            (identical(other.type, type) || other.type == type) &&
+            (identical(other.disabled, disabled) ||
+                other.disabled == disabled));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, key, value, type, disabled);
+
+  @override
+  String toString() {
+    return 'Urlencoded(key: $key, value: $value, type: $type, disabled: $disabled)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $UrlencodedCopyWith<$Res> {
+  factory $UrlencodedCopyWith(
+          Urlencoded value, $Res Function(Urlencoded) _then) =
+      _$UrlencodedCopyWithImpl;
+  @useResult
+  $Res call({String? key, String? value, String? type, bool? disabled});
+}
+
+/// @nodoc
+class _$UrlencodedCopyWithImpl<$Res> implements $UrlencodedCopyWith<$Res> {
+  _$UrlencodedCopyWithImpl(this._self, this._then);
+
+  final Urlencoded _self;
+  final $Res Function(Urlencoded) _then;
+
+  /// Create a copy of Urlencoded
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? key = freezed,
+    Object? value = freezed,
+    Object? type = freezed,
+    Object? disabled = freezed,
+  }) {
+    return _then(_self.copyWith(
+      key: freezed == key
+          ? _self.key
+          : key // ignore: cast_nullable_to_non_nullable
+              as String?,
+      value: freezed == value
+          ? _self.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as String?,
+      type: freezed == type
+          ? _self.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String?,
+      disabled: freezed == disabled
+          ? _self.disabled
+          : disabled // ignore: cast_nullable_to_non_nullable
+              as bool?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Urlencoded].
+extension UrlencodedPatterns on Urlencoded {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Urlencoded value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Urlencoded() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Urlencoded value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Urlencoded():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Urlencoded value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Urlencoded() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String? key, String? value, String? type, bool? disabled)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Urlencoded() when $default != null:
+        return $default(_that.key, _that.value, _that.type, _that.disabled);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String? key, String? value, String? type, bool? disabled)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Urlencoded():
+        return $default(_that.key, _that.value, _that.type, _that.disabled);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String? key, String? value, String? type, bool? disabled)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Urlencoded() when $default != null:
+        return $default(_that.key, _that.value, _that.type, _that.disabled);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+@JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
+class _Urlencoded implements Urlencoded {
+  const _Urlencoded({this.key, this.value, this.type, this.disabled});
+  factory _Urlencoded.fromJson(Map<String, dynamic> json) =>
+      _$UrlencodedFromJson(json);
+
+  @override
+  final String? key;
+  @override
+  final String? value;
+  @override
+  final String? type;
+  @override
+  final bool? disabled;
+
+  /// Create a copy of Urlencoded
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$UrlencodedCopyWith<_Urlencoded> get copyWith =>
+      __$UrlencodedCopyWithImpl<_Urlencoded>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$UrlencodedToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Urlencoded &&
+            (identical(other.key, key) || other.key == key) &&
+            (identical(other.value, value) || other.value == value) &&
+            (identical(other.type, type) || other.type == type) &&
+            (identical(other.disabled, disabled) ||
+                other.disabled == disabled));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, key, value, type, disabled);
+
+  @override
+  String toString() {
+    return 'Urlencoded(key: $key, value: $value, type: $type, disabled: $disabled)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$UrlencodedCopyWith<$Res>
+    implements $UrlencodedCopyWith<$Res> {
+  factory _$UrlencodedCopyWith(
+          _Urlencoded value, $Res Function(_Urlencoded) _then) =
+      __$UrlencodedCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String? key, String? value, String? type, bool? disabled});
+}
+
+/// @nodoc
+class __$UrlencodedCopyWithImpl<$Res> implements _$UrlencodedCopyWith<$Res> {
+  __$UrlencodedCopyWithImpl(this._self, this._then);
+
+  final _Urlencoded _self;
+  final $Res Function(_Urlencoded) _then;
+
+  /// Create a copy of Urlencoded
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? key = freezed,
+    Object? value = freezed,
+    Object? type = freezed,
+    Object? disabled = freezed,
+  }) {
+    return _then(_Urlencoded(
+      key: freezed == key
+          ? _self.key
+          : key // ignore: cast_nullable_to_non_nullable
+              as String?,
+      value: freezed == value
+          ? _self.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as String?,
+      type: freezed == type
+          ? _self.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String?,
+      disabled: freezed == disabled
+          ? _self.disabled
+          : disabled // ignore: cast_nullable_to_non_nullable
+              as bool?,
+    ));
+  }
+}
+
+/// @nodoc
+mixin _$PostmanAuth {
+  String? get type;
+  List<AuthKeyValue>? get bearer;
+  List<AuthKeyValue>? get basic;
+  List<AuthKeyValue>? get apikey;
+
+  /// Create a copy of PostmanAuth
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $PostmanAuthCopyWith<PostmanAuth> get copyWith =>
+      _$PostmanAuthCopyWithImpl<PostmanAuth>(this as PostmanAuth, _$identity);
+
+  /// Serializes this PostmanAuth to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is PostmanAuth &&
+            (identical(other.type, type) || other.type == type) &&
+            const DeepCollectionEquality().equals(other.bearer, bearer) &&
+            const DeepCollectionEquality().equals(other.basic, basic) &&
+            const DeepCollectionEquality().equals(other.apikey, apikey));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      type,
+      const DeepCollectionEquality().hash(bearer),
+      const DeepCollectionEquality().hash(basic),
+      const DeepCollectionEquality().hash(apikey));
+
+  @override
+  String toString() {
+    return 'PostmanAuth(type: $type, bearer: $bearer, basic: $basic, apikey: $apikey)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $PostmanAuthCopyWith<$Res> {
+  factory $PostmanAuthCopyWith(
+          PostmanAuth value, $Res Function(PostmanAuth) _then) =
+      _$PostmanAuthCopyWithImpl;
+  @useResult
+  $Res call(
+      {String? type,
+      List<AuthKeyValue>? bearer,
+      List<AuthKeyValue>? basic,
+      List<AuthKeyValue>? apikey});
+}
+
+/// @nodoc
+class _$PostmanAuthCopyWithImpl<$Res> implements $PostmanAuthCopyWith<$Res> {
+  _$PostmanAuthCopyWithImpl(this._self, this._then);
+
+  final PostmanAuth _self;
+  final $Res Function(PostmanAuth) _then;
+
+  /// Create a copy of PostmanAuth
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? type = freezed,
+    Object? bearer = freezed,
+    Object? basic = freezed,
+    Object? apikey = freezed,
+  }) {
+    return _then(_self.copyWith(
+      type: freezed == type
+          ? _self.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String?,
+      bearer: freezed == bearer
+          ? _self.bearer
+          : bearer // ignore: cast_nullable_to_non_nullable
+              as List<AuthKeyValue>?,
+      basic: freezed == basic
+          ? _self.basic
+          : basic // ignore: cast_nullable_to_non_nullable
+              as List<AuthKeyValue>?,
+      apikey: freezed == apikey
+          ? _self.apikey
+          : apikey // ignore: cast_nullable_to_non_nullable
+              as List<AuthKeyValue>?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [PostmanAuth].
+extension PostmanAuthPatterns on PostmanAuth {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_PostmanAuth value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _PostmanAuth() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_PostmanAuth value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _PostmanAuth():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_PostmanAuth value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _PostmanAuth() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String? type, List<AuthKeyValue>? bearer,
+            List<AuthKeyValue>? basic, List<AuthKeyValue>? apikey)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _PostmanAuth() when $default != null:
+        return $default(_that.type, _that.bearer, _that.basic, _that.apikey);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String? type, List<AuthKeyValue>? bearer,
+            List<AuthKeyValue>? basic, List<AuthKeyValue>? apikey)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _PostmanAuth():
+        return $default(_that.type, _that.bearer, _that.basic, _that.apikey);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String? type, List<AuthKeyValue>? bearer,
+            List<AuthKeyValue>? basic, List<AuthKeyValue>? apikey)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _PostmanAuth() when $default != null:
+        return $default(_that.type, _that.bearer, _that.basic, _that.apikey);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+@JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
+class _PostmanAuth implements PostmanAuth {
+  const _PostmanAuth(
+      {this.type,
+      final List<AuthKeyValue>? bearer,
+      final List<AuthKeyValue>? basic,
+      final List<AuthKeyValue>? apikey})
+      : _bearer = bearer,
+        _basic = basic,
+        _apikey = apikey;
+  factory _PostmanAuth.fromJson(Map<String, dynamic> json) =>
+      _$PostmanAuthFromJson(json);
+
+  @override
+  final String? type;
+  final List<AuthKeyValue>? _bearer;
+  @override
+  List<AuthKeyValue>? get bearer {
+    final value = _bearer;
+    if (value == null) return null;
+    if (_bearer is EqualUnmodifiableListView) return _bearer;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  final List<AuthKeyValue>? _basic;
+  @override
+  List<AuthKeyValue>? get basic {
+    final value = _basic;
+    if (value == null) return null;
+    if (_basic is EqualUnmodifiableListView) return _basic;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  final List<AuthKeyValue>? _apikey;
+  @override
+  List<AuthKeyValue>? get apikey {
+    final value = _apikey;
+    if (value == null) return null;
+    if (_apikey is EqualUnmodifiableListView) return _apikey;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  /// Create a copy of PostmanAuth
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$PostmanAuthCopyWith<_PostmanAuth> get copyWith =>
+      __$PostmanAuthCopyWithImpl<_PostmanAuth>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$PostmanAuthToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _PostmanAuth &&
+            (identical(other.type, type) || other.type == type) &&
+            const DeepCollectionEquality().equals(other._bearer, _bearer) &&
+            const DeepCollectionEquality().equals(other._basic, _basic) &&
+            const DeepCollectionEquality().equals(other._apikey, _apikey));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      type,
+      const DeepCollectionEquality().hash(_bearer),
+      const DeepCollectionEquality().hash(_basic),
+      const DeepCollectionEquality().hash(_apikey));
+
+  @override
+  String toString() {
+    return 'PostmanAuth(type: $type, bearer: $bearer, basic: $basic, apikey: $apikey)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$PostmanAuthCopyWith<$Res>
+    implements $PostmanAuthCopyWith<$Res> {
+  factory _$PostmanAuthCopyWith(
+          _PostmanAuth value, $Res Function(_PostmanAuth) _then) =
+      __$PostmanAuthCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String? type,
+      List<AuthKeyValue>? bearer,
+      List<AuthKeyValue>? basic,
+      List<AuthKeyValue>? apikey});
+}
+
+/// @nodoc
+class __$PostmanAuthCopyWithImpl<$Res> implements _$PostmanAuthCopyWith<$Res> {
+  __$PostmanAuthCopyWithImpl(this._self, this._then);
+
+  final _PostmanAuth _self;
+  final $Res Function(_PostmanAuth) _then;
+
+  /// Create a copy of PostmanAuth
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? type = freezed,
+    Object? bearer = freezed,
+    Object? basic = freezed,
+    Object? apikey = freezed,
+  }) {
+    return _then(_PostmanAuth(
+      type: freezed == type
+          ? _self.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String?,
+      bearer: freezed == bearer
+          ? _self._bearer
+          : bearer // ignore: cast_nullable_to_non_nullable
+              as List<AuthKeyValue>?,
+      basic: freezed == basic
+          ? _self._basic
+          : basic // ignore: cast_nullable_to_non_nullable
+              as List<AuthKeyValue>?,
+      apikey: freezed == apikey
+          ? _self._apikey
+          : apikey // ignore: cast_nullable_to_non_nullable
+              as List<AuthKeyValue>?,
+    ));
+  }
+}
+
+/// @nodoc
+mixin _$AuthKeyValue {
+  String? get key;
+  String? get value;
+  String? get type;
+
+  /// Create a copy of AuthKeyValue
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $AuthKeyValueCopyWith<AuthKeyValue> get copyWith =>
+      _$AuthKeyValueCopyWithImpl<AuthKeyValue>(
+          this as AuthKeyValue, _$identity);
+
+  /// Serializes this AuthKeyValue to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is AuthKeyValue &&
+            (identical(other.key, key) || other.key == key) &&
+            (identical(other.value, value) || other.value == value) &&
+            (identical(other.type, type) || other.type == type));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, key, value, type);
+
+  @override
+  String toString() {
+    return 'AuthKeyValue(key: $key, value: $value, type: $type)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $AuthKeyValueCopyWith<$Res> {
+  factory $AuthKeyValueCopyWith(
+          AuthKeyValue value, $Res Function(AuthKeyValue) _then) =
+      _$AuthKeyValueCopyWithImpl;
+  @useResult
+  $Res call({String? key, String? value, String? type});
+}
+
+/// @nodoc
+class _$AuthKeyValueCopyWithImpl<$Res> implements $AuthKeyValueCopyWith<$Res> {
+  _$AuthKeyValueCopyWithImpl(this._self, this._then);
+
+  final AuthKeyValue _self;
+  final $Res Function(AuthKeyValue) _then;
+
+  /// Create a copy of AuthKeyValue
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? key = freezed,
+    Object? value = freezed,
+    Object? type = freezed,
+  }) {
+    return _then(_self.copyWith(
+      key: freezed == key
+          ? _self.key
+          : key // ignore: cast_nullable_to_non_nullable
+              as String?,
+      value: freezed == value
+          ? _self.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as String?,
+      type: freezed == type
+          ? _self.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [AuthKeyValue].
+extension AuthKeyValuePatterns on AuthKeyValue {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_AuthKeyValue value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _AuthKeyValue() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_AuthKeyValue value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthKeyValue():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_AuthKeyValue value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthKeyValue() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String? key, String? value, String? type)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _AuthKeyValue() when $default != null:
+        return $default(_that.key, _that.value, _that.type);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String? key, String? value, String? type) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthKeyValue():
+        return $default(_that.key, _that.value, _that.type);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String? key, String? value, String? type)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _AuthKeyValue() when $default != null:
+        return $default(_that.key, _that.value, _that.type);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+@JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
+class _AuthKeyValue implements AuthKeyValue {
+  const _AuthKeyValue({this.key, this.value, this.type});
+  factory _AuthKeyValue.fromJson(Map<String, dynamic> json) =>
+      _$AuthKeyValueFromJson(json);
+
+  @override
+  final String? key;
+  @override
+  final String? value;
+  @override
+  final String? type;
+
+  /// Create a copy of AuthKeyValue
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$AuthKeyValueCopyWith<_AuthKeyValue> get copyWith =>
+      __$AuthKeyValueCopyWithImpl<_AuthKeyValue>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$AuthKeyValueToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _AuthKeyValue &&
+            (identical(other.key, key) || other.key == key) &&
+            (identical(other.value, value) || other.value == value) &&
+            (identical(other.type, type) || other.type == type));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, key, value, type);
+
+  @override
+  String toString() {
+    return 'AuthKeyValue(key: $key, value: $value, type: $type)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$AuthKeyValueCopyWith<$Res>
+    implements $AuthKeyValueCopyWith<$Res> {
+  factory _$AuthKeyValueCopyWith(
+          _AuthKeyValue value, $Res Function(_AuthKeyValue) _then) =
+      __$AuthKeyValueCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String? key, String? value, String? type});
+}
+
+/// @nodoc
+class __$AuthKeyValueCopyWithImpl<$Res>
+    implements _$AuthKeyValueCopyWith<$Res> {
+  __$AuthKeyValueCopyWithImpl(this._self, this._then);
+
+  final _AuthKeyValue _self;
+  final $Res Function(_AuthKeyValue) _then;
+
+  /// Create a copy of AuthKeyValue
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? key = freezed,
+    Object? value = freezed,
+    Object? type = freezed,
+  }) {
+    return _then(_AuthKeyValue(
+      key: freezed == key
+          ? _self.key
+          : key // ignore: cast_nullable_to_non_nullable
+              as String?,
+      value: freezed == value
+          ? _self.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as String?,
+      type: freezed == type
+          ? _self.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+mixin _$Variable {
+  String? get key;
+  String? get value;
+  String? get type;
+
+  /// Create a copy of Variable
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $VariableCopyWith<Variable> get copyWith =>
+      _$VariableCopyWithImpl<Variable>(this as Variable, _$identity);
+
+  /// Serializes this Variable to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Variable &&
+            (identical(other.key, key) || other.key == key) &&
+            (identical(other.value, value) || other.value == value) &&
+            (identical(other.type, type) || other.type == type));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, key, value, type);
+
+  @override
+  String toString() {
+    return 'Variable(key: $key, value: $value, type: $type)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $VariableCopyWith<$Res> {
+  factory $VariableCopyWith(Variable value, $Res Function(Variable) _then) =
+      _$VariableCopyWithImpl;
+  @useResult
+  $Res call({String? key, String? value, String? type});
+}
+
+/// @nodoc
+class _$VariableCopyWithImpl<$Res> implements $VariableCopyWith<$Res> {
+  _$VariableCopyWithImpl(this._self, this._then);
+
+  final Variable _self;
+  final $Res Function(Variable) _then;
+
+  /// Create a copy of Variable
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? key = freezed,
+    Object? value = freezed,
+    Object? type = freezed,
+  }) {
+    return _then(_self.copyWith(
+      key: freezed == key
+          ? _self.key
+          : key // ignore: cast_nullable_to_non_nullable
+              as String?,
+      value: freezed == value
+          ? _self.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as String?,
+      type: freezed == type
+          ? _self.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [Variable].
+extension VariablePatterns on Variable {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_Variable value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Variable() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_Variable value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Variable():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_Variable value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Variable() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String? key, String? value, String? type)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _Variable() when $default != null:
+        return $default(_that.key, _that.value, _that.type);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String? key, String? value, String? type) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Variable():
+        return $default(_that.key, _that.value, _that.type);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String? key, String? value, String? type)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _Variable() when $default != null:
+        return $default(_that.key, _that.value, _that.type);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+@JsonSerializable(explicitToJson: true, anyMap: true, includeIfNull: false)
+class _Variable implements Variable {
+  const _Variable({this.key, this.value, this.type});
+  factory _Variable.fromJson(Map<String, dynamic> json) =>
+      _$VariableFromJson(json);
+
+  @override
+  final String? key;
+  @override
+  final String? value;
+  @override
+  final String? type;
+
+  /// Create a copy of Variable
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$VariableCopyWith<_Variable> get copyWith =>
+      __$VariableCopyWithImpl<_Variable>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$VariableToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Variable &&
+            (identical(other.key, key) || other.key == key) &&
+            (identical(other.value, value) || other.value == value) &&
+            (identical(other.type, type) || other.type == type));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, key, value, type);
+
+  @override
+  String toString() {
+    return 'Variable(key: $key, value: $value, type: $type)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$VariableCopyWith<$Res>
+    implements $VariableCopyWith<$Res> {
+  factory _$VariableCopyWith(_Variable value, $Res Function(_Variable) _then) =
+      __$VariableCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String? key, String? value, String? type});
+}
+
+/// @nodoc
+class __$VariableCopyWithImpl<$Res> implements _$VariableCopyWith<$Res> {
+  __$VariableCopyWithImpl(this._self, this._then);
+
+  final _Variable _self;
+  final $Res Function(_Variable) _then;
+
+  /// Create a copy of Variable
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? key = freezed,
+    Object? value = freezed,
+    Object? type = freezed,
+  }) {
+    return _then(_Variable(
+      key: freezed == key
+          ? _self.key
+          : key // ignore: cast_nullable_to_non_nullable
+              as String?,
+      value: freezed == value
+          ? _self.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as String?,
+      type: freezed == type
+          ? _self.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+// dart format on

--- a/packages/postman/lib/models/postman_collection.g.dart
+++ b/packages/postman/lib/models/postman_collection.g.dart
@@ -6,40 +6,42 @@ part of 'postman_collection.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$PostmanCollectionImpl _$$PostmanCollectionImplFromJson(Map json) =>
-    _$PostmanCollectionImpl(
+_PostmanCollection _$PostmanCollectionFromJson(Map json) => _PostmanCollection(
       info: json['info'] == null
           ? null
           : Info.fromJson(Map<String, dynamic>.from(json['info'] as Map)),
       item: (json['item'] as List<dynamic>?)
           ?.map((e) => Item.fromJson(Map<String, dynamic>.from(e as Map)))
           .toList(),
+      variable: (json['variable'] as List<dynamic>?)
+          ?.map((e) => Variable.fromJson(Map<String, dynamic>.from(e as Map)))
+          .toList(),
     );
 
-Map<String, dynamic> _$$PostmanCollectionImplToJson(
-        _$PostmanCollectionImpl instance) =>
+Map<String, dynamic> _$PostmanCollectionToJson(_PostmanCollection instance) =>
     <String, dynamic>{
       if (instance.info?.toJson() case final value?) 'info': value,
       if (instance.item?.map((e) => e.toJson()).toList() case final value?)
         'item': value,
+      if (instance.variable?.map((e) => e.toJson()).toList() case final value?)
+        'variable': value,
     };
 
-_$InfoImpl _$$InfoImplFromJson(Map json) => _$InfoImpl(
+_Info _$InfoFromJson(Map json) => _Info(
       postmanId: json['_postman_id'] as String?,
       name: json['name'] as String?,
       schema: json['schema'] as String?,
       exporterId: json['_exporter_id'] as String?,
     );
 
-Map<String, dynamic> _$$InfoImplToJson(_$InfoImpl instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$InfoToJson(_Info instance) => <String, dynamic>{
       if (instance.postmanId case final value?) '_postman_id': value,
       if (instance.name case final value?) 'name': value,
       if (instance.schema case final value?) 'schema': value,
       if (instance.exporterId case final value?) '_exporter_id': value,
     };
 
-_$ItemImpl _$$ItemImplFromJson(Map json) => _$ItemImpl(
+_Item _$ItemFromJson(Map json) => _Item(
       name: json['name'] as String?,
       item: (json['item'] as List<dynamic>?)
           ?.map((e) => Item.fromJson(Map<String, dynamic>.from(e as Map)))
@@ -50,8 +52,7 @@ _$ItemImpl _$$ItemImplFromJson(Map json) => _$ItemImpl(
       response: json['response'] as List<dynamic>?,
     );
 
-Map<String, dynamic> _$$ItemImplToJson(_$ItemImpl instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$ItemToJson(_Item instance) => <String, dynamic>{
       if (instance.name case final value?) 'name': value,
       if (instance.item?.map((e) => e.toJson()).toList() case final value?)
         'item': value,
@@ -59,7 +60,7 @@ Map<String, dynamic> _$$ItemImplToJson(_$ItemImpl instance) =>
       if (instance.response case final value?) 'response': value,
     };
 
-_$RequestImpl _$$RequestImplFromJson(Map json) => _$RequestImpl(
+_Request _$RequestFromJson(Map json) => _Request(
       method: json['method'] as String?,
       header: (json['header'] as List<dynamic>?)
           ?.map((e) => Header.fromJson(Map<String, dynamic>.from(e as Map)))
@@ -70,33 +71,36 @@ _$RequestImpl _$$RequestImplFromJson(Map json) => _$RequestImpl(
       url: json['url'] == null
           ? null
           : Url.fromJson(Map<String, dynamic>.from(json['url'] as Map)),
+      auth: json['auth'] == null
+          ? null
+          : PostmanAuth.fromJson(
+              Map<String, dynamic>.from(json['auth'] as Map)),
     );
 
-Map<String, dynamic> _$$RequestImplToJson(_$RequestImpl instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$RequestToJson(_Request instance) => <String, dynamic>{
       if (instance.method case final value?) 'method': value,
       if (instance.header?.map((e) => e.toJson()).toList() case final value?)
         'header': value,
       if (instance.body?.toJson() case final value?) 'body': value,
       if (instance.url?.toJson() case final value?) 'url': value,
+      if (instance.auth?.toJson() case final value?) 'auth': value,
     };
 
-_$HeaderImpl _$$HeaderImplFromJson(Map json) => _$HeaderImpl(
+_Header _$HeaderFromJson(Map json) => _Header(
       key: json['key'] as String?,
       value: json['value'] as String?,
       type: json['type'] as String?,
       disabled: json['disabled'] as bool?,
     );
 
-Map<String, dynamic> _$$HeaderImplToJson(_$HeaderImpl instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$HeaderToJson(_Header instance) => <String, dynamic>{
       if (instance.key case final value?) 'key': value,
       if (instance.value case final value?) 'value': value,
       if (instance.type case final value?) 'type': value,
       if (instance.disabled case final value?) 'disabled': value,
     };
 
-_$UrlImpl _$$UrlImplFromJson(Map json) => _$UrlImpl(
+_Url _$UrlFromJson(Map json) => _Url(
       raw: json['raw'] as String?,
       protocol: json['protocol'] as String?,
       host: (json['host'] as List<dynamic>?)?.map((e) => e as String).toList(),
@@ -106,7 +110,7 @@ _$UrlImpl _$$UrlImplFromJson(Map json) => _$UrlImpl(
           .toList(),
     );
 
-Map<String, dynamic> _$$UrlImplToJson(_$UrlImpl instance) => <String, dynamic>{
+Map<String, dynamic> _$UrlToJson(_Url instance) => <String, dynamic>{
       if (instance.raw case final value?) 'raw': value,
       if (instance.protocol case final value?) 'protocol': value,
       if (instance.host case final value?) 'host': value,
@@ -115,20 +119,19 @@ Map<String, dynamic> _$$UrlImplToJson(_$UrlImpl instance) => <String, dynamic>{
         'query': value,
     };
 
-_$QueryImpl _$$QueryImplFromJson(Map json) => _$QueryImpl(
+_Query _$QueryFromJson(Map json) => _Query(
       key: json['key'] as String?,
       value: json['value'] as String?,
       disabled: json['disabled'] as bool?,
     );
 
-Map<String, dynamic> _$$QueryImplToJson(_$QueryImpl instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$QueryToJson(_Query instance) => <String, dynamic>{
       if (instance.key case final value?) 'key': value,
       if (instance.value case final value?) 'value': value,
       if (instance.disabled case final value?) 'disabled': value,
     };
 
-_$BodyImpl _$$BodyImplFromJson(Map json) => _$BodyImpl(
+_Body _$BodyFromJson(Map json) => _Body(
       mode: json['mode'] as String?,
       raw: json['raw'] as String?,
       options: json['options'] == null
@@ -137,47 +140,118 @@ _$BodyImpl _$$BodyImplFromJson(Map json) => _$BodyImpl(
       formdata: (json['formdata'] as List<dynamic>?)
           ?.map((e) => Formdatum.fromJson(Map<String, dynamic>.from(e as Map)))
           .toList(),
+      urlencoded: (json['urlencoded'] as List<dynamic>?)
+          ?.map((e) => Urlencoded.fromJson(Map<String, dynamic>.from(e as Map)))
+          .toList(),
     );
 
-Map<String, dynamic> _$$BodyImplToJson(_$BodyImpl instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$BodyToJson(_Body instance) => <String, dynamic>{
       if (instance.mode case final value?) 'mode': value,
       if (instance.raw case final value?) 'raw': value,
       if (instance.options?.toJson() case final value?) 'options': value,
       if (instance.formdata?.map((e) => e.toJson()).toList() case final value?)
         'formdata': value,
+      if (instance.urlencoded?.map((e) => e.toJson()).toList()
+          case final value?)
+        'urlencoded': value,
     };
 
-_$OptionsImpl _$$OptionsImplFromJson(Map json) => _$OptionsImpl(
+_Options _$OptionsFromJson(Map json) => _Options(
       raw: json['raw'] == null
           ? null
           : Raw.fromJson(Map<String, dynamic>.from(json['raw'] as Map)),
     );
 
-Map<String, dynamic> _$$OptionsImplToJson(_$OptionsImpl instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$OptionsToJson(_Options instance) => <String, dynamic>{
       if (instance.raw?.toJson() case final value?) 'raw': value,
     };
 
-_$RawImpl _$$RawImplFromJson(Map json) => _$RawImpl(
+_Raw _$RawFromJson(Map json) => _Raw(
       language: json['language'] as String?,
     );
 
-Map<String, dynamic> _$$RawImplToJson(_$RawImpl instance) => <String, dynamic>{
+Map<String, dynamic> _$RawToJson(_Raw instance) => <String, dynamic>{
       if (instance.language case final value?) 'language': value,
     };
 
-_$FormdatumImpl _$$FormdatumImplFromJson(Map json) => _$FormdatumImpl(
+_Formdatum _$FormdatumFromJson(Map json) => _Formdatum(
       key: json['key'] as String?,
       value: json['value'] as String?,
       type: json['type'] as String?,
       src: json['src'] as String?,
     );
 
-Map<String, dynamic> _$$FormdatumImplToJson(_$FormdatumImpl instance) =>
+Map<String, dynamic> _$FormdatumToJson(_Formdatum instance) =>
     <String, dynamic>{
       if (instance.key case final value?) 'key': value,
       if (instance.value case final value?) 'value': value,
       if (instance.type case final value?) 'type': value,
       if (instance.src case final value?) 'src': value,
+    };
+
+_Urlencoded _$UrlencodedFromJson(Map json) => _Urlencoded(
+      key: json['key'] as String?,
+      value: json['value'] as String?,
+      type: json['type'] as String?,
+      disabled: json['disabled'] as bool?,
+    );
+
+Map<String, dynamic> _$UrlencodedToJson(_Urlencoded instance) =>
+    <String, dynamic>{
+      if (instance.key case final value?) 'key': value,
+      if (instance.value case final value?) 'value': value,
+      if (instance.type case final value?) 'type': value,
+      if (instance.disabled case final value?) 'disabled': value,
+    };
+
+_PostmanAuth _$PostmanAuthFromJson(Map json) => _PostmanAuth(
+      type: json['type'] as String?,
+      bearer: (json['bearer'] as List<dynamic>?)
+          ?.map(
+              (e) => AuthKeyValue.fromJson(Map<String, dynamic>.from(e as Map)))
+          .toList(),
+      basic: (json['basic'] as List<dynamic>?)
+          ?.map(
+              (e) => AuthKeyValue.fromJson(Map<String, dynamic>.from(e as Map)))
+          .toList(),
+      apikey: (json['apikey'] as List<dynamic>?)
+          ?.map(
+              (e) => AuthKeyValue.fromJson(Map<String, dynamic>.from(e as Map)))
+          .toList(),
+    );
+
+Map<String, dynamic> _$PostmanAuthToJson(_PostmanAuth instance) =>
+    <String, dynamic>{
+      if (instance.type case final value?) 'type': value,
+      if (instance.bearer?.map((e) => e.toJson()).toList() case final value?)
+        'bearer': value,
+      if (instance.basic?.map((e) => e.toJson()).toList() case final value?)
+        'basic': value,
+      if (instance.apikey?.map((e) => e.toJson()).toList() case final value?)
+        'apikey': value,
+    };
+
+_AuthKeyValue _$AuthKeyValueFromJson(Map json) => _AuthKeyValue(
+      key: json['key'] as String?,
+      value: json['value'] as String?,
+      type: json['type'] as String?,
+    );
+
+Map<String, dynamic> _$AuthKeyValueToJson(_AuthKeyValue instance) =>
+    <String, dynamic>{
+      if (instance.key case final value?) 'key': value,
+      if (instance.value case final value?) 'value': value,
+      if (instance.type case final value?) 'type': value,
+    };
+
+_Variable _$VariableFromJson(Map json) => _Variable(
+      key: json['key'] as String?,
+      value: json['value'] as String?,
+      type: json['type'] as String?,
+    );
+
+Map<String, dynamic> _$VariableToJson(_Variable instance) => <String, dynamic>{
+      if (instance.key case final value?) 'key': value,
+      if (instance.value case final value?) 'value': value,
+      if (instance.type case final value?) 'type': value,
     };

--- a/packages/postman/lib/utils/postman_utils.dart
+++ b/packages/postman/lib/utils/postman_utils.dart
@@ -1,5 +1,30 @@
 import '../models/postman_collection.dart';
 
+String substituteVariables(String input, Map<String, String> variables) {
+  return input.replaceAllMapped(RegExp(r'\{\{([^{}]+)\}\}'), (match) {
+    final key = match.group(1)?.trim();
+    if (key == null || key.isEmpty) {
+      return match.group(0) ?? '';
+    }
+    return variables[key] ?? (match.group(0) ?? '');
+  });
+}
+
+Map<String, String> buildVariableMap(List<Variable>? variables) {
+  if (variables == null) {
+    return {};
+  }
+  final map = <String, String>{};
+  for (final variable in variables) {
+    final key = variable.key;
+    if (key == null || key.isEmpty) {
+      continue;
+    }
+    map[key] = variable.value ?? '';
+  }
+  return map;
+}
+
 List<(String?, Request)> getRequestsFromPostmanCollection(
     PostmanCollection? pc) {
   if (pc == null || pc.item == null) {

--- a/packages/postman/test/postman_test.dart
+++ b/packages/postman/test/postman_test.dart
@@ -24,5 +24,103 @@ void main() {
     test('API Dash Postman collection to Json', () {
       expect(collectionApiDashModel.toJson(), collectionApiDashJson);
     });
+
+    test('Postman collection parses variables, auth, and urlencoded body', () {
+      const jsonStr = r'''
+{
+  "info": {
+    "name": "Auth + Variables",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "https://api.example.com",
+      "type": "string"
+    }
+  ],
+  "item": [
+    {
+      "name": "Token",
+      "request": {
+        "method": "POST",
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{token}}",
+              "type": "string"
+            }
+          ]
+        },
+        "body": {
+          "mode": "urlencoded",
+          "urlencoded": [
+            {
+              "key": "grant_type",
+              "value": "client_credentials",
+              "type": "text"
+            }
+          ]
+        },
+        "url": {
+          "raw": "{{base_url}}/oauth/token"
+        }
+      }
+    }
+  ]
+}
+''';
+
+      final collection = postmanCollectionFromJsonStr(jsonStr);
+      final request = collection.item!.first.request!;
+
+      expect(collection.variable, isNotNull);
+      expect(collection.variable!.first.key, 'base_url');
+      expect(request.auth, isNotNull);
+      expect(request.auth!.type, 'bearer');
+      expect(request.body?.mode, 'urlencoded');
+      expect(request.body?.urlencoded, isNotNull);
+      expect(request.body?.urlencoded?.first.key, 'grant_type');
+    });
+
+    test('Postman collection keeps new fields in round-trip serialization', () {
+      final collection = PostmanCollection(
+        info: const Info(name: 'Roundtrip'),
+        variable: const [
+          Variable(key: 'base_url', value: 'https://api.example.com')
+        ],
+        item: const [
+          Item(
+            name: 'With auth',
+            request: Request(
+              method: 'GET',
+              auth: PostmanAuth(
+                type: 'apikey',
+                apikey: [
+                  AuthKeyValue(key: 'key', value: 'x-api-key'),
+                  AuthKeyValue(key: 'value', value: '{{api_key}}'),
+                  AuthKeyValue(key: 'in', value: 'header'),
+                ],
+              ),
+              body: Body(
+                mode: 'urlencoded',
+                urlencoded: [
+                  Urlencoded(
+                      key: 'client_id', value: '{{client_id}}', type: 'text'),
+                ],
+              ),
+              url: Url(raw: '{{base_url}}/v1/items'),
+            ),
+          ),
+        ],
+      );
+
+      final serialized = postmanCollectionToJsonStr(collection);
+      final parsed = postmanCollectionFromJsonStr(serialized);
+
+      expect(parsed, collection);
+    });
   });
 }


### PR DESCRIPTION
## PR Description

This PR contains two sets of improvements:

1. Fixes RenderFlex overflow in the AI Model Selector dialog on Android/smaller viewports.
- Added height constraints and scroll-safe behavior for dialog content.
- Kept the existing UI structure and interaction flow intact.

2. Enhances Postman v2.1 importer support.
- Added auth mapping support (Bearer, Basic, API Key).
- Added `urlencoded` body mode import handling.
- Added collection variable substitution in URL/headers/body values.
- Added coverage with importer and serialization tests.

---

### POC (Screenshots)

The following screenshots are included for visual proof:
1. Responsive view (1280x800): main app layout renders correctly with no overflow.
<img width="1664" height="1209" alt="ai-dialog-big" src="https://github.com/user-attachments/assets/91dd78fc-6ab5-422a-beb1-d9bd865c50b8" />

###

2. Responsive view (768x1024): medium viewport layout remains stable and usable.
<img width="1116" height="1406" alt="ai-dialog-mid" src="https://github.com/user-attachments/assets/3fbca3f7-78fe-4609-bcd2-fd2f3d2ec900" />


###

3. AI Model Selector dialog: dialog content is fully visible/scrollable, no RenderFlex overflow stripes.
<img width="2240" height="1387" alt="console-proof" src="https://github.com/user-attachments/assets/c1d05b79-addd-4127-9438-67d70ef4be62" />


###

4. Imported request (Bearer + variable URL):
   - Auth tab shows Bearer Token populated (`bearer-123`).
   - URL resolved from variable to `https://api.example.com/v1/data`. 
<img width="1665" height="1387" alt="importer-bearer" src="https://github.com/user-attachments/assets/af0f0f94-f888-454b-9a90-8d5c9017b55b" />


###

5. Imported request (API Key + urlencoded):
   - Auth tab shows API Key mapping (`X-API-Key`, `top-secret`, Header).
   - URL resolved to `https://api.example.com/oauth/token`.
<img width="1671" height="1401" alt="importer-basic" src="https://github.com/user-attachments/assets/20a31da9-53c7-4089-9f06-d60f5632c50e" />



---

## Related Issues

- Closes #1330
- Addresses Postman importer gap for auth/urlencoded/variables in this branch

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [ ] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [x] Yes
- Added importer tests for auth mapping (Bearer/Basic/API Key), `urlencoded` body parsing, and collection variable substitution.
- Added/updated UI coverage to validate the AI Model Selector dialog behaves correctly on smaller viewports without overflow.
- [ ] No

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux
