### PR TITLE
fix: resolve null check crash on AI request search (#1276)

### DIFF
--- a/lib/screens/home_page/collection_pane.dart
+++ b/lib/screens/home_page/collection_pane.dart
@@ -146,9 +146,10 @@ class _RequestListState extends ConsumerState<RequestList> {
               controller: controller,
               children: requestSequence.map((id) {
                 var item = requestItems[id]!;
-                if (item.httpRequestModel!.url.toLowerCase().contains(
-                      filterQuery,
-                    ) ||
+                if ((item.httpRequestModel?.url.toLowerCase().contains(
+                          filterQuery,
+                        ) ??
+                        false) ||
                     item.name.toLowerCase().contains(filterQuery)) {
                   return Padding(
                     padding: kP1,


### PR DESCRIPTION
## PR Description

Fixed an unhandled null operator crash in the collection search filter. AI requests lack an httpRequestModel, causing a fatal error when searching. Implemented a safe fallback to bypass the URL check for AI requests while still matching by item name. Verified via local tests.

## Related Issues

- Closes #1113

### Checklist
- [ ] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [ ] I have updated my branch and synced it with project `main` branch before making this PR
- [ ] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [ ] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_

## OS on which you have developed and tested the feature?

- [ ] Windows
- [ ] macOS
- [ ] Linux
