### PR TITLE
docs: Add macOS sandbox troubleshooting note for local development

### DIFF
--- a/doc/dev_guide/setup_run.md
+++ b/doc/dev_guide/setup_run.md
@@ -44,3 +44,8 @@ flutter pub get
 ```
 flutter run
 ```
+### Troubleshooting
+
+**macOS Local Development:**
+If you are compiling locally on an Apple Silicon Mac and the file-picker freezes when attempting to select a workspace, it is due to Apple's App Sandbox blocking local file access in debug mode. 
+To fix this, go to `macos/Runner/DebugProfile.entitlements` and change `<key>com.apple.security.app-sandbox</key>` to `<false/>` before running the app.


### PR DESCRIPTION
While setting up my local environment for GSoC on an Apple Silicon Mac, the app froze during workspace selection due to default Apple App Sandbox entitlements blocking file access. I added a quick troubleshooting note to setup_run.md to save future macOS contributors some debugging time!