### PR TITLE
fix(request): stop sendRequest early when validation fails

### DIFF
--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -377,6 +377,7 @@ class CollectionStateNotifier
         level: TerminalLevel.error,
       );
       ref.read(showTerminalBadgeProvider.notifier).state = true;
+      return;
     }
 
     // Terminal: start network log

--- a/test/providers/collection_validation_test.dart
+++ b/test/providers/collection_validation_test.dart
@@ -1,0 +1,32 @@
+import 'package:apidash/providers/providers.dart';
+import 'package:apidash/terminal/terminal.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'helpers.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await testSetUpTempDirForHive();
+  });
+
+  test('sendRequest stops early when validation fails', () async {
+    final container = createContainer();
+    final notifier = container.read(collectionStateNotifierProvider.notifier);
+
+    final requestId = container.read(selectedIdStateProvider);
+    expect(requestId, isNotNull);
+
+    await notifier.sendRequest();
+
+    final requestModel = notifier.getRequestModel(requestId!);
+    expect(requestModel?.isWorking, isFalse);
+    expect(requestModel?.responseStatus, isNull);
+
+    final terminalEntries = container.read(terminalStateProvider).entries;
+    expect(terminalEntries, isNotEmpty);
+    expect(terminalEntries.first.source, TerminalSource.system);
+    expect(terminalEntries.first.level, TerminalLevel.error);
+    expect(terminalEntries.first.system?.category, 'validation');
+  });
+}


### PR DESCRIPTION
## PR Description

This PR ensures `sendRequest()` exits immediately when request validation fails.

Before this change, validation errors were logged in terminal but execution could still continue and start the network flow. Now, after logging the validation error and setting terminal badge, the function returns early. This keeps behavior safe and avoids unnecessary network calls for invalid requests.

Also added a regression test:
- `test/providers/collection_validation_test.dart`
  - verifies `sendRequest()` early-exits on invalid request input
  - verifies validation error is logged in terminal
  - verifies no response status is set from network execution.

## Related Issues

- Closes #

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [ ] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [ ] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_

## OS on which you have developed and tested the feature?

- [ ] Windows
- [ ] macOS
- [x] Linux