### PR TITLE
#1585 - feat(better_networking): add structured response evaluator

### DIFF
--- a/packages/better_networking/lib/utils/response_evaluator.dart
+++ b/packages/better_networking/lib/utils/response_evaluator.dart
@@ -1,0 +1,203 @@
+import 'dart:convert';
+
+import '../models/http_response_model.dart';
+
+/// Identifies which aspect of the response was evaluated.
+enum EvalField {
+  statusCode,
+  latency,
+  jsonKeyPresence,
+  bodyContains,
+  contentType,
+}
+
+/// The result of a single evaluation check against an [HttpResponseModel].
+class EvalResult {
+  const EvalResult({
+    required this.field,
+    required this.passed,
+    this.expected,
+    this.actual,
+    this.message,
+  });
+
+  /// The response field that was evaluated.
+  final EvalField field;
+
+  /// Whether the assertion passed.
+  final bool passed;
+
+  /// The expected value for this assertion.
+  final Object? expected;
+
+  /// The actual value observed in the response.
+  final Object? actual;
+
+  /// A human-readable summary of the result.
+  final String? message;
+
+  @override
+  String toString() =>
+      'EvalResult(field: $field, passed: $passed, '
+      'expected: $expected, actual: $actual)';
+}
+
+/// Defines the set of assertions to run against an [HttpResponseModel].
+/// Only fields with non-null values produce an [EvalResult].
+class ResponseExpectation {
+  const ResponseExpectation({
+    this.statusCode,
+    this.maxLatency,
+    this.requiredJsonKeys,
+    this.bodyContains,
+    this.contentType,
+  });
+
+  /// Expected HTTP status code (exact match).
+  final int? statusCode;
+
+  /// Maximum acceptable response time.
+  final Duration? maxLatency;
+
+  /// Top-level JSON keys that must be present in the response body.
+  final List<String>? requiredJsonKeys;
+
+  /// A string that must appear anywhere in the response body.
+  final String? bodyContains;
+
+  /// A substring that must appear in the Content-Type header.
+  final String? contentType;
+}
+
+/// Evaluates [response] against [expectation] and returns a list of
+/// [EvalResult] — one entry per configured assertion.
+///
+/// Only assertions with non-null values in [expectation] are evaluated.
+/// The order of results matches the order of fields in [ResponseExpectation].
+List<EvalResult> evaluateResponse(
+  HttpResponseModel response,
+  ResponseExpectation expectation,
+) {
+  final results = <EvalResult>[];
+
+  if (expectation.statusCode != null) {
+    results.add(_evalStatusCode(response, expectation.statusCode!));
+  }
+
+  if (expectation.maxLatency != null) {
+    results.add(_evalLatency(response, expectation.maxLatency!));
+  }
+
+  if (expectation.requiredJsonKeys != null &&
+      expectation.requiredJsonKeys!.isNotEmpty) {
+    results.add(_evalJsonKeys(response, expectation.requiredJsonKeys!));
+  }
+
+  if (expectation.bodyContains != null) {
+    results.add(_evalBodyContains(response, expectation.bodyContains!));
+  }
+
+  if (expectation.contentType != null) {
+    results.add(_evalContentType(response, expectation.contentType!));
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+EvalResult _evalStatusCode(HttpResponseModel response, int expected) {
+  final actual = response.statusCode;
+  final passed = actual == expected;
+  return EvalResult(
+    field: EvalField.statusCode,
+    passed: passed,
+    expected: expected,
+    actual: actual,
+    message: passed
+        ? 'Status code matched: $actual'
+        : 'Expected status $expected, got $actual',
+  );
+}
+
+EvalResult _evalLatency(HttpResponseModel response, Duration max) {
+  final actual = response.time;
+  if (actual == null) {
+    return EvalResult(
+      field: EvalField.latency,
+      passed: false,
+      expected: '≤ ${max.inMilliseconds}ms',
+      actual: null,
+      message: 'Latency data unavailable',
+    );
+  }
+  final passed = actual <= max;
+  return EvalResult(
+    field: EvalField.latency,
+    passed: passed,
+    expected: '≤ ${max.inMilliseconds}ms',
+    actual: '${actual.inMilliseconds}ms',
+    message: passed
+        ? 'Latency ${actual.inMilliseconds}ms within limit'
+        : 'Latency ${actual.inMilliseconds}ms exceeded ${max.inMilliseconds}ms',
+  );
+}
+
+EvalResult _evalJsonKeys(
+  HttpResponseModel response,
+  List<String> requiredKeys,
+) {
+  final body = response.body;
+  try {
+    final decoded = jsonDecode(body ?? '') as Map<String, dynamic>;
+    final missing = requiredKeys.where((k) => !decoded.containsKey(k)).toList();
+    return EvalResult(
+      field: EvalField.jsonKeyPresence,
+      passed: missing.isEmpty,
+      expected: requiredKeys,
+      actual: decoded.keys.toList(),
+      message: missing.isEmpty
+          ? 'All required keys present'
+          : 'Missing keys: $missing',
+    );
+  } catch (_) {
+    return EvalResult(
+      field: EvalField.jsonKeyPresence,
+      passed: false,
+      expected: requiredKeys,
+      actual: null,
+      message: 'Response body is not valid JSON',
+    );
+  }
+}
+
+EvalResult _evalBodyContains(HttpResponseModel response, String needle) {
+  final body = response.body ?? '';
+  final passed = body.contains(needle);
+  final preview = body.length > 120 ? '${body.substring(0, 120)}…' : body;
+  return EvalResult(
+    field: EvalField.bodyContains,
+    passed: passed,
+    expected: needle,
+    actual: preview,
+    message: passed
+        ? 'Body contains "$needle"'
+        : 'Body does not contain "$needle"',
+  );
+}
+
+EvalResult _evalContentType(HttpResponseModel response, String expected) {
+  final actual = response.contentType ?? '';
+  final passed = actual.contains(expected);
+  return EvalResult(
+    field: EvalField.contentType,
+    passed: passed,
+    expected: expected,
+    actual: actual.isEmpty ? null : actual,
+    message: passed
+        ? 'Content-Type contains "$expected"'
+        : 'Content-Type "$actual" does not contain "$expected"',
+  );
+}

--- a/packages/better_networking/lib/utils/utils.dart
+++ b/packages/better_networking/lib/utils/utils.dart
@@ -3,6 +3,7 @@ export 'graphql_utils.dart';
 export 'http_request_utils.dart';
 export 'http_response_utils.dart';
 export 'platform_utils.dart';
+export 'response_evaluator.dart';
 export 'string_utils.dart' hide RandomStringGenerator;
 export 'uri_utils.dart';
 export 'auth/handle_auth.dart';

--- a/packages/better_networking/test/utils/response_evaluator_test.dart
+++ b/packages/better_networking/test/utils/response_evaluator_test.dart
@@ -1,0 +1,325 @@
+import 'package:better_networking/utils/response_evaluator.dart';
+import 'package:better_networking/models/http_response_model.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  HttpResponseModel makeResponse({
+    int? statusCode = 200,
+    Duration? time = const Duration(milliseconds: 150),
+    String? body = '{"status":"ok","data":{"id":1}}',
+    Map<String, String>? headers = const {
+      'content-type': 'application/json',
+    },
+  }) {
+    return HttpResponseModel(
+      statusCode: statusCode,
+      time: time,
+      body: body,
+      headers: headers,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // evaluateResponse — no assertions
+  // ---------------------------------------------------------------------------
+
+  group('evaluateResponse - empty expectation', () {
+    test('returns empty list when no assertions are configured', () {
+      final results = evaluateResponse(
+        makeResponse(),
+        const ResponseExpectation(),
+      );
+      expect(results, isEmpty);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Status code
+  // ---------------------------------------------------------------------------
+
+  group('EvalField.statusCode', () {
+    test('passes when status code matches', () {
+      final results = evaluateResponse(
+        makeResponse(statusCode: 200),
+        const ResponseExpectation(statusCode: 200),
+      );
+      expect(results, hasLength(1));
+      expect(results[0].field, EvalField.statusCode);
+      expect(results[0].passed, isTrue);
+      expect(results[0].expected, 200);
+      expect(results[0].actual, 200);
+    });
+
+    test('fails when status code does not match', () {
+      final results = evaluateResponse(
+        makeResponse(statusCode: 404),
+        const ResponseExpectation(statusCode: 200),
+      );
+      expect(results[0].passed, isFalse);
+      expect(results[0].expected, 200);
+      expect(results[0].actual, 404);
+    });
+
+    test('fails when response status code is null', () {
+      final results = evaluateResponse(
+        makeResponse(statusCode: null),
+        const ResponseExpectation(statusCode: 200),
+      );
+      expect(results[0].passed, isFalse);
+      expect(results[0].actual, isNull);
+    });
+
+    test('passes for 4xx expected status', () {
+      final results = evaluateResponse(
+        makeResponse(statusCode: 422),
+        const ResponseExpectation(statusCode: 422),
+      );
+      expect(results[0].passed, isTrue);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Latency
+  // ---------------------------------------------------------------------------
+
+  group('EvalField.latency', () {
+    test('passes when response time is within limit', () {
+      final results = evaluateResponse(
+        makeResponse(time: const Duration(milliseconds: 80)),
+        const ResponseExpectation(maxLatency: Duration(milliseconds: 200)),
+      );
+      expect(results[0].field, EvalField.latency);
+      expect(results[0].passed, isTrue);
+    });
+
+    test('passes when response time equals limit exactly', () {
+      final results = evaluateResponse(
+        makeResponse(time: const Duration(milliseconds: 200)),
+        const ResponseExpectation(maxLatency: Duration(milliseconds: 200)),
+      );
+      expect(results[0].passed, isTrue);
+    });
+
+    test('fails when response time exceeds limit', () {
+      final results = evaluateResponse(
+        makeResponse(time: const Duration(milliseconds: 500)),
+        const ResponseExpectation(maxLatency: Duration(milliseconds: 200)),
+      );
+      expect(results[0].passed, isFalse);
+      expect(results[0].actual, '500ms');
+      expect(results[0].expected, '≤ 200ms');
+    });
+
+    test('fails when response time is null', () {
+      final results = evaluateResponse(
+        makeResponse(time: null),
+        const ResponseExpectation(maxLatency: Duration(milliseconds: 200)),
+      );
+      expect(results[0].passed, isFalse);
+      expect(results[0].actual, isNull);
+      expect(results[0].message, contains('unavailable'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // JSON key presence
+  // ---------------------------------------------------------------------------
+
+  group('EvalField.jsonKeyPresence', () {
+    test('passes when all required keys are present', () {
+      final results = evaluateResponse(
+        makeResponse(body: '{"status":"ok","data":{"id":1}}'),
+        const ResponseExpectation(requiredJsonKeys: ['status', 'data']),
+      );
+      expect(results[0].field, EvalField.jsonKeyPresence);
+      expect(results[0].passed, isTrue);
+      expect(results[0].message, contains('All required keys present'));
+    });
+
+    test('fails when a required key is missing', () {
+      final results = evaluateResponse(
+        makeResponse(body: '{"status":"ok"}'),
+        const ResponseExpectation(requiredJsonKeys: ['status', 'data']),
+      );
+      expect(results[0].passed, isFalse);
+      expect(results[0].message, contains('data'));
+    });
+
+    test('fails when body is not valid JSON', () {
+      final results = evaluateResponse(
+        makeResponse(body: 'not json'),
+        const ResponseExpectation(requiredJsonKeys: ['key']),
+      );
+      expect(results[0].passed, isFalse);
+      expect(results[0].message, contains('not valid JSON'));
+    });
+
+    test('fails when body is null', () {
+      final results = evaluateResponse(
+        makeResponse(body: null),
+        const ResponseExpectation(requiredJsonKeys: ['key']),
+      );
+      expect(results[0].passed, isFalse);
+    });
+
+    test('skips evaluation when requiredJsonKeys is empty list', () {
+      final results = evaluateResponse(
+        makeResponse(),
+        const ResponseExpectation(requiredJsonKeys: []),
+      );
+      expect(results, isEmpty);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Body contains
+  // ---------------------------------------------------------------------------
+
+  group('EvalField.bodyContains', () {
+    test('passes when body contains expected string', () {
+      final results = evaluateResponse(
+        makeResponse(body: '{"message":"success","token":"abc123"}'),
+        const ResponseExpectation(bodyContains: 'success'),
+      );
+      expect(results[0].field, EvalField.bodyContains);
+      expect(results[0].passed, isTrue);
+    });
+
+    test('fails when body does not contain expected string', () {
+      final results = evaluateResponse(
+        makeResponse(body: '{"message":"error"}'),
+        const ResponseExpectation(bodyContains: 'success'),
+      );
+      expect(results[0].passed, isFalse);
+    });
+
+    test('passes when body is empty string and needle is also empty', () {
+      final results = evaluateResponse(
+        makeResponse(body: ''),
+        const ResponseExpectation(bodyContains: ''),
+      );
+      expect(results[0].passed, isTrue);
+    });
+
+    test('treats null body as empty string', () {
+      final results = evaluateResponse(
+        makeResponse(body: null),
+        const ResponseExpectation(bodyContains: 'data'),
+      );
+      expect(results[0].passed, isFalse);
+    });
+
+    test('truncates long body in actual field', () {
+      final longBody = 'x' * 200;
+      final results = evaluateResponse(
+        makeResponse(body: longBody),
+        const ResponseExpectation(bodyContains: 'y'),
+      );
+      final actual = results[0].actual as String;
+      expect(actual, endsWith('…'));
+      expect(actual.length, lessThan(200));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Content type
+  // ---------------------------------------------------------------------------
+
+  group('EvalField.contentType', () {
+    test('passes when content-type contains expected substring', () {
+      final results = evaluateResponse(
+        makeResponse(headers: {'content-type': 'application/json; charset=utf-8'}),
+        const ResponseExpectation(contentType: 'application/json'),
+      );
+      expect(results[0].field, EvalField.contentType);
+      expect(results[0].passed, isTrue);
+    });
+
+    test('fails when content-type does not match', () {
+      final results = evaluateResponse(
+        makeResponse(headers: {'content-type': 'text/html'}),
+        const ResponseExpectation(contentType: 'application/json'),
+      );
+      expect(results[0].passed, isFalse);
+      expect(results[0].actual, 'text/html');
+    });
+
+    test('fails when headers are null', () {
+      final results = evaluateResponse(
+        makeResponse(headers: null),
+        const ResponseExpectation(contentType: 'application/json'),
+      );
+      expect(results[0].passed, isFalse);
+      expect(results[0].actual, isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Multiple assertions combined
+  // ---------------------------------------------------------------------------
+
+  group('evaluateResponse - multiple assertions', () {
+    test('returns one result per configured assertion', () {
+      final results = evaluateResponse(
+        makeResponse(
+          statusCode: 200,
+          time: const Duration(milliseconds: 100),
+          body: '{"id":1,"name":"test"}',
+          headers: {'content-type': 'application/json'},
+        ),
+        const ResponseExpectation(
+          statusCode: 200,
+          maxLatency: Duration(milliseconds: 500),
+          requiredJsonKeys: ['id', 'name'],
+          bodyContains: 'test',
+          contentType: 'application/json',
+        ),
+      );
+
+      expect(results, hasLength(5));
+      expect(results.every((r) => r.passed), isTrue);
+    });
+
+    test('correctly reports mix of pass and fail', () {
+      final results = evaluateResponse(
+        makeResponse(
+          statusCode: 500,
+          time: const Duration(milliseconds: 800),
+        ),
+        const ResponseExpectation(
+          statusCode: 200,
+          maxLatency: Duration(milliseconds: 500),
+        ),
+      );
+
+      expect(results, hasLength(2));
+      expect(results[0].field, EvalField.statusCode);
+      expect(results[0].passed, isFalse);
+      expect(results[1].field, EvalField.latency);
+      expect(results[1].passed, isFalse);
+    });
+
+    test('result order matches ResponseExpectation field order', () {
+      final results = evaluateResponse(
+        makeResponse(),
+        const ResponseExpectation(
+          statusCode: 200,
+          maxLatency: Duration(seconds: 1),
+          requiredJsonKeys: ['status'],
+          bodyContains: 'ok',
+          contentType: 'json',
+        ),
+      );
+
+      expect(results[0].field, EvalField.statusCode);
+      expect(results[1].field, EvalField.latency);
+      expect(results[2].field, EvalField.jsonKeyPresence);
+      expect(results[3].field, EvalField.bodyContains);
+      expect(results[4].field, EvalField.contentType);
+    });
+  });
+}


### PR DESCRIPTION
## PR Description                                                                                                                             
                                                                                                                                                
  Closes #1585. Introduces a structured, pure-Dart response evaluation utility in the `better_networking` package.

  The current codebase has no way to programmatically assert API response correctness — only visual inspection via the UI. This PR adds
  `evaluateResponse()`, a pure function that takes an `HttpResponseModel` and a `ResponseExpectation`, and returns a typed `List<EvalResult>` —
  one entry per configured assertion.

  **Supported assertions:**
  - `statusCode` — exact match against expected HTTP status
  - `maxLatency` — response time within a duration threshold
  - `requiredJsonKeys` — top-level JSON keys must be present in the body
  - `bodyContains` — response body must contain a given substring
  - `contentType` — Content-Type header must contain a given substring

  **Why this approach over a simple logger:**

  A `void` logger with side effects is untestable and throws away the result. Returning `List<EvalResult>` lets callers (UI, tests, future batch
   eval) decide what to do with the outcome — display it, aggregate it, or fail a test.

  ```dart
  final results = evaluateResponse(
    response,
    const ResponseExpectation(
      statusCode: 200,
      maxLatency: Duration(milliseconds: 500),
      requiredJsonKeys: ['id', 'name'],
      bodyContains: 'success',
      contentType: 'application/json',
    ),
  );

  // results → List<EvalResult> with .field, .passed, .expected, .actual, .message
  ```

  This also serves as the foundation for the multimodal AI & Agent API Eval Framework (Idea #2), where batch evaluation requires running
  per-response assertions across datasets.

  ## Related Issues

  - Closes #1585 

  ### Checklist
  - [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
  - [x] I have updated my branch and synced it with project `main` branch before making this PR
  - [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
  - [x] I have run the tests (`flutter test`) and all tests are passing

  ## Added/updated tests?

  - [x] Yes
    - `test/utils/response_evaluator_test.dart` — 25 tests covering all 5 evaluation fields independently, edge cases (null body, null headers,
  null latency, empty keys list, long body truncation), and combined multi-assertion scenarios including result ordering

  ## OS on which you have developed and tested the feature?

  - [ ] Windows
  - [x] macOS
  - [ ] Linux