### PR TITLE
fix(history): make selected request group provider reactive

### DIFF
--- a/lib/providers/history_providers.dart
+++ b/lib/providers/history_providers.dart
@@ -8,7 +8,7 @@ final selectedHistoryIdStateProvider = StateProvider<String?>((ref) => null);
 
 final selectedRequestGroupIdStateProvider = StateProvider<String?>((ref) {
   final selectedHistoryId = ref.watch(selectedHistoryIdStateProvider);
-  final historyMetaState = ref.read(historyMetaStateNotifier);
+  final historyMetaState = ref.watch(historyMetaStateNotifier);
   if (selectedHistoryId == null) {
     return null;
   }

--- a/test/providers/history_group_provider_test.dart
+++ b/test/providers/history_group_provider_test.dart
@@ -1,0 +1,48 @@
+import 'package:apidash/models/models.dart';
+import 'package:apidash/providers/providers.dart';
+import 'package:apidash/utils/history_utils.dart';
+import 'package:apidash_core/apidash_core.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'helpers.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await testSetUpTempDirForHive();
+  });
+
+  test('selected request group updates when history meta state changes', () async {
+    final container = createContainer();
+    final notifier = container.read(historyMetaStateNotifier.notifier);
+
+    final historyId = getNewUuid();
+    container.read(selectedHistoryIdStateProvider.notifier).state = historyId;
+
+    expect(container.read(selectedRequestGroupIdStateProvider), isNull);
+
+    final meta = HistoryMetaModel(
+      historyId: historyId,
+      requestId: getNewUuid(),
+      apiType: APIType.rest,
+      name: 'History item',
+      url: 'https://api.apidash.dev/todos',
+      method: HTTPVerb.get,
+      responseStatus: 200,
+      timeStamp: DateTime.now(),
+    );
+
+    final model = HistoryRequestModel(
+      historyId: historyId,
+      metaData: meta,
+      httpResponseModel: const HttpResponseModel(),
+    );
+    notifier.addHistoryRequest(model);
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    expect(
+      container.read(selectedRequestGroupIdStateProvider),
+      getHistoryRequestKey(meta),
+    );
+  });
+}


### PR DESCRIPTION
## PR Description

This PR fixes provider reactivity for history selection grouping.

`selectedRequestGroupIdStateProvider` was using `ref.read(historyMetaStateNotifier)`, so it did not react when history metadata changed. This PR switches it to `ref.watch(historyMetaStateNotifier)`, allowing selected group id to update when history entries are inserted/updated.

Also added a regression test:
- `test/providers/history_group_provider_test.dart`
  - sets a selected history id
  - adds corresponding history meta
  - verifies selected request group id updates reactively.

## Related Issues

- Closes #

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [ ] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [ ] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_

## OS on which you have developed and tested the feature?

- [ ] Windows
- [ ] macOS
- [x] Linux