### PR TITLE
Improve JSON pretty printing in generated snippets

### DIFF
--- a/lib/codegen/js/fetch.dart
+++ b/lib/codegen/js/fetch.dart
@@ -38,12 +38,14 @@ payload.append("{{name}}", {{value}})
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:\${err}`);

--- a/lib/codegen/python/requests.dart
+++ b/lib/codegen/python/requests.dart
@@ -6,6 +6,7 @@ import '../codegen_utils.dart';
 
 class PythonRequestsCodeGen {
   final String kTemplateStart = """import requests
+import json
 {% if hasFormData %}from requests_toolbelt.multipart.encoder import MultipartEncoder
 {% endif %}
 url = '{{url}}'
@@ -67,7 +68,10 @@ payload = MultipartEncoder({
   final String kStringRequestEnd = """)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
 
   String kStringFormDataContentType = "payload.content_type";

--- a/test/codegen/js_fetch_codegen_test.dart
+++ b/test/codegen/js_fetch_codegen_test.dart
@@ -16,12 +16,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -45,12 +47,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -74,12 +78,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -103,12 +109,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -135,12 +143,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -167,12 +177,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -195,12 +207,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -227,12 +241,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -256,12 +272,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -288,12 +306,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -320,12 +340,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -349,12 +371,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -379,12 +403,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -407,12 +433,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -441,12 +469,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -473,12 +503,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -506,12 +538,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -539,12 +573,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -576,12 +612,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -611,12 +649,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -646,12 +686,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -679,12 +721,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -718,12 +762,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -752,12 +798,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -786,12 +834,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -816,12 +866,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);
@@ -848,12 +900,14 @@ const options = {
 };
 
 fetch(url, options)
-  .then(res => {
+  .then(async res => {
     console.log(res.status);
-    return res.text()
-  })
-  .then(body => {
-    console.log(body);
+    const body = await res.text();
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
   })
   .catch(err => {
     console.error(`error:${err}`);

--- a/test/codegen/python_requests_codegen_test.dart
+++ b/test/codegen/python_requests_codegen_test.dart
@@ -10,13 +10,17 @@ void main() {
   group('GET Request', () {
     test('GET 1', () {
       const expectedCode = r"""import requests
+import json
 
 url = 'https://api.apidash.dev'
 
 response = requests.get(url)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -29,6 +33,7 @@ print('Response Body:', response.text)
 
     test('GET 2', () {
       const expectedCode = r"""import requests
+import json
 
 url = 'https://api.apidash.dev/country/data'
 
@@ -39,7 +44,10 @@ params = {
 response = requests.get(url, params=params)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -52,6 +60,7 @@ print('Response Body:', response.text)
 
     test('GET 3', () {
       const expectedCode = r"""import requests
+import json
 
 url = 'https://api.apidash.dev/country/data'
 
@@ -62,7 +71,10 @@ params = {
 response = requests.get(url, params=params)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -75,6 +87,7 @@ print('Response Body:', response.text)
 
     test('GET 4', () {
       const expectedCode = r"""import requests
+import json
 
 url = 'https://api.apidash.dev/humanize/social'
 
@@ -89,7 +102,10 @@ params = {
 response = requests.get(url, params=params)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -102,6 +118,7 @@ print('Response Body:', response.text)
 
     test('GET 5', () {
       const expectedCode = r"""import requests
+import json
 
 url = 'https://api.github.com/repos/foss42/apidash'
 
@@ -112,7 +129,10 @@ headers = {
 response = requests.get(url, headers=headers)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -125,6 +145,7 @@ print('Response Body:', response.text)
 
     test('GET 6', () {
       const expectedCode = r"""import requests
+import json
 
 url = 'https://api.github.com/repos/foss42/apidash'
 
@@ -139,7 +160,10 @@ headers = {
 response = requests.get(url, params=params, headers=headers)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -152,13 +176,17 @@ print('Response Body:', response.text)
 
     test('GET 7', () {
       const expectedCode = r"""import requests
+import json
 
 url = 'https://api.apidash.dev'
 
 response = requests.get(url)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -171,6 +199,7 @@ print('Response Body:', response.text)
 
     test('GET 8', () {
       const expectedCode = r"""import requests
+import json
 
 url = 'https://api.github.com/repos/foss42/apidash'
 
@@ -185,7 +214,10 @@ headers = {
 response = requests.get(url, params=params, headers=headers)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -198,6 +230,7 @@ print('Response Body:', response.text)
 
     test('GET 9', () {
       const expectedCode = r"""import requests
+import json
 
 url = 'https://api.apidash.dev/humanize/social'
 
@@ -209,7 +242,10 @@ params = {
 response = requests.get(url, params=params)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -222,6 +258,7 @@ print('Response Body:', response.text)
 
     test('GET 10', () {
       const expectedCode = r"""import requests
+import json
 
 url = 'https://api.apidash.dev/humanize/social'
 
@@ -232,7 +269,10 @@ headers = {
 response = requests.get(url, headers=headers)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -245,6 +285,7 @@ print('Response Body:', response.text)
 
     test('GET 11', () {
       const expectedCode = r"""import requests
+import json
 
 url = 'https://api.apidash.dev/humanize/social'
 
@@ -260,7 +301,10 @@ headers = {
 response = requests.get(url, params=params, headers=headers)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -273,13 +317,17 @@ print('Response Body:', response.text)
 
     test('GET 12', () {
       const expectedCode = r"""import requests
+import json
 
 url = 'https://api.apidash.dev/humanize/social'
 
 response = requests.get(url)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -294,13 +342,17 @@ print('Response Body:', response.text)
   group('HEAD Request', () {
     test('HEAD 1', () {
       const expectedCode = r"""import requests
+import json
 
 url = 'https://api.apidash.dev'
 
 response = requests.head(url)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -313,13 +365,17 @@ print('Response Body:', response.text)
 
     test('HEAD 2', () {
       const expectedCode = r"""import requests
+import json
 
 url = 'http://api.apidash.dev'
 
 response = requests.head(url)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -334,6 +390,7 @@ print('Response Body:', response.text)
   group('POST Request', () {
     test('POST 1', () {
       const expectedCode = r"""import requests
+import json
 
 url = 'https://api.apidash.dev/case/lower'
 
@@ -348,7 +405,10 @@ headers = {
 response = requests.post(url, data=payload, headers=headers)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -361,6 +421,7 @@ print('Response Body:', response.text)
 
     test('POST 2', () {
       const expectedCode = r"""import requests
+import json
 
 url = 'https://api.apidash.dev/case/lower'
 
@@ -376,7 +437,10 @@ payload = {
 response = requests.post(url, json=payload)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -389,6 +453,7 @@ print('Response Body:', response.text)
 
     test('POST 3', () {
       const expectedCode = r"""import requests
+import json
 
 url = 'https://api.apidash.dev/case/lower'
 
@@ -403,7 +468,10 @@ headers = {
 response = requests.post(url, json=payload, headers=headers)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -416,6 +484,7 @@ print('Response Body:', response.text)
 
     test('POST 4', () {
       const expectedCode = r"""import requests
+import json
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 
 url = 'https://api.apidash.dev/io/form'
@@ -433,7 +502,10 @@ headers = {
 response = requests.post(url, data=payload, headers=headers)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -446,6 +518,7 @@ print('Response Body:', response.text)
 
     test('POST 5', () {
       const expectedCode = r"""import requests
+import json
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 
 url = 'https://api.apidash.dev/io/form'
@@ -464,7 +537,10 @@ headers = {
 response = requests.post(url, data=payload, headers=headers)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -477,6 +553,7 @@ print('Response Body:', response.text)
 
     test('POST 6', () {
       const expectedCode = r"""import requests
+import json
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 
 url = 'https://api.apidash.dev/io/img'
@@ -493,7 +570,10 @@ headers = {
 response = requests.post(url, data=payload, headers=headers)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -506,6 +586,7 @@ print('Response Body:', response.text)
 
     test('POST 7', () {
       const expectedCode = r"""import requests
+import json
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 
 url = 'https://api.apidash.dev/io/img'
@@ -522,7 +603,10 @@ headers = {
 response = requests.post(url, data=payload, headers=headers)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -535,6 +619,7 @@ print('Response Body:', response.text)
 
     test('POST 8', () {
       const expectedCode = r"""import requests
+import json
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 
 url = 'https://api.apidash.dev/io/form'
@@ -557,7 +642,10 @@ headers = {
 response = requests.post(url, params=params, data=payload, headers=headers)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -570,6 +658,7 @@ print('Response Body:', response.text)
 
     test('POST 9', () {
       const expectedCode = r"""import requests
+import json
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 
 url = 'https://api.apidash.dev/io/img'
@@ -593,7 +682,10 @@ headers = {
 response = requests.post(url, params=params, data=payload, headers=headers)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -608,6 +700,7 @@ print('Response Body:', response.text)
   group('PUT Request', () {
     test('PUT 1', () {
       const expectedCode = r"""import requests
+import json
 
 url = 'https://reqres.in/api/users/2'
 
@@ -619,7 +712,10 @@ payload = {
 response = requests.put(url, json=payload)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -634,6 +730,7 @@ print('Response Body:', response.text)
   group('PATCH Request', () {
     test('PATCH 1', () {
       const expectedCode = r"""import requests
+import json
 
 url = 'https://reqres.in/api/users/2'
 
@@ -645,7 +742,10 @@ payload = {
 response = requests.patch(url, json=payload)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -660,13 +760,17 @@ print('Response Body:', response.text)
   group('DELETE Request', () {
     test('DELETE 1', () {
       const expectedCode = r"""import requests
+import json
 
 url = 'https://reqres.in/api/users/2'
 
 response = requests.delete(url)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(
@@ -679,6 +783,7 @@ print('Response Body:', response.text)
 
     test('DELETE 2', () {
       const expectedCode = r"""import requests
+import json
 
 url = 'https://reqres.in/api/users/2'
 
@@ -690,7 +795,10 @@ payload = {
 response = requests.delete(url, json=payload)
 
 print('Status Code:', response.status_code)
-print('Response Body:', response.text)
+try:
+    print(json.dumps(response.json(), indent=4))
+except ValueError:
+    print('Response Body:', response.text)
 """;
       expect(
           codeGen.getCode(


### PR DESCRIPTION
Closes #1555

## Summary

This PR improves generated snippets for Python Requests and JavaScript Fetch by pretty-printing JSON responses when possible, while preserving a plain-text fallback for non-JSON responses.

## Changes

- Python Requests snippets now import `json` and try `json.dumps(response.json(), indent=4)` before falling back to `response.text`
- JavaScript Fetch snippets now try `JSON.parse(body)` and log `JSON.stringify(..., null, 2)` before falling back to the raw body
- Updated codegen tests for both generators

## Validation

- `flutter test --no-pub test/codegen/python_requests_codegen_test.dart` ✅
- `flutter test --no-pub test/codegen/js_fetch_codegen_test.dart` ✅