### PR TITLE
fix(better_networking): getEnabledRows uses row index, not indexOf (#1441)

### DIFF
--- a/packages/better_networking/lib/utils/http_request_utils.dart
+++ b/packages/better_networking/lib/utils/http_request_utils.dart
@@ -80,10 +80,13 @@ List<NameValueModel>? getEnabledRows(
   if (rows == null || isRowEnabledList == null) {
     return rows;
   }
-  List<NameValueModel> finalRows = rows
-      .where((element) => isRowEnabledList[rows.indexOf(element)])
-      .toList();
-  return finalRows == [] ? null : finalRows;
+  final List<NameValueModel> finalRows = [];
+  for (var i = 0; i < rows.length; i++) {
+    if (i < isRowEnabledList.length && isRowEnabledList[i]) {
+      finalRows.add(rows[i]);
+    }
+  }
+  return finalRows;
 }
 
 String? getRequestBody(APIType type, HttpRequestModel httpRequestModel) {

--- a/packages/better_networking/test/utils/http_request_utils_test.dart
+++ b/packages/better_networking/test/utils/http_request_utils_test.dart
@@ -197,6 +197,26 @@ void main() {
         [kvRow1, kvRow3],
       );
     });
+    test(
+      'duplicate rows map to their own enabled flag (indexOf would break)',
+      () {
+        const dup = NameValueModel(name: 'same', value: 'same');
+        expect(
+          getEnabledRows(
+            [dup, dup],
+            [true, false],
+          ),
+          [dup],
+        );
+        expect(
+          getEnabledRows(
+            [dup, dup],
+            [false, true],
+          ),
+          [dup],
+        );
+      },
+    );
   });
 
   group('Testing getRequestBody', () {


### PR DESCRIPTION
## PR Description

`getEnabledRows` filtered rows using `rows.indexOf(element)`, which always resolves duplicate `NameValueModel` values to the **first** matching index. That made later duplicate rows incorrectly reuse the first row’s enabled flag.

This change uses **index-based** iteration so each row maps to `isRowEnabledList[i]`.

Also removes the `finalRows == [] ? null : finalRows` branch so an all-disabled result returns `[]`, matching existing tests.

## Related Issues

- Closes #1441

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [ ] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [ ] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_

## OS on which you have developed and tested the feature?

- [ ] Windows
- [ ] macOS
- [x] Linux

## Test plan
- `flutter test packages/better_networking/test/utils/http_request_utils_test.dart`
- `flutter test packages/better_networking` (optional)
- `flutter analyze packages/better_networking`