### PR TITLE
fix: remove keyboard inset padding from mobile bottom bar

### DIFF
--- a/lib/screens/mobile/requests_page/request_response_page_bottombar.dart
+++ b/lib/screens/mobile/requests_page/request_response_page_bottombar.dart
@@ -14,59 +14,56 @@ class RequestResponsePageBottombar extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Padding(
-      padding: MediaQuery.of(context).viewInsets,
-      child: Container(
-        height: 60 + MediaQuery.paddingOf(context).bottom,
-        width: MediaQuery.sizeOf(context).width,
-        padding: EdgeInsets.only(
-          bottom: MediaQuery.paddingOf(context).bottom,
-          left: 16,
-          right: 16,
-        ),
-        decoration: BoxDecoration(
-          color: Theme.of(context).colorScheme.surface,
-          border: Border(
-            top: BorderSide(
-              color: Theme.of(context).colorScheme.onInverseSurface,
-              width: 1,
-            ),
+    return Container(
+      height: 60 + MediaQuery.paddingOf(context).bottom,
+      width: MediaQuery.sizeOf(context).width,
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.paddingOf(context).bottom,
+        left: 16,
+        right: 16,
+      ),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        border: Border(
+          top: BorderSide(
+            color: Theme.of(context).colorScheme.onInverseSurface,
+            width: 1,
           ),
         ),
-        child: Row(
-          children: [
-            ADFilledButton(
-              onPressed: () {
-                ref
-                    .read(dashbotShowMobileProvider.notifier)
-                    .update((state) => !state);
-              },
-              isTonal: true,
-              items: [
-                kHSpacer6,
-                Text(
-                  ref.watch(dashbotShowMobileProvider)
-                      ? kLabelClose
-                      : kLabelDashBot,
-                  style: kTextStyleButton,
-                ),
-                kHSpacer6,
-              ],
-            ),
-            const Spacer(),
-            SizedBox(
-              height: 36,
-              child: SendRequestButton(
-                onTap: () {
-                  ref.read(dashbotShowMobileProvider.notifier).state = false;
-                  if (requestTabController.index != 1) {
-                    requestTabController.animateTo(1);
-                  }
-                },
+      ),
+      child: Row(
+        children: [
+          ADFilledButton(
+            onPressed: () {
+              ref
+                  .read(dashbotShowMobileProvider.notifier)
+                  .update((state) => !state);
+            },
+            isTonal: true,
+            items: [
+              kHSpacer6,
+              Text(
+                ref.watch(dashbotShowMobileProvider)
+                    ? kLabelClose
+                    : kLabelDashBot,
+                style: kTextStyleButton,
               ),
+              kHSpacer6,
+            ],
+          ),
+          const Spacer(),
+          SizedBox(
+            height: 36,
+            child: SendRequestButton(
+              onTap: () {
+                ref.read(dashbotShowMobileProvider.notifier).state = false;
+                if (requestTabController.index != 1) {
+                  requestTabController.animateTo(1);
+                }
+              },
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## PR Description

This PR fixes the Android layout overflow issue that occurs when focusing the URL field or preview search bar after sending a request.

The issue was caused by applying `MediaQuery.of(context).viewInsets` to the mobile bottom bar, which likely double-counted keyboard insets and reduced the available layout space too much when the keyboard opened.

## Related Issues

* Fixes #1535

### Checklist

* [x] I have gone through the contributing guide
* [x] I have updated my branch and synced it with project `main` branch before making this PR
* [x] I am using the latest Flutter stable branch
* [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

* [ ] Yes
* [x] No, and this is why: This is a small layout fix in the mobile UI. The issue was verified manually on Android by reproducing the overflow scenario before the fix and confirming it no longer occurs after the change.

## OS on which you have developed and tested the feature?

* [x] Windows
* [ ] macOS
* [ ] Linux


