### PR TITLE
fix(history): avoid duplicate history IDs in persistence

### DIFF
--- a/lib/providers/history_providers.dart
+++ b/lib/providers/history_providers.dart
@@ -85,9 +85,7 @@ class HistoryMetaStateNotifier
   void addHistoryRequest(HistoryRequestModel model) async {
     final id = model.historyId;
     state = {...state ?? {}, id: model.metaData};
-    final List<String> updatedHistoryKeys = state == null
-        ? [id]
-        : [...state!.keys, id];
+    final List<String> updatedHistoryKeys = state?.keys.toList() ?? <String>[];
     hiveHandler.setHistoryIds(updatedHistoryKeys);
     hiveHandler.setHistoryMeta(id, model.metaData.toJson());
     await hiveHandler.setHistoryRequest(id, model.toJson());

--- a/test/providers/history_providers_test.dart
+++ b/test/providers/history_providers_test.dart
@@ -1,0 +1,41 @@
+import 'package:apidash/models/models.dart';
+import 'package:apidash/providers/providers.dart';
+import 'package:apidash/services/services.dart';
+import 'package:apidash_core/apidash_core.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'helpers.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await testSetUpTempDirForHive();
+  });
+
+  test('addHistoryRequest persists unique history ids only', () async {
+    final container = createContainer();
+    final notifier = container.read(historyMetaStateNotifier.notifier);
+
+    final historyId = getNewUuid();
+    final model = HistoryRequestModel(
+      historyId: historyId,
+      metaData: HistoryMetaModel(
+        historyId: historyId,
+        requestId: getNewUuid(),
+        apiType: APIType.rest,
+        url: 'https://api.apidash.dev',
+        method: HTTPVerb.get,
+        responseStatus: 200,
+        timeStamp: DateTime.now(),
+      ),
+      httpResponseModel: const HttpResponseModel(),
+    );
+
+    notifier.addHistoryRequest(model);
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    final historyIds = hiveHandler.getHistoryIds() as List<String>?;
+    expect(historyIds, isNotNull);
+    expect(historyIds, [historyId]);
+  });
+}


### PR DESCRIPTION
## PR Description

This PR fixes duplicate `historyIds` persistence in `HistoryMetaStateNotifier.addHistoryRequest`.

Previously, the provider rebuilt state with the new id and then appended the same id again while writing `historyIds`, which could introduce duplicates in storage. This change persists `historyIds` directly from the current state keys so each history id is stored exactly once.

Also added a regression test:
- `test/providers/history_providers_test.dart`
  - verifies that adding a history request persists a unique history id list.

## Related Issues

- Closes #

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [ ] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [ ] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_

## OS on which you have developed and tested the feature?

- [ ] Windows
- [ ] macOS
- [x] Linux