### PR TITLE
fix: preserve cursor position in JSON body editor

### DIFF
--- a/lib/widgets/editor_json.dart
+++ b/lib/widgets/editor_json.dart
@@ -73,9 +73,38 @@ class _JsonTextFieldEditorState extends State<JsonTextFieldEditor> {
   void didUpdateWidget(JsonTextFieldEditor oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.initialValue != widget.initialValue) {
-      controller.text = widget.initialValue ?? "";
-      controller.selection =
-          TextSelection.collapsed(offset: controller.text.length);
+      final newText = widget.initialValue ?? "";
+      final oldSelection = controller.selection;
+
+      // Avoid unnecessary controller.text assignment; it can reset selection
+      // during typing. Only update controller text if the incoming value
+      // differs from what we currently have.
+      if (controller.text != newText) {
+        controller.text = newText;
+      }
+
+      // Preserve selection as much as possible by clamping offsets into the
+      // new text range (prevents out-of-bounds crashes).
+      final int newLen = controller.text.length;
+      int clampOffset(int offset) {
+        if (offset < 0) return 0;
+        if (offset > newLen) return newLen;
+        return offset;
+      }
+
+      final baseOffset = clampOffset(oldSelection.baseOffset);
+      final extentOffset = clampOffset(oldSelection.extentOffset);
+
+      if (oldSelection.isCollapsed) {
+        controller.selection = TextSelection.collapsed(offset: baseOffset);
+      } else {
+        controller.selection = TextSelection(
+          baseOffset: baseOffset,
+          extentOffset: extentOffset,
+          affinity: oldSelection.affinity,
+          isDirectional: oldSelection.isDirectional,
+        );
+      }
     }
     if ((oldWidget.fieldKey != widget.fieldKey) ||
         (oldWidget.isDark != widget.isDark)) {


### PR DESCRIPTION
## PR Description

This PR fixes an issue in the JSON request body editor where typing in the middle of text could cause characters to appear in incorrect positions (e.g., "answer" becoming "anwe\nr").

The issue was caused by resetting the cursor position to the end on every widget update.

## Related Issues

* Fixes #1574


### Checklist

* [x] I have gone through the contributing guide
* [x] I have updated my branch and synced it with project `main` branch before making this PR
* [x] I am using the latest Flutter stable branch
* [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

* [ ] Yes
* [x] No, and this is why: This change is limited to UI cursor behavior and does not affect business logic. The issue was verified manually through interaction in the JSON editor.

## OS on which you have developed and tested the feature?

* [x] Windows
* [ ] macOS
* [ ] Linux

