### PR TITLE
fix: prevent keyboard overlap in AI prompt on mobile

### DIFF
--- a/lib/screens/home_page/editor_pane/details_card/request_pane/ai_request/aireq_prompt.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/ai_request/aireq_prompt.dart
@@ -29,7 +29,7 @@ class AIRequestPromptSection extends ConsumerWidget {
       return kSizedBoxEmpty;
     }
 
-    return Container(
+    final content = Container(
       padding: EdgeInsets.symmetric(vertical: 20),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -39,54 +39,109 @@ class AIRequestPromptSection extends ConsumerWidget {
             child: Text(kLabelSystemPrompt),
           ),
           kVSpacer10,
-          Expanded(
-            child: Container(
-              padding: EdgeInsets.symmetric(horizontal: 20),
-              child: TextFieldEditor(
-                key: Key("$selectedId-aireq-sysprompt-body"),
-                fieldKey: "$selectedId-aireq-sysprompt-body",
-                initialValue: systemPrompt,
-                onChanged: (String value) {
-                  ref
-                      .read(collectionStateNotifierProvider.notifier)
-                      .update(
-                        aiRequestModel: aiRequestModel.copyWith(
-                          systemPrompt: value,
-                        ),
-                      );
-                },
-                hintText: kHintEnterSystemPrompt,
-              ),
-            ),
-          ),
+          context.isMediumWindow
+              ? SizedBox(
+                  height: 200,
+                  child: Container(
+                    padding: EdgeInsets.symmetric(horizontal: 20),
+                    child: TextFieldEditor(
+                      key: Key("$selectedId-aireq-sysprompt-body"),
+                      fieldKey: "$selectedId-aireq-sysprompt-body",
+                      initialValue: systemPrompt,
+                      onChanged: (String value) {
+                        ref
+                            .read(collectionStateNotifierProvider.notifier)
+                            .update(
+                              aiRequestModel: aiRequestModel.copyWith(
+                                systemPrompt: value,
+                              ),
+                            );
+                      },
+                      hintText: kHintEnterSystemPrompt,
+                    ),
+                  ),
+                )
+              : Expanded(
+                  child: Container(
+                    padding: EdgeInsets.symmetric(horizontal: 20),
+                    child: TextFieldEditor(
+                      key: Key("$selectedId-aireq-sysprompt-body"),
+                      fieldKey: "$selectedId-aireq-sysprompt-body",
+                      initialValue: systemPrompt,
+                      onChanged: (String value) {
+                        ref
+                            .read(collectionStateNotifierProvider.notifier)
+                            .update(
+                              aiRequestModel: aiRequestModel.copyWith(
+                                systemPrompt: value,
+                              ),
+                            );
+                      },
+                      hintText: kHintEnterSystemPrompt,
+                    ),
+                  ),
+                ),
           SizedBox(height: 10),
           Padding(
             padding: const EdgeInsets.only(left: 25.0),
             child: Text(kLabelUserPromptInput),
           ),
           kVSpacer10,
-          Expanded(
-            child: Container(
-              padding: EdgeInsets.symmetric(horizontal: 20),
-              child: TextFieldEditor(
-                key: Key("$selectedId-aireq-userprompt-body"),
-                fieldKey: "$selectedId-aireq-userprompt-body",
-                initialValue: userPrompt,
-                onChanged: (String value) {
-                  ref
-                      .read(collectionStateNotifierProvider.notifier)
-                      .update(
-                        aiRequestModel: aiRequestModel.copyWith(
-                          userPrompt: value,
-                        ),
-                      );
-                },
-                hintText: kHintEnterUserPrompt,
-              ),
-            ),
-          ),
+          context.isMediumWindow
+              ? SizedBox(
+                  height: 200,
+                  child: Container(
+                    padding: EdgeInsets.symmetric(horizontal: 20),
+                    child: TextFieldEditor(
+                      key: Key("$selectedId-aireq-userprompt-body"),
+                      fieldKey: "$selectedId-aireq-userprompt-body",
+                      initialValue: userPrompt,
+                      onChanged: (String value) {
+                        ref
+                            .read(collectionStateNotifierProvider.notifier)
+                            .update(
+                              aiRequestModel: aiRequestModel.copyWith(
+                                userPrompt: value,
+                              ),
+                            );
+                      },
+                      hintText: kHintEnterUserPrompt,
+                    ),
+                  ),
+                )
+              : Expanded(
+                  child: Container(
+                    padding: EdgeInsets.symmetric(horizontal: 20),
+                    child: TextFieldEditor(
+                      key: Key("$selectedId-aireq-userprompt-body"),
+                      fieldKey: "$selectedId-aireq-userprompt-body",
+                      initialValue: userPrompt,
+                      onChanged: (String value) {
+                        ref
+                            .read(collectionStateNotifierProvider.notifier)
+                            .update(
+                              aiRequestModel: aiRequestModel.copyWith(
+                                userPrompt: value,
+                              ),
+                            );
+                      },
+                      hintText: kHintEnterUserPrompt,
+                    ),
+                  ),
+                ),
         ],
       ),
     );
+
+    if (context.isMediumWindow) {
+      return SingleChildScrollView(
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.of(context).viewInsets.bottom,
+        ),
+        child: content,
+      );
+    }
+
+    return content;
   }
 }


### PR DESCRIPTION
## PR Description

This PR fixes the Android keyboard overlap issue in the AI Prompt tab where the on-screen keyboard could cover the "System Prompt" and "User Prompt / Input" fields.

The fix:

* makes the prompt section scrollable on mobile using `SingleChildScrollView`
* replaces mobile-only `Expanded` editors with fixed-height `SizedBox` containers

This ensures the focused input field remains visible when the keyboard opens.

## Related Issues

* Fixes #1381 

### Checklist

* [x] I have gone through the contributing guide
* [x] I have updated my branch and synced it with project `main` branch before making this PR
* [x] I am using the latest Flutter stable branch
* [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

* [ ] Yes
* [x] No, and this is why: This is a UI layout fix verified manually on Android by reproducing the issue and confirming proper scrolling after the fix.

## OS on which you have developed and tested the feature?

* [x] Windows
* [ ] macOS
* [ ] Linux
