### PR TITLE
addedSniffingLogicInModelLayer

### DIFF
--- a/packages/better_networking/lib/models/http_response_model.dart
+++ b/packages/better_networking/lib/models/http_response_model.dart
@@ -60,7 +60,7 @@ class HttpResponseModel with _$HttpResponseModel {
       _$HttpResponseModelFromJson(json);
 
   String? get contentType => headers?.getValueContentType();
-  MediaType? get mediaType => getMediaTypeFromHeaders(headers);
+  MediaType? get mediaType => getMediaTypeFromHeadersOrSniff(headers, bodyBytes);
 
   HttpResponseModel fromResponse({
     required Response response,
@@ -70,7 +70,7 @@ class HttpResponseModel with _$HttpResponseModel {
     final responseHeaders = mergeMaps({
       HttpHeaders.contentLengthHeader: response.contentLength.toString(),
     }, response.headers);
-    MediaType? mediaType = getMediaTypeFromHeaders(responseHeaders);
+    MediaType? mediaType = getMediaTypeFromHeadersOrSniff(responseHeaders, response.bodyBytes);
 
     final body = (mediaType?.subtype == kSubTypeJson)
         ? utf8.decode(response.bodyBytes)

--- a/packages/better_networking/lib/utils/content_type_utils.dart
+++ b/packages/better_networking/lib/utils/content_type_utils.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+import 'dart:typed_data';
 import 'package:http_parser/http_parser.dart';
 import '../consts.dart';
 import '../extensions/extensions.dart';
@@ -14,6 +16,83 @@ MediaType? getMediaTypeFromHeaders(Map? headers) {
   var contentType = headers?.getValueContentType();
   MediaType? mediaType = getMediaTypeFromContentType(contentType);
   return mediaType;
+}
+
+MediaType? getMediaTypeFromHeadersOrSniff(
+  Map<String, String>? headers,
+  Uint8List? bodyBytes,
+) {
+  final parsed = getMediaTypeFromHeaders(headers);
+
+  final shouldSniff = parsed == null ||
+      (parsed.type == kTypeApplication &&
+          parsed.subtype == kSubTypeOctetStream);
+
+  if (!shouldSniff || bodyBytes == null || bodyBytes.isEmpty) {
+    return parsed;
+  }
+
+  return sniffMediaTypeFromBytes(bodyBytes) ?? parsed;
+}
+
+MediaType? sniffMediaTypeFromBytes(Uint8List bytes) {
+  if (bytes.isEmpty) return null;
+
+  // Conservative binary signatures for first-pass detection.
+  if (_startsWith(bytes, const [0x25, 0x50, 0x44, 0x46])) {
+    return MediaType(kTypeApplication, kSubTypePdf); // %PDF
+  }
+  if (_startsWith(bytes, const [0x89, 0x50, 0x4E, 0x47])) {
+    return MediaType(kTypeImage, 'png');
+  }
+  if (_startsWith(bytes, const [0xFF, 0xD8, 0xFF])) {
+    return MediaType(kTypeImage, 'jpeg');
+  }
+  if (_startsWith(bytes, const [0x47, 0x49, 0x46, 0x38])) {
+    return MediaType(kTypeImage, 'gif');
+  }
+
+  // Text-like payload probing
+  final prefixLen = bytes.length < 1024 ? bytes.length : 1024;
+  final prefix = bytes.sublist(0, prefixLen);
+
+  String textPrefix;
+  try {
+    textPrefix = utf8.decode(prefix);
+  } catch (_) {
+    textPrefix = '';
+  }
+
+  final trimmed = textPrefix.trimLeft();
+
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    return MediaType(kTypeApplication, kSubTypeJson);
+  }
+
+  if (_isLikelyText(prefix)) {
+    return MediaType(kTypeText, kSubTypePlain);
+  }
+
+  return null;
+}
+
+bool _startsWith(Uint8List bytes, List<int> sig) {
+  if (bytes.length < sig.length) return false;
+  for (var i = 0; i < sig.length; i++) {
+    if (bytes[i] != sig[i]) return false;
+  }
+  return true;
+}
+
+bool _isLikelyText(Uint8List bytes) {
+  var printable = 0;
+  for (final b in bytes) {
+    if (b == 0) return false;
+    if (b == 9 || b == 10 || b == 13 || (b >= 32 && b <= 126)) {
+      printable++;
+    }
+  }
+  return bytes.isNotEmpty && printable / bytes.length > 0.9;
 }
 
 MediaType? getMediaTypeFromContentType(String? contentType) {


### PR DESCRIPTION
Fixes #1382 
## Summary
Moves response content sniffing and preview-type selection into the model/networking layer so content interpretation happens once, before any UI rendering.

## Problem
Through sniffing the magic bytes we are routing the application/stream-octet to a appropriate previewer

## Solution
- Response sniffing now happens in the model/networking flow
- Content type is classified once and exposed as structured model data
- Improved content-type utility handling for ambiguous or missing headers

This should be architecturally better approach 

## Why Model Layer
| Concern | Before | After |
|---|---|---|
| Logic location | Widget layer | Model/networking layer |
| Source of truth | Multiple widgets | Single classification |
| Testability | Widget-level tests | Pure unit tests |
| Reusability | Per-view | Desktop, mobile, web |
| Rebuild performance | Repeated parsing | Computed once |

## Impact
- No UI changes
- Reduces renderer mismatch risk across all response consumers

## Demo

https://github.com/user-attachments/assets/cb69823b-0861-4358-b971-8d2bbab14f92

