### PR TITLE
fix(design-system): implement missing ADListTile checkbox/button variants

### DIFF
--- a/packages/apidash_design_system/lib/widgets/list_tile.dart
+++ b/packages/apidash_design_system/lib/widgets/list_tile.dart
@@ -27,16 +27,25 @@ class ADListTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return switch (type) {
       ListTileType.switchOnOff => SwitchListTile(
-          hoverColor: hoverColor,
-          title: Text(title),
-          subtitle: subtitle == null ? null : Text(subtitle ?? ''),
-          value: value ?? false,
-          onChanged: onChanged,
-        ),
-      // TODO: Handle this case.
-      ListTileType.checkbox => throw UnimplementedError(),
-      // TODO: Handle this case.
-      ListTileType.button => throw UnimplementedError(),
+        hoverColor: hoverColor,
+        title: Text(title),
+        subtitle: subtitle == null ? null : Text(subtitle ?? ''),
+        value: value ?? false,
+        onChanged: onChanged,
+      ),
+      ListTileType.checkbox => CheckboxListTile(
+        hoverColor: hoverColor,
+        title: Text(title),
+        subtitle: subtitle == null ? null : Text(subtitle ?? ''),
+        value: value ?? false,
+        onChanged: onChanged,
+      ),
+      ListTileType.button => ListTile(
+        hoverColor: hoverColor,
+        title: Text(title),
+        subtitle: subtitle == null ? null : Text(subtitle ?? ''),
+        onTap: () => onChanged?.call(value),
+      ),
     };
   }
 }

--- a/packages/apidash_design_system/test/widgets/list_tile_test.dart
+++ b/packages/apidash_design_system/test/widgets/list_tile_test.dart
@@ -1,0 +1,91 @@
+﻿import 'package:apidash_design_system/widgets/list_tile.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Widget wrap(Widget child) {
+    return MaterialApp(
+      home: Scaffold(body: child),
+    );
+  }
+
+  group('ADListTile', () {
+    testWidgets('renders switchOnOff and triggers callback',
+            (WidgetTester tester) async {
+          bool? changedValue;
+
+          await tester.pumpWidget(
+            wrap(
+              ADListTile(
+                type: ListTileType.switchOnOff,
+                title: 'Switch Tile',
+                value: false,
+                onChanged: (value) {
+                  changedValue = value;
+                },
+              ),
+            ),
+          );
+
+          expect(find.text('Switch Tile'), findsOneWidget);
+          expect(find.byType(SwitchListTile), findsOneWidget);
+
+          await tester.tap(find.byType(Switch));
+          await tester.pumpAndSettle();
+
+          expect(changedValue, isNotNull);
+        });
+
+    testWidgets('renders checkbox and triggers callback',
+            (WidgetTester tester) async {
+          bool? changedValue;
+
+          await tester.pumpWidget(
+            wrap(
+              ADListTile(
+                type: ListTileType.checkbox,
+                title: 'Checkbox Tile',
+                value: false,
+                onChanged: (value) {
+                  changedValue = value;
+                },
+              ),
+            ),
+          );
+
+          expect(find.text('Checkbox Tile'), findsOneWidget);
+          expect(find.byType(CheckboxListTile), findsOneWidget);
+
+          await tester.tap(find.byType(Checkbox));
+          await tester.pumpAndSettle();
+
+          expect(changedValue, isNotNull);
+        });
+
+    testWidgets('renders button and triggers callback on tap',
+            (WidgetTester tester) async {
+          bool? changedValue;
+
+          await tester.pumpWidget(
+            wrap(
+              ADListTile(
+                type: ListTileType.button,
+                title: 'Button Tile',
+                value: true,
+                onChanged: (value) {
+                  changedValue = value;
+                },
+              ),
+            ),
+          );
+
+          expect(find.text('Button Tile'), findsOneWidget);
+          expect(find.byType(ListTile), findsOneWidget);
+
+          await tester.tap(find.byType(ListTile));
+          await tester.pumpAndSettle();
+
+          expect(changedValue, true);
+        });
+  });
+}


### PR DESCRIPTION
## Summary

Implements the missing `checkbox` and `button` variants in `ADListTile` without changing the public API.

## Changes made

* implemented `ListTileType.checkbox` using `CheckboxListTile`
* implemented `ListTileType.button` using `ListTile` and `onChanged?.call(value)` on tap
* added widget tests for all 3 modes:

  * `switchOnOff`
  * `checkbox`
  * `button`

## Validation

* `flutter test packages/apidash_design_system/test/widgets/list_tile_test.dart`
* `flutter analyze packages/apidash_design_system`

Note: `flutter analyze packages/apidash_design_system` reports one existing info-level lint in `packages/apidash_design_system/lib/apidash_design_system.dart`:
`unnecessary_library_name`

Closes #1435