### PR TITLE
Resolving issue #1591 - making genai pure dart (clean) - latest

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,16 +12,14 @@ import 'app.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Stac.initialize();
+  registerDefaultOAuth2CallbackHandler(oauth2PlatformCallbackHandler);
 
   //Load all LLMs
   await ModelManager.fetchAvailableModels();
 
   var settingsModel = await getSettingsFromSharedPrefs();
   var onboardingStatus = await getOnboardingStatusFromSharedPrefs();
-  final initStatus = await initApp(
-    kIsDesktop,
-    settingsModel: settingsModel,
-  );
+  final initStatus = await initApp(kIsDesktop, settingsModel: settingsModel);
   if (kIsDesktop) {
     await initWindow(settingsModel: settingsModel);
   }
@@ -65,26 +63,15 @@ Future<bool> initApp(
   }
 }
 
-Future<void> initWindow({
-  Size? sz,
-  SettingsModel? settingsModel,
-}) async {
+Future<void> initWindow({Size? sz, SettingsModel? settingsModel}) async {
   if (kIsLinux) {
-    await setupInitialWindow(
-      sz: sz ?? settingsModel?.size,
-    );
+    await setupInitialWindow(sz: sz ?? settingsModel?.size);
   }
   if (kIsMacOS || kIsWindows) {
     if (sz != null) {
-      await setupWindow(
-        sz: sz,
-        off: const Offset(100, 100),
-      );
+      await setupWindow(sz: sz, off: const Offset(100, 100));
     } else {
-      await setupWindow(
-        sz: settingsModel?.size,
-        off: settingsModel?.offset,
-      );
+      await setupWindow(sz: settingsModel?.size, off: settingsModel?.offset);
     }
   }
 }

--- a/lib/services/oauth_services.dart
+++ b/lib/services/oauth_services.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_web_auth_2/flutter_web_auth_2.dart';
+
+Future<String> oauth2PlatformCallbackHandler(
+  String url, {
+  required String callbackUrlScheme,
+}) async {
+  return FlutterWebAuth2.authenticate(
+    url: url,
+    callbackUrlScheme: callbackUrlScheme,
+    options: const FlutterWebAuth2Options(
+      useWebview: true,
+      windowName: 'OAuth Authorization - API Dash',
+    ),
+  );
+}

--- a/lib/services/services.dart
+++ b/lib/services/services.dart
@@ -1,4 +1,5 @@
 export 'hive_services.dart';
 export 'history_service.dart';
+export 'oauth_services.dart';
 export 'window_services.dart';
 export 'shared_preferences_services.dart';

--- a/packages/better_networking/analysis_options.yaml
+++ b/packages/better_networking/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:flutter_lints/flutter.yaml
+include: package:lints/recommended.yaml
 
 analyzer:
   errors:

--- a/packages/better_networking/example/pubspec.lock
+++ b/packages/better_networking/example/pubspec.lock
@@ -48,14 +48,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
-  code_assets:
-    dependency: transitive
-    description:
-      name: code_assets
-      sha256: "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
   collection:
     dependency: transitive
     description:
@@ -96,14 +88,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.3.2"
-  desktop_webview_window:
-    dependency: transitive
-    description:
-      name: desktop_webview_window
-      sha256: "57cf20d81689d5cbb1adfd0017e96b669398a669d927906073b0e42fc64111c0"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.3"
   ed25519_edwards:
     dependency: transitive
     description:
@@ -120,22 +104,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
-  ffi:
-    dependency: transitive
-    description:
-      name: ffi
-      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.0"
-  file:
-    dependency: transitive
-    description:
-      name: file
-      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.1"
   fixnum:
     dependency: transitive
     description:
@@ -162,51 +130,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_web_auth_2:
-    dependency: transitive
-    description:
-      name: flutter_web_auth_2
-      sha256: "432ff8c7b2834eaeec3378d99e24a0210b9ac2f453b3f7a7d739a5c09069fba3"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.0.1"
-  flutter_web_auth_2_platform_interface:
-    dependency: transitive
-    description:
-      name: flutter_web_auth_2_platform_interface
-      sha256: ba0fbba55bffb47242025f96852ad1ffba34bc451568f56ef36e613612baffab
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.0.0"
-  flutter_web_plugins:
-    dependency: transitive
-    description: flutter
-    source: sdk
-    version: "0.0.0"
   freezed_annotation:
     dependency: transitive
     description:
       name: freezed_annotation
-      sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
+      sha256: "7294967ff0a6d98638e7acb774aac3af2550777accd8149c90af5b014e6d44d8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.4"
-  glob:
-    dependency: transitive
-    description:
-      name: glob
-      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.3"
-  hooks:
-    dependency: transitive
-    description:
-      name: hooks
-      sha256: e79ed1e8e1929bc6ecb6ec85f0cb519c887aa5b423705ded0d0f2d9226def388
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.2"
+    version: "3.1.0"
   http:
     dependency: transitive
     description:
@@ -271,14 +202,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
-  logging:
-    dependency: transitive
-    description:
-      name: logging
-      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
@@ -303,14 +226,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
-  native_toolchain_c:
-    dependency: transitive
-    description:
-      name: native_toolchain_c
-      sha256: "92b2ca62c8bd2b8d2f267cdfccf9bfbdb7322f778f8f91b3ce5b5cda23a3899f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.17.5"
   oauth1:
     dependency: transitive
     description:
@@ -327,14 +242,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.5"
-  objective_c:
-    dependency: transitive
-    description:
-      name: objective_c
-      sha256: "100a1c87616ab6ed41ec263b083c0ef3261ee6cd1dc3b0f35f8ddfa4f996fe52"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.3.0"
   path:
     dependency: transitive
     description:
@@ -343,54 +250,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
-  path_provider:
-    dependency: transitive
-    description:
-      name: path_provider
-      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.5"
-  path_provider_android:
-    dependency: transitive
-    description:
-      name: path_provider_android
-      sha256: f2c65e21139ce2c3dad46922be8272bb5963516045659e71bb16e151c93b580e
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.22"
-  path_provider_foundation:
-    dependency: transitive
-    description:
-      name: path_provider_foundation
-      sha256: "2a376b7d6392d80cd3705782d2caa734ca4727776db0b6ec36ef3f1855197699"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.6.0"
-  path_provider_linux:
-    dependency: transitive
-    description:
-      name: path_provider_linux
-      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.1"
-  path_provider_platform_interface:
-    dependency: transitive
-    description:
-      name: path_provider_platform_interface
-      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.2"
-  path_provider_windows:
-    dependency: transitive
-    description:
-      name: path_provider_windows
-      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.3.0"
   petitparser:
     dependency: transitive
     description:
@@ -399,22 +258,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.2"
-  platform:
-    dependency: transitive
-    description:
-      name: platform
-      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.6"
-  plugin_platform_interface:
-    dependency: transitive
-    description:
-      name: plugin_platform_interface
-      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.8"
   pointycastle:
     dependency: transitive
     description:
@@ -423,22 +266,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
-  pub_semver:
-    dependency: transitive
-    description:
-      name: pub_semver
-      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.0"
   seed:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: seed
-      sha256: "0d74a46abd169c96a73d9dec4739e6623021915661beadf265e885bb1eafd214"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.0.3"
+      path: "../../seed"
+      relative: true
+    source: path
+    version: "0.0.4-dev"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -500,70 +334,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
-  url_launcher:
-    dependency: transitive
-    description:
-      name: url_launcher
-      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.3.2"
-  url_launcher_android:
-    dependency: transitive
-    description:
-      name: url_launcher_android
-      sha256: "767344bf3063897b5cf0db830e94f904528e6dd50a6dfaf839f0abf509009611"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.3.28"
-  url_launcher_ios:
-    dependency: transitive
-    description:
-      name: url_launcher_ios
-      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.4.1"
-  url_launcher_linux:
-    dependency: transitive
-    description:
-      name: url_launcher_linux
-      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.2.2"
-  url_launcher_macos:
-    dependency: transitive
-    description:
-      name: url_launcher_macos
-      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.2.5"
-  url_launcher_platform_interface:
-    dependency: transitive
-    description:
-      name: url_launcher_platform_interface
-      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.3.2"
-  url_launcher_web:
-    dependency: transitive
-    description:
-      name: url_launcher_web
-      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.2"
-  url_launcher_windows:
-    dependency: transitive
-    description:
-      name: url_launcher_windows
-      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.5"
   vector_math:
     dependency: transitive
     description:
@@ -588,22 +358,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
-  window_to_front:
-    dependency: transitive
-    description:
-      name: window_to_front
-      sha256: "7aef379752b7190c10479e12b5fd7c0b9d92adc96817d9e96c59937929512aee"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.0.3"
-  xdg_directories:
-    dependency: transitive
-    description:
-      name: xdg_directories
-      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.0"
   xml:
     dependency: transitive
     description:
@@ -612,14 +366,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.6.1"
-  yaml:
-    dependency: transitive
-    description:
-      name: yaml
-      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.3"
 sdks:
-  dart: ">=3.10.3 <4.0.0"
-  flutter: ">=3.38.4"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/packages/better_networking/example/pubspec.yaml
+++ b/packages/better_networking/example/pubspec.yaml
@@ -14,6 +14,10 @@ dependencies:
     path: ..
   cupertino_icons: ^1.0.8
 
+dependency_overrides:
+  seed:
+    path: ../../seed
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/packages/better_networking/lib/services/http_client_manager.dart
+++ b/packages/better_networking/lib/services/http_client_manager.dart
@@ -1,7 +1,9 @@
 import 'dart:io';
-import 'package:flutter/foundation.dart';
+
 import 'package:http/http.dart' as http;
 import 'package:http/io_client.dart';
+
+import '../utils/platform_utils.dart';
 
 http.Client createHttpClientWithNoSSL() {
   var ioClient = HttpClient()
@@ -40,7 +42,7 @@ class HttpClientManager {
   HttpClientManager._internal();
 
   http.Client createClient(String requestId, {bool noSSL = false}) {
-    final client = (noSSL && !kIsWeb)
+    final client = (noSSL && !isThisWeb)
         ? createHttpClientWithNoSSL()
         : http.Client();
     _clients[requestId] = client;
@@ -82,7 +84,7 @@ class HttpClientManager {
     String requestId, {
     bool noSSL = false,
   }) {
-    final baseClient = (noSSL && !kIsWeb)
+    final baseClient = (noSSL && !isThisWeb)
         ? createHttpClientWithNoSSL()
         : http.Client();
 

--- a/packages/better_networking/lib/services/http_service.dart
+++ b/packages/better_networking/lib/services/http_service.dart
@@ -26,6 +26,11 @@ Future<(HttpResponse?, Duration?, String?)> sendHttpRequestV1(
   HttpRequestModel requestModel, {
   SupportedUriSchemes defaultUriScheme = kDefaultUriScheme,
   bool noSSL = false,
+
+  /// Overrides the registered default OAuth2 callback handler for
+  /// authorization-code flows on platforms that do not support the localhost
+  /// callback server.
+  OAuth2CallbackHandler? customCallbackHandler,
 }) async {
   final authData = requestModel.authModel;
   if (httpClientManager.wasRequestCancelled(requestId)) {
@@ -37,7 +42,11 @@ Future<(HttpResponse?, Duration?, String?)> sendHttpRequestV1(
 
   try {
     if (authData != null && authData.type != APIAuthType.none) {
-      authenticatedRequestModel = await handleAuth(requestModel, authData);
+      authenticatedRequestModel = await handleAuth(
+        requestModel,
+        authData,
+        customCallbackHandler: customCallbackHandler,
+      );
     }
   } catch (e) {
     return (null, null, e.toString());
@@ -161,6 +170,11 @@ Future<(HttpResponse?, Duration?, String?)> sendHttpRequest(
   HttpRequestModel requestModel, {
   SupportedUriSchemes defaultUriScheme = kDefaultUriScheme,
   bool noSSL = false,
+
+  /// Overrides the registered default OAuth2 callback handler for
+  /// authorization-code flows on platforms that do not support the localhost
+  /// callback server.
+  OAuth2CallbackHandler? customCallbackHandler,
 }) async {
   final stream = await streamHttpRequest(
     requestId,
@@ -168,6 +182,7 @@ Future<(HttpResponse?, Duration?, String?)> sendHttpRequest(
     requestModel,
     defaultUriScheme: defaultUriScheme,
     noSSL: noSSL,
+    customCallbackHandler: customCallbackHandler,
   );
   final output = await stream.first;
   return (output?.$2, output?.$3, output?.$4);
@@ -216,6 +231,11 @@ Future<Stream<HttpStreamOutput>> streamHttpRequest(
   HttpRequestModel httpRequestModel, {
   SupportedUriSchemes defaultUriScheme = kDefaultUriScheme,
   bool noSSL = false,
+
+  /// Overrides the registered default OAuth2 callback handler for
+  /// authorization-code flows on platforms that do not support the localhost
+  /// callback server.
+  OAuth2CallbackHandler? customCallbackHandler,
 }) async {
   final authData = httpRequestModel.authModel;
   final controller = StreamController<HttpStreamOutput>();
@@ -267,6 +287,7 @@ Future<Stream<HttpStreamOutput>> streamHttpRequest(
       authenticatedHttpRequestModel = await handleAuth(
         httpRequestModel,
         authData,
+        customCallbackHandler: customCallbackHandler,
       );
     }
   } catch (e) {

--- a/packages/better_networking/lib/src/logging.dart
+++ b/packages/better_networking/lib/src/logging.dart
@@ -1,0 +1,5 @@
+import 'dart:developer' as developer;
+
+void logDebug(String message) {
+  developer.log(message, name: 'better_networking');
+}

--- a/packages/better_networking/lib/utils/auth/auth.dart
+++ b/packages/better_networking/lib/utils/auth/auth.dart
@@ -1,0 +1,3 @@
+export 'handle_auth.dart';
+export 'auth_exceptions.dart';
+export 'oauth2_utils.dart';

--- a/packages/better_networking/lib/utils/auth/auth_exceptions.dart
+++ b/packages/better_networking/lib/utils/auth/auth_exceptions.dart
@@ -1,0 +1,27 @@
+class AuthException implements Exception {
+  const AuthException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class OAuth2ConfigurationException extends AuthException {
+  const OAuth2ConfigurationException(super.message);
+}
+
+class OAuth2AuthorizationException extends AuthException {
+  const OAuth2AuthorizationException(super.message);
+}
+
+class OAuth2CallbackHandlerRequiredException extends AuthException {
+  OAuth2CallbackHandlerRequiredException({
+    required String callbackUrlScheme,
+    required String platformDescription,
+  }) : super(
+         'A custom callback handler is required for OAuth2 authorization on '
+         '$platformDescription. Provide a handler capable of completing the '
+         'redirect for the "$callbackUrlScheme" scheme.',
+       );
+}

--- a/packages/better_networking/lib/utils/auth/handle_auth.dart
+++ b/packages/better_networking/lib/utils/auth/handle_auth.dart
@@ -1,32 +1,27 @@
 import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
-import 'package:better_networking/utils/auth/jwt_auth_utils.dart';
-import 'package:better_networking/utils/auth/digest_auth_utils.dart';
-import 'package:better_networking/better_networking.dart';
-import 'package:better_networking/utils/auth/oauth2_utils.dart';
-import 'package:flutter/foundation.dart';
 
+import 'package:better_networking/better_networking.dart';
+import 'package:better_networking/utils/auth/digest_auth_utils.dart';
+import 'package:better_networking/utils/auth/jwt_auth_utils.dart';
+
+import '../../src/logging.dart';
 import 'oauth1_utils.dart';
 
 Future<HttpRequestModel> handleAuth(
   HttpRequestModel httpRequestModel,
-  AuthModel? authData,
-) async {
+  AuthModel? authData, {
+  /// Overrides the registered default OAuth2 callback handler for
+  /// authorization-code flows on platforms that do not support the localhost
+  /// callback server.
+  OAuth2CallbackHandler? customCallbackHandler,
+}) async {
   if (authData == null || authData.type == APIAuthType.none) {
     return httpRequestModel;
   }
 
-  List<NameValueModel> updatedHeaders = List.from(
-    httpRequestModel.headers ?? [],
-  );
-  List<NameValueModel> updatedParams = List.from(httpRequestModel.params ?? []);
-  List<bool> updatedHeaderEnabledList = List.from(
-    httpRequestModel.isHeaderEnabledList ?? [],
-  );
-  List<bool> updatedParamEnabledList = List.from(
-    httpRequestModel.isParamEnabledList ?? [],
-  );
+  final mutations = _AuthMutationBuffer.fromRequest(httpRequestModel);
 
   switch (authData.type) {
     case APIAuthType.basic:
@@ -35,23 +30,13 @@ Future<HttpRequestModel> handleAuth(
         final encoded = base64Encode(
           utf8.encode('${basicAuth.username}:${basicAuth.password}'),
         );
-        updatedHeaders.add(
-          NameValueModel(name: 'Authorization', value: 'Basic $encoded'),
-        );
-        updatedHeaderEnabledList.add(true);
+        mutations.addHeader('Authorization', 'Basic $encoded');
       }
       break;
 
     case APIAuthType.bearer:
       if (authData.bearer != null) {
-        final bearerAuth = authData.bearer!;
-        updatedHeaders.add(
-          NameValueModel(
-            name: 'Authorization',
-            value: 'Bearer ${bearerAuth.token}',
-          ),
-        );
-        updatedHeaderEnabledList.add(true);
+        mutations.addBearerAuthorization(authData.bearer!.token);
       }
       break;
 
@@ -64,16 +49,12 @@ Future<HttpRequestModel> handleAuth(
           final headerValue = jwtAuth.headerPrefix.isNotEmpty
               ? '${jwtAuth.headerPrefix} $jwtToken'
               : jwtToken;
-          updatedHeaders.add(
-            NameValueModel(name: 'Authorization', value: headerValue),
-          );
-          updatedHeaderEnabledList.add(true);
+          mutations.addHeader('Authorization', headerValue);
         } else if (jwtAuth.addTokenTo == 'query') {
           final paramKey = jwtAuth.queryParamKey.isNotEmpty
               ? jwtAuth.queryParamKey
               : 'token';
-          updatedParams.add(NameValueModel(name: paramKey, value: jwtToken));
-          updatedParamEnabledList.add(true);
+          mutations.addParam(paramKey, jwtToken);
         }
       }
       break;
@@ -82,197 +63,222 @@ Future<HttpRequestModel> handleAuth(
       if (authData.apikey != null) {
         final apiKeyAuth = authData.apikey!;
         if (apiKeyAuth.location == 'header') {
-          updatedHeaders.add(
-            NameValueModel(name: apiKeyAuth.name, value: apiKeyAuth.key),
-          );
-          updatedHeaderEnabledList.add(true);
+          mutations.addHeader(apiKeyAuth.name, apiKeyAuth.key);
         } else if (apiKeyAuth.location == 'query') {
-          updatedParams.add(
-            NameValueModel(name: apiKeyAuth.name, value: apiKeyAuth.key),
-          );
-          updatedParamEnabledList.add(true);
+          mutations.addParam(apiKeyAuth.name, apiKeyAuth.key);
         }
       }
       break;
 
     case APIAuthType.none:
       break;
+
     case APIAuthType.digest:
       if (authData.digest != null) {
-        final digestAuthModel = authData.digest!;
-
-        if (digestAuthModel.realm.isNotEmpty &&
-            digestAuthModel.nonce.isNotEmpty) {
-          final digestAuth = DigestAuth.fromModel(digestAuthModel);
-          final authString = digestAuth.getAuthString(httpRequestModel);
-
-          updatedHeaders.add(
-            NameValueModel(name: 'Authorization', value: authString),
-          );
-          updatedHeaderEnabledList.add(true);
-        } else {
-          final httpResult = await sendHttpRequestV1(
-            "digest-${Random.secure()}",
-            APIType.rest,
-            httpRequestModel,
-          );
-          final httpResponse = httpResult.$1;
-
-          if (httpResponse == null) {
-            throw Exception("Initial Digest request failed: no response");
-          }
-
-          if (httpResponse.statusCode == 401) {
-            final wwwAuthHeader = httpResponse.headers[kHeaderWwwAuthenticate];
-
-            if (wwwAuthHeader == null) {
-              throw Exception("401 response missing www-authenticate header");
-            }
-
-            final authParams = splitAuthenticateHeader(wwwAuthHeader);
-
-            if (authParams == null) {
-              throw Exception("Invalid Digest header format");
-            }
-
-            final updatedDigestModel = digestAuthModel.copyWith(
-              realm: authParams['realm'] ?? '',
-              nonce: authParams['nonce'] ?? '',
-              algorithm: authParams['algorithm'] ?? 'MD5',
-              qop: authParams['qop'] ?? 'auth',
-              opaque: authParams['opaque'] ?? '',
-            );
-
-            final digestAuth = DigestAuth.fromModel(updatedDigestModel);
-            final authString = digestAuth.getAuthString(httpRequestModel);
-            updatedHeaders.add(
-              NameValueModel(name: 'Authorization', value: authString),
-            );
-            updatedHeaderEnabledList.add(true);
-          } else {
-            throw Exception(
-              "Initial Digest request failed due to unexpected status code: ${httpResponse.body}. Status Code: ${httpResponse.statusCode}",
-            );
-          }
-        }
+        await _applyDigestAuth(
+          httpRequestModel,
+          authData.digest!,
+          mutations,
+        );
       }
       break;
+
     case APIAuthType.oauth1:
       if (authData.oauth1 != null) {
         final oauth1Model = authData.oauth1!;
 
         try {
-          final client = generateOAuth1AuthHeader(
+          final header = generateOAuth1AuthHeader(
             oauth1Model,
             httpRequestModel,
           );
-
-          updatedHeaders.add(
-            NameValueModel(name: 'Authorization', value: client),
-          );
-          updatedHeaderEnabledList.add(true);
+          mutations.addHeader('Authorization', header);
         } catch (e) {
-          throw Exception('OAuth 1.0 authentication failed: $e');
+          throw AuthException('OAuth 1.0 authentication failed: $e');
         }
       }
       break;
+
     case APIAuthType.oauth2:
-      final oauth2 = authData.oauth2;
-
-      if (oauth2 == null) {
-        throw Exception("Failed to get OAuth2 Data");
-      }
-
-      if (oauth2.redirectUrl == null) {
-        throw Exception("No Redirect URL found!");
-      }
-
-      final credentialsFile = oauth2.credentialsFilePath != null
-          ? File(oauth2.credentialsFilePath!)
-          : null;
-
-      switch (oauth2.grantType) {
-        case OAuth2GrantType.authorizationCode:
-          // Use localhost callback server for desktop platforms, fallback to custom scheme for mobile
-          final res = await oAuth2AuthorizationCodeGrant(
-            identifier: oauth2.clientId,
-            secret: oauth2.clientSecret,
-            authorizationEndpoint: Uri.parse(oauth2.authorizationUrl),
-            redirectUrl: Uri.parse(
-              oauth2.redirectUrl!.isEmpty
-                  ? "apidash://oauth2/callback"
-                  : oauth2.redirectUrl!,
-            ),
-            tokenEndpoint: Uri.parse(oauth2.accessTokenUrl),
-            credentialsFile: credentialsFile,
-            scope: oauth2.scope,
-          );
-
-          // Clean up the callback server if it exists and is still running
-          // Note: The server might have already stopped itself due to timeout/error/completion
-          final server = res.$2;
-          if (server != null) {
-            try {
-              await server.stop();
-            } catch (e) {
-              debugPrint(
-                'Error stopping OAuth callback server (might already be stopped): $e',
-              );
-            }
-          }
-
-          debugPrint(res.$1.credentials.accessToken);
-
-          // Add the access token to the request headers
-          updatedHeaders.add(
-            NameValueModel(
-              name: 'Authorization',
-              value: 'Bearer ${res.$1.credentials.accessToken}',
-            ),
-          );
-          updatedHeaderEnabledList.add(true);
-
-          break;
-        case OAuth2GrantType.clientCredentials:
-          final client = await oAuth2ClientCredentialsGrantHandler(
-            oauth2Model: oauth2,
-            credentialsFile: credentialsFile,
-          );
-          debugPrint(client.credentials.accessToken);
-
-          // Add the access token to the request headers
-          updatedHeaders.add(
-            NameValueModel(
-              name: 'Authorization',
-              value: 'Bearer ${client.credentials.accessToken}',
-            ),
-          );
-          updatedHeaderEnabledList.add(true);
-          break;
-        case OAuth2GrantType.resourceOwnerPassword:
-          debugPrint("==Resource Owner Password==");
-          final client = await oAuth2ResourceOwnerPasswordGrantHandler(
-            oauth2Model: oauth2,
-            credentialsFile: credentialsFile,
-          );
-          debugPrint(client.credentials.accessToken);
-
-          // Add the access token to the request headers
-          updatedHeaders.add(
-            NameValueModel(
-              name: 'Authorization',
-              value: 'Bearer ${client.credentials.accessToken}',
-            ),
-          );
-          updatedHeaderEnabledList.add(true);
-          break;
-      }
+      await _applyOAuth2Auth(
+        httpRequestModel,
+        authData.oauth2,
+        mutations,
+        customCallbackHandler: customCallbackHandler,
+      );
+      break;
   }
 
-  return httpRequestModel.copyWith(
-    headers: updatedHeaders,
-    params: updatedParams,
-    isHeaderEnabledList: updatedHeaderEnabledList,
-    isParamEnabledList: updatedParamEnabledList,
+  return mutations.build(httpRequestModel);
+}
+
+Future<void> _applyDigestAuth(
+  HttpRequestModel httpRequestModel,
+  AuthDigestModel digestAuthModel,
+  _AuthMutationBuffer mutations,
+) async {
+  if (digestAuthModel.realm.isNotEmpty && digestAuthModel.nonce.isNotEmpty) {
+    final digestAuth = DigestAuth.fromModel(digestAuthModel);
+    final authString = digestAuth.getAuthString(httpRequestModel);
+    mutations.addHeader('Authorization', authString);
+    return;
+  }
+
+  final httpResult = await sendHttpRequestV1(
+    'digest-${Random.secure()}',
+    APIType.rest,
+    httpRequestModel,
   );
+  final httpResponse = httpResult.$1;
+
+  if (httpResponse == null) {
+    throw const AuthException('Initial Digest request failed: no response');
+  }
+
+  if (httpResponse.statusCode != 401) {
+    throw AuthException(
+      'Initial Digest request failed due to unexpected status code: '
+      '${httpResponse.body}. Status Code: ${httpResponse.statusCode}',
+    );
+  }
+
+  final wwwAuthHeader = httpResponse.headers[kHeaderWwwAuthenticate];
+  if (wwwAuthHeader == null) {
+    throw const AuthException('401 response missing www-authenticate header');
+  }
+
+  final authParams = splitAuthenticateHeader(wwwAuthHeader);
+  if (authParams == null) {
+    throw const AuthException('Invalid Digest header format');
+  }
+
+  final updatedDigestModel = digestAuthModel.copyWith(
+    realm: authParams['realm'] ?? '',
+    nonce: authParams['nonce'] ?? '',
+    algorithm: authParams['algorithm'] ?? 'MD5',
+    qop: authParams['qop'] ?? 'auth',
+    opaque: authParams['opaque'] ?? '',
+  );
+
+  final digestAuth = DigestAuth.fromModel(updatedDigestModel);
+  mutations.addHeader(
+    'Authorization',
+    digestAuth.getAuthString(httpRequestModel),
+  );
+}
+
+Future<void> _applyOAuth2Auth(
+  HttpRequestModel httpRequestModel,
+  AuthOAuth2Model? oauth2,
+  _AuthMutationBuffer mutations, {
+  OAuth2CallbackHandler? customCallbackHandler,
+}) async {
+  if (oauth2 == null) {
+    throw const OAuth2ConfigurationException('Failed to get OAuth2 data.');
+  }
+
+  logDebug('Starting OAuth2 ${oauth2.grantType.name} flow.');
+  final accessToken = await _resolveOAuth2AccessToken(
+    oauth2,
+    customCallbackHandler: customCallbackHandler,
+  );
+  mutations.addBearerAuthorization(accessToken);
+  logDebug('OAuth2 ${oauth2.grantType.name} flow completed successfully.');
+}
+
+Future<String> _resolveOAuth2AccessToken(
+  AuthOAuth2Model oauth2, {
+  OAuth2CallbackHandler? customCallbackHandler,
+}) async {
+  final credentialsFile = oauth2.credentialsFilePath != null
+      ? File(oauth2.credentialsFilePath!)
+      : null;
+
+  switch (oauth2.grantType) {
+    case OAuth2GrantType.authorizationCode:
+      final result = await oAuth2AuthorizationCodeGrant(
+        identifier: oauth2.clientId,
+        secret: oauth2.clientSecret,
+        authorizationEndpoint: Uri.parse(oauth2.authorizationUrl),
+        redirectUrl: _resolveOAuth2RedirectUrl(oauth2),
+        tokenEndpoint: Uri.parse(oauth2.accessTokenUrl),
+        credentialsFile: credentialsFile,
+        scope: oauth2.scope,
+        customCallbackHandler: customCallbackHandler,
+      );
+      await _stopOAuth2CallbackServer(result.$2);
+      return result.$1.credentials.accessToken;
+
+    case OAuth2GrantType.clientCredentials:
+      final client = await oAuth2ClientCredentialsGrantHandler(
+        oauth2Model: oauth2,
+        credentialsFile: credentialsFile,
+      );
+      return client.credentials.accessToken;
+
+    case OAuth2GrantType.resourceOwnerPassword:
+      final client = await oAuth2ResourceOwnerPasswordGrantHandler(
+        oauth2Model: oauth2,
+        credentialsFile: credentialsFile,
+      );
+      return client.credentials.accessToken;
+  }
+}
+
+Uri _resolveOAuth2RedirectUrl(AuthOAuth2Model oauth2) {
+  final redirectUrl = oauth2.redirectUrl;
+  if (redirectUrl == null || redirectUrl.isEmpty) {
+    return Uri.parse('apidash://oauth2/callback');
+  }
+  return Uri.parse(redirectUrl);
+}
+
+Future<void> _stopOAuth2CallbackServer(OAuthCallbackServer? server) async {
+  if (server == null) {
+    return;
+  }
+
+  try {
+    await server.stop();
+  } catch (e) {
+    logDebug(
+      'Error stopping OAuth callback server (might already be stopped): $e',
+    );
+  }
+}
+
+class _AuthMutationBuffer {
+  _AuthMutationBuffer.fromRequest(HttpRequestModel requestModel)
+      : headers = List.from(requestModel.headers ?? []),
+        params = List.from(requestModel.params ?? []),
+        headerEnabled = List.from(requestModel.isHeaderEnabledList ?? []),
+        paramEnabled = List.from(requestModel.isParamEnabledList ?? []);
+
+  final List<NameValueModel> headers;
+  final List<NameValueModel> params;
+  final List<bool> headerEnabled;
+  final List<bool> paramEnabled;
+
+  void addHeader(String name, String value) {
+    headers.add(NameValueModel(name: name, value: value));
+    headerEnabled.add(true);
+  }
+
+  void addParam(String name, String value) {
+    params.add(NameValueModel(name: name, value: value));
+    paramEnabled.add(true);
+  }
+
+  void addBearerAuthorization(String token) {
+    addHeader('Authorization', 'Bearer $token');
+  }
+
+  HttpRequestModel build(HttpRequestModel requestModel) {
+    return requestModel.copyWith(
+      headers: headers,
+      params: params,
+      isHeaderEnabledList: headerEnabled,
+      isParamEnabledList: paramEnabled,
+    );
+  }
 }

--- a/packages/better_networking/lib/utils/auth/oauth2_utils.dart
+++ b/packages/better_networking/lib/utils/auth/oauth2_utils.dart
@@ -1,12 +1,30 @@
 import 'dart:async';
 import 'dart:io';
-import 'package:flutter_web_auth_2/flutter_web_auth_2.dart';
 import 'package:oauth2/oauth2.dart' as oauth2;
 
 import '../../models/auth/auth_oauth2_model.dart';
 import '../../services/http_client_manager.dart';
 import '../../services/oauth_callback_server.dart';
 import '../platform_utils.dart';
+import 'auth_exceptions.dart';
+
+typedef OAuth2CallbackHandler = Future<String> Function(
+  String url, {
+  required String callbackUrlScheme,
+});
+
+OAuth2CallbackHandler? _defaultOAuth2CallbackHandler;
+
+OAuth2CallbackHandler? get defaultOAuth2CallbackHandler =>
+    _defaultOAuth2CallbackHandler;
+
+void registerDefaultOAuth2CallbackHandler(OAuth2CallbackHandler handler) {
+  _defaultOAuth2CallbackHandler = handler;
+}
+
+void clearDefaultOAuth2CallbackHandler() {
+  _defaultOAuth2CallbackHandler = null;
+}
 
 /// Advanced OAuth2 authorization code grant handler that returns both the client and server
 /// for cases where you need manual control over the callback server lifecycle.
@@ -22,6 +40,10 @@ Future<(oauth2.Client, OAuthCallbackServer?)> oAuth2AuthorizationCodeGrant({
   required File? credentialsFile,
   String? state,
   String? scope,
+
+  /// Required when running the authorization-code flow on platforms that
+  /// cannot capture a localhost callback directly.
+  OAuth2CallbackHandler? customCallbackHandler,
 }) async {
   // Check for existing credentials first
   if (credentialsFile != null && await credentialsFile.exists()) {
@@ -85,7 +107,7 @@ Future<(oauth2.Client, OAuthCallbackServer?)> oAuth2AuthorizationCodeGrant({
         callbackUri =
             'http://localhost${Uri.parse(callbackUri).path}${Uri.parse(callbackUri).query.isNotEmpty ? '?${Uri.parse(callbackUri).query}' : ''}';
       } on TimeoutException {
-        throw Exception(
+        throw const OAuth2AuthorizationException(
           'OAuth authorization timed out after 3 minutes. '
           'Please try again and complete the authorization in your browser. '
           'If you closed the browser tab, please restart the OAuth flow.',
@@ -94,27 +116,32 @@ Future<(oauth2.Client, OAuthCallbackServer?)> oAuth2AuthorizationCodeGrant({
         // Handle custom exceptions like browser tab closure
         final errorMessage = e.toString();
         if (errorMessage.contains('Browser tab was closed')) {
-          throw Exception(
+          throw const OAuth2AuthorizationException(
             'OAuth authorization was cancelled because the browser tab was closed. '
             'Please try again and complete the authorization process without closing the browser tab.',
           );
         } else if (errorMessage.contains('OAuth callback cancelled')) {
-          throw Exception(
+          throw const OAuth2AuthorizationException(
             'OAuth authorization was cancelled. Please try again if you want to complete the authentication.',
           );
         } else {
-          throw Exception('OAuth authorization failed: $errorMessage');
+          throw OAuth2AuthorizationException(
+            'OAuth authorization failed: $errorMessage',
+          );
         }
       }
     } else {
-      // For mobile: Use the standard flutter_web_auth_2 approach
-      callbackUri = await FlutterWebAuth2.authenticate(
-        url: authorizationUrl.toString(),
+      final callbackHandler =
+          customCallbackHandler ?? _defaultOAuth2CallbackHandler;
+      if (callbackHandler == null) {
+        throw OAuth2CallbackHandlerRequiredException(
+          callbackUrlScheme: actualRedirectUrl.scheme,
+          platformDescription: Platform.operatingSystem,
+        );
+      }
+      callbackUri = await callbackHandler(
+        authorizationUrl.toString(),
         callbackUrlScheme: actualRedirectUrl.scheme,
-        options: const FlutterWebAuth2Options(
-          useWebview: true,
-          windowName: 'OAuth Authorization - API Dash',
-        ),
       );
     }
 
@@ -226,7 +253,9 @@ Future<oauth2.Client> oAuth2ResourceOwnerPasswordGrantHandler({
   }
   if ((oauth2Model.username == null || oauth2Model.username!.isEmpty) ||
       (oauth2Model.password == null || oauth2Model.password!.isEmpty)) {
-    throw Exception("Username or Password cannot be empty");
+    throw const OAuth2ConfigurationException(
+      'Username or password cannot be empty for the resource owner password grant.',
+    );
   }
 
   // Create a unique request ID for this OAuth flow
@@ -290,6 +319,8 @@ Future<void> _openUrlInBrowser(String url) async {
     }
   } catch (e) {
     // Fallback: throw an exception so the calling code can handle it
-    throw Exception('Failed to open authorization URL in browser: $e');
+    throw OAuth2AuthorizationException(
+      'Failed to open authorization URL in browser: $e',
+    );
   }
 }

--- a/packages/better_networking/lib/utils/platform_utils.dart
+++ b/packages/better_networking/lib/utils/platform_utils.dart
@@ -1,17 +1,21 @@
 import 'dart:io';
-import 'package:flutter/foundation.dart';
+
+/// Pure Dart web-detection constant to avoid pulling in the Flutter SDK.
+const bool isThisWeb = bool.fromEnvironment('dart.library.js_interop');
 
 /// Platform detection utilities for the better_networking package.
 class PlatformUtils {
   /// Returns true if running on desktop platforms (macOS, Windows, Linux).
   static bool get isDesktop =>
-      !kIsWeb && (Platform.isMacOS || Platform.isWindows || Platform.isLinux);
+      !isThisWeb &&
+      (Platform.isMacOS || Platform.isWindows || Platform.isLinux);
 
   /// Returns true if running on mobile platforms (iOS, Android).
-  static bool get isMobile => !kIsWeb && (Platform.isIOS || Platform.isAndroid);
+  static bool get isMobile =>
+      !isThisWeb && (Platform.isIOS || Platform.isAndroid);
 
   /// Returns true if running on web.
-  static bool get isWeb => kIsWeb;
+  static bool get isWeb => isThisWeb;
 
   /// Returns true if OAuth should use localhost callback server.
   /// This is true for desktop platforms.

--- a/packages/better_networking/lib/utils/utils.dart
+++ b/packages/better_networking/lib/utils/utils.dart
@@ -5,4 +5,4 @@ export 'http_response_utils.dart';
 export 'platform_utils.dart';
 export 'string_utils.dart' hide RandomStringGenerator;
 export 'uri_utils.dart';
-export 'auth/handle_auth.dart';
+export 'auth/auth.dart';

--- a/packages/better_networking/pubspec.yaml
+++ b/packages/better_networking/pubspec.yaml
@@ -12,18 +12,15 @@ topics:
 
 environment:
   sdk: ">=3.6.0 <4.0.0"
-  flutter: ">=1.17.0"
 
 resolution: workspace
 
 dependencies:
-  flutter:
-    sdk: flutter
   collection: ^1.18.0
   convert: ^3.1.2
   crypto: ^3.0.7
   dart_jsonwebtoken: ^3.3.2
-  flutter_web_auth_2: ^5.0.1
+  freezed_annotation: ^3.1.0
   http: ^1.6.0
   http_parser: ^4.1.2
   json5: ^0.8.2
@@ -34,10 +31,8 @@ dependencies:
   oauth2: ^2.0.5
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
   build_runner: ^2.11.1
-  flutter_lints: ^6.0.0
   freezed: ^3.2.5
   json_serializable: ^6.13.0
+  lints: ^6.0.0
   test: ^1.29.0

--- a/packages/better_networking/test/pure_dart_compatibility_test.dart
+++ b/packages/better_networking/test/pure_dart_compatibility_test.dart
@@ -1,0 +1,81 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+Directory _packageRoot() {
+  final candidates = <String>[
+    '${Directory.current.path}${Platform.pathSeparator}packages${Platform.pathSeparator}better_networking',
+    Directory.current.path,
+  ];
+
+  for (final candidate in candidates) {
+    final pubspec = File('$candidate${Platform.pathSeparator}pubspec.yaml');
+    if (pubspec.existsSync()) {
+      return Directory(candidate);
+    }
+  }
+
+  fail('Unable to locate better_networking package root.');
+}
+
+Future<List<File>> _dartFilesIn(Directory dir) async {
+  return dir
+      .list(recursive: true)
+      .where((entity) => entity is File && entity.path.endsWith('.dart'))
+      .cast<File>()
+      .toList();
+}
+
+void main() {
+  group('pure Dart compatibility', () {
+    test('pubspec does not require Flutter-only dependencies', () async {
+      final root = _packageRoot();
+      final pubspec =
+          await File('${root.path}${Platform.pathSeparator}pubspec.yaml')
+              .readAsString();
+
+      expect(pubspec,
+          isNot(contains(RegExp(r'^\s*flutter:\s*$', multiLine: true))));
+      expect(pubspec, isNot(contains('sdk: flutter')));
+      expect(pubspec, isNot(contains('flutter_web_auth_2')));
+      expect(pubspec, contains('seed: any'));
+    });
+
+    test('library sources do not import Flutter-only libraries', () async {
+      final root = _packageRoot();
+      final libDir = Directory('${root.path}${Platform.pathSeparator}lib');
+      final dartFiles = await _dartFilesIn(libDir);
+
+      for (final file in dartFiles) {
+        final content = await file.readAsString();
+        expect(
+          content,
+          isNot(contains('package:flutter/')),
+          reason: 'Unexpected Flutter import in ${file.path}',
+        );
+        expect(
+          content,
+          isNot(contains('kIsWeb')),
+          reason: 'Unexpected Flutter kIsWeb usage in ${file.path}',
+        );
+      }
+    });
+
+    test('OAuth auth flow does not log access tokens', () async {
+      final root = _packageRoot();
+      final handleAuthFile = File(
+        '${root.path}${Platform.pathSeparator}lib${Platform.pathSeparator}utils${Platform.pathSeparator}auth${Platform.pathSeparator}handle_auth.dart',
+      );
+      final content = await handleAuthFile.readAsString();
+
+      expect(content,
+          isNot(contains('logDebug(res.\$1.credentials.accessToken)')));
+      expect(
+          content, isNot(contains('logDebug(client.credentials.accessToken)')));
+      expect(content,
+          isNot(contains('developer.log(res.\$1.credentials.accessToken)')));
+      expect(content,
+          isNot(contains('developer.log(client.credentials.accessToken)')));
+    });
+  });
+}

--- a/packages/better_networking/test/utils/auth/auth_handling_test.dart
+++ b/packages/better_networking/test/utils/auth/auth_handling_test.dart
@@ -2,6 +2,8 @@ import 'package:better_networking/better_networking.dart';
 import 'package:test/test.dart';
 
 void main() {
+  tearDown(clearDefaultOAuth2CallbackHandler);
+
   group('Authentication Handling Tests', () {
     test(
       'given sendHttpRequest when no authentication is provided then it should not throw any error',
@@ -452,13 +454,47 @@ void main() {
         expect(
           () async => await handleAuth(httpRequestModel, authModel),
           throwsA(
-            isA<Exception>().having(
+            isA<OAuth2ConfigurationException>().having(
               (e) => e.toString(),
               'message',
-              contains('Failed to get OAuth2 Data'),
+              contains('Failed to get OAuth2 data'),
             ),
           ),
         );
+      },
+    );
+
+    test(
+      'given OAuth2 callback handler exception when converted to string then it should explain the missing mobile callback contract',
+      () {
+        final exception = OAuth2CallbackHandlerRequiredException(
+          callbackUrlScheme: 'apidash',
+          platformDescription: 'android',
+        );
+
+        expect(exception.toString(), contains('custom callback handler'));
+        expect(exception.toString(), contains('"apidash"'));
+        expect(exception.toString(), contains('android'));
+      },
+    );
+
+    test(
+      'given a default OAuth2 callback handler when registered then it should be available globally',
+      () async {
+        Future<String> handler(
+          String url, {
+          required String callbackUrlScheme,
+        }) async =>
+            '$callbackUrlScheme:$url';
+
+        registerDefaultOAuth2CallbackHandler(handler);
+
+        expect(defaultOAuth2CallbackHandler, isNotNull);
+        final result = await defaultOAuth2CallbackHandler!(
+          'https://auth.example.com',
+          callbackUrlScheme: 'apidash',
+        );
+        expect(result, equals('apidash:https://auth.example.com'));
       },
     );
 

--- a/packages/genai/analysis_options.yaml
+++ b/packages/genai/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:flutter_lints/flutter.yaml
+include: package:lints/recommended.yaml
 
 analyzer:
   errors:

--- a/packages/genai/genai_example/lib/main.dart
+++ b/packages/genai/genai_example/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:genai/genai.dart';
+import 'package:genai/genai_flutter.dart';
 
 void main() {
   runApp(const GenAIExample());

--- a/packages/genai/lib/agentic_engine/agent_service.dart
+++ b/packages/genai/lib/agentic_engine/agent_service.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/foundation.dart';
 import '../models/models.dart';
+import '../src/logging.dart';
 import '../utils/utils.dart';
 import 'blueprint.dart';
 
@@ -69,7 +69,7 @@ class AIAgentService {
         );
       }
       RETRY_COUNT += 1;
-      debugPrint(
+      logDebug(
         "Retrying AgentCall for (${agent.agentName}): ATTEMPT: $RETRY_COUNT",
       );
     } while (RETRY_COUNT < 5);

--- a/packages/genai/lib/genai.dart
+++ b/packages/genai/lib/genai.dart
@@ -1,7 +1,6 @@
 export 'models/models.dart';
 export 'interface/interface.dart';
 export 'utils/utils.dart';
-export 'widgets/widgets.dart';
 export 'agentic_engine/agentic_engine.dart';
 
 // Export 3rd party

--- a/packages/genai/lib/genai_flutter.dart
+++ b/packages/genai/lib/genai_flutter.dart
@@ -1,0 +1,2 @@
+export 'genai.dart';
+export 'widgets/widgets.dart';

--- a/packages/genai/lib/models/model_config_value.dart
+++ b/packages/genai/lib/models/model_config_value.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
-import 'package:flutter/material.dart';
+
+import '../src/logging.dart';
 
 enum ConfigType { boolean, slider, numeric, text }
 
@@ -8,7 +9,7 @@ ConfigType getConfigTypeEnum(String? t) {
     final val = ConfigType.values.byName(t ?? "");
     return val;
   } catch (e) {
-    debugPrint("ConfigType <$t> not found.");
+    logDebug("ConfigType <$t> not found.");
     return ConfigType.text;
   }
 }

--- a/packages/genai/lib/src/logging.dart
+++ b/packages/genai/lib/src/logging.dart
@@ -1,0 +1,5 @@
+import 'dart:developer' as developer;
+
+void logDebug(String message) {
+  developer.log(message, name: 'genai');
+}

--- a/packages/genai/lib/utils/ai_request_utils.dart
+++ b/packages/genai/lib/utils/ai_request_utils.dart
@@ -1,14 +1,16 @@
 import 'dart:async';
 import 'dart:convert';
+
 import 'package:better_networking/better_networking.dart';
-import 'package:flutter/foundation.dart';
 import 'package:nanoid/nanoid.dart';
+
 import '../models/models.dart';
+import '../src/logging.dart';
 
 Future<String?> executeGenAIRequest(AIRequestModel? aiRequestModel) async {
   final httpRequestModel = aiRequestModel?.httpRequestModel;
   if (httpRequestModel == null) {
-    debugPrint("executeGenAIRequest -> httpRequestModel is null");
+    logDebug("executeGenAIRequest -> httpRequestModel is null");
     return null;
   }
   final (response, _, _) = await sendHttpRequest(
@@ -21,7 +23,7 @@ Future<String?> executeGenAIRequest(AIRequestModel? aiRequestModel) async {
     final data = jsonDecode(response.body);
     return aiRequestModel?.getFormattedOutput(data);
   } else {
-    debugPrint('LLM_EXCEPTION: ${response.statusCode}\n${response.body}');
+    logDebug('LLM_EXCEPTION: ${response.statusCode}\n${response.body}');
     return null;
   }
 }
@@ -32,7 +34,7 @@ Future<Stream<String?>> streamGenAIRequest(
   final httpRequestModel = aiRequestModel?.httpRequestModel;
   final streamController = StreamController<String?>();
   if (httpRequestModel == null) {
-    debugPrint("streamGenAIRequest -> httpRequestModel is null");
+    logDebug("streamGenAIRequest -> httpRequestModel is null");
   } else {
     final httpStream = await streamHttpRequest(
       nanoid(),
@@ -68,9 +70,7 @@ Future<Stream<String?>> streamGenAIRequest(
             );
             streamController.sink.add(formattedOutput);
           } catch (e) {
-            debugPrint(
-              '⚠️ JSON decode error in SSE: $e\nSending as Regular Text',
-            );
+            logDebug('JSON decode error in SSE: $e\nSending as Regular Text');
             streamController.sink.add(jsonStr);
           }
         }
@@ -123,10 +123,8 @@ void processGenAIStreamOutput(
     (chunk) {
       if (chunk == null || chunk.isEmpty) return;
       buffer += chunk;
-      // Split on spaces but preserve last partial word
       final parts = buffer.split(RegExp(r'\s+'));
       if (parts.length > 1) {
-        // Keep the last part in buffer (it may be incomplete)
         buffer = parts.removeLast();
         for (final word in parts) {
           if (word.trim().isNotEmpty) {
@@ -136,7 +134,6 @@ void processGenAIStreamOutput(
       }
     },
     onDone: () {
-      // Print any remaining word when stream is finished
       if (buffer.trim().isNotEmpty) {
         onWord(buffer);
       }

--- a/packages/genai/lib/utils/model_manager.dart
+++ b/packages/genai/lib/utils/model_manager.dart
@@ -1,9 +1,11 @@
 import 'dart:convert';
+
 import 'package:better_networking/better_networking.dart';
-import 'package:flutter/foundation.dart';
+
 import '../consts.dart';
 import '../interface/interface.dart';
 import '../models/models.dart';
+import '../src/logging.dart';
 
 class ModelManager {
   static Future<AvailableModels?> fetchModelsFromRemote({
@@ -19,13 +21,13 @@ class ModelManager {
         ),
       );
       if (resp == null) {
-        debugPrint('fetchModelsFromRemote -> resp == null');
+        logDebug('fetchModelsFromRemote -> resp == null');
       } else {
         var remoteModels = availableModelsFromJson(resp.body);
         return remoteModels;
       }
     } catch (e) {
-      debugPrint('fetchModelsFromRemote -> ${e.toString()}');
+      logDebug('fetchModelsFromRemote -> ${e.toString()}');
     }
     return null;
   }
@@ -57,7 +59,7 @@ class ModelManager {
         );
       }
     } catch (e) {
-      debugPrint('fetchAvailableModels -> ${e.toString()}');
+      logDebug('fetchAvailableModels -> ${e.toString()}');
     }
     return kAvailableModels;
   }
@@ -90,7 +92,7 @@ class ModelManager {
       }
       return ollamaModels;
     } catch (e) {
-      debugPrint('fetchInstalledOllamaModels -> ${e.toString()}');
+      logDebug('fetchInstalledOllamaModels -> ${e.toString()}');
       return null;
     }
   }

--- a/packages/genai/pubspec.yaml
+++ b/packages/genai/pubspec.yaml
@@ -12,22 +12,18 @@ topics:
 
 environment:
   sdk: ^3.8.0
-  flutter: ">=1.17.0"
 
 resolution: workspace
 
 dependencies:
-  flutter:
-    sdk: flutter
   better_networking: any
+  freezed_annotation: ^3.1.0
   json_annotation: ^4.11.0
   nanoid: ^1.0.0
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
   build_runner: ^2.11.1
-  flutter_lints: ^ 6.0.0
   freezed: ^3.2.5
   json_serializable: ^6.13.0
+  lints: ^6.0.0
   test: ^1.29.0

--- a/packages/genai/test/pure_dart_compatibility_test.dart
+++ b/packages/genai/test/pure_dart_compatibility_test.dart
@@ -1,0 +1,86 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+Directory _packageRoot() {
+  final candidates = <String>[
+    '${Directory.current.path}${Platform.pathSeparator}packages${Platform.pathSeparator}genai',
+    Directory.current.path,
+  ];
+
+  for (final candidate in candidates) {
+    final pubspec = File('$candidate${Platform.pathSeparator}pubspec.yaml');
+    if (pubspec.existsSync()) {
+      return Directory(candidate);
+    }
+  }
+
+  fail('Unable to locate genai package root.');
+}
+
+Future<List<File>> _dartFilesIn(Directory dir) async {
+  return dir
+      .list(recursive: true)
+      .where((entity) => entity is File && entity.path.endsWith('.dart'))
+      .cast<File>()
+      .toList();
+}
+
+void main() {
+  group('pure Dart compatibility', () {
+    test('pubspec does not require Flutter and resolves local better_networking',
+        () async {
+      final root = _packageRoot();
+      final pubspec = await File(
+        '${root.path}${Platform.pathSeparator}pubspec.yaml',
+      ).readAsString();
+
+      expect(
+        pubspec,
+        isNot(contains(RegExp(r'^\s*flutter:\s*$', multiLine: true))),
+      );
+      expect(pubspec, isNot(contains('sdk: flutter')));
+      expect(pubspec, contains('better_networking: any'));
+    });
+
+    test('library sources do not import Flutter-only libraries', () async {
+      final root = _packageRoot();
+      final libDir = Directory('${root.path}${Platform.pathSeparator}lib');
+      final dartFiles = await _dartFilesIn(libDir);
+
+      for (final file in dartFiles) {
+        if (file.path.contains(
+          '${Platform.pathSeparator}widgets${Platform.pathSeparator}',
+        )) {
+          continue;
+        }
+        final content = await file.readAsString();
+        expect(
+          content,
+          isNot(contains('package:flutter/')),
+          reason: 'Unexpected Flutter import in ${file.path}',
+        );
+        expect(
+          content,
+          isNot(contains('dart:ui')),
+          reason: 'Unexpected dart:ui import in ${file.path}',
+        );
+      }
+    });
+
+    test('pure Dart and Flutter entrypoints stay separated', () async {
+      final root = _packageRoot();
+      final pureEntrypoint = await File(
+        '${root.path}${Platform.pathSeparator}lib${Platform.pathSeparator}genai.dart',
+      ).readAsString();
+      final flutterEntrypoint = await File(
+        '${root.path}${Platform.pathSeparator}lib${Platform.pathSeparator}genai_flutter.dart',
+      ).readAsString();
+
+      expect(pureEntrypoint, isNot(contains('widgets/widgets.dart')));
+      expect(pureEntrypoint, isNot(contains('package:flutter/')));
+      expect(flutterEntrypoint, contains("export 'genai.dart';"));
+      expect(flutterEntrypoint, contains("export 'widgets/widgets.dart';"));
+    });
+  });
+}

--- a/packages/seed/pubspec.yaml
+++ b/packages/seed/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  freezed_annotation: ^3.0.0
+  freezed_annotation: ^3.1.0
 
 dev_dependencies:
   build_runner: ^2.11.1

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -681,7 +681,7 @@ packages:
     source: sdk
     version: "0.0.0"
   flutter_web_auth_2:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: flutter_web_auth_2
       sha256: "432ff8c7b2834eaeec3378d99e24a0210b9ac2f453b3f7a7d739a5c09069fba3"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   flutter_markdown_plus: ^1.0.7
   flutter_portal: ^1.1.4
   flutter_riverpod: ^3.2.1
+  flutter_web_auth_2: ^5.0.1
   flutter_svg: ^2.2.4
   fvp: ^0.35.2
   highlight: ^0.7.0


### PR DESCRIPTION
## PR Description

This PR fixes the pure-Dart `genai` packaging issue by separating Flutter-only APIs from the pure-Dart entrypoint and completing the transitive cleanup needed for headless/CLI usage.

The original problem was that `package:genai/genai.dart` and its dependency chain still pulled in Flutter-specific code, which prevented pure-Dart consumers from using the package without the Flutter SDK. This PR moves Flutter-only behavior to the Flutter app layer and keeps the package-side core logic pure Dart.

## What changed

### `genai`
- Split entrypoints into:
  - pure-Dart entrypoint: `package:genai/genai.dart`
  - Flutter entrypoint: `package:genai/genai_flutter.dart`
- Removed widget exports from the pure-Dart entrypoint
- Removed Flutter SDK requirements from `packages/genai/pubspec.yaml`
- Replaced Flutter-only logging usage in non-widget code with `dart:developer`
- Updated the Flutter example app to import `genai_flutter.dart`
- Added a pure-Dart compatibility test to ensure:
  - no Flutter-only imports in the pure-Dart library surface
  - pure-Dart and Flutter entrypoints stay separated

### `better_networking`
- Removed Flutter SDK dependency from `packages/better_networking/pubspec.yaml`
- Removed direct use of Flutter platform helpers (`kIsWeb`)
- Replaced Flutter-specific platform detection with pure-Dart helpers
- Removed `flutter_web_auth_2` from the package layer
- Introduced injectable/default OAuth2 callback handler support so platform-specific callback capture can be provided externally
- Added auth-specific exceptions for clearer OAuth2 error handling
- Replaced package logging with `dart:developer`
- Added a pure-Dart compatibility test to ensure:
  - no Flutter-only imports remain
  - no access token logging remains in the OAuth flow

### Flutter app integration
- Added Flutter-side OAuth2 callback implementation in `lib/services/oauth_services.dart`
- Registered the default OAuth2 callback handler in `lib/main.dart`
- Added the required Flutter dependency in the root app `pubspec.yaml`
- Exported the new OAuth service from `lib/services/services.dart`

### Transitive dependency alignment
- Updated `seed` to align `freezed_annotation` with the package graph used by `genai` and `better_networking`
- Updated the `better_networking` example to resolve the local `seed` package correctly

## Why these changes were needed

The issue was not only in `genai` itself, but also in its transitive dependency chain:
- `genai` exposed Flutter-only widgets from the default entrypoint
- `better_networking` still depended on Flutter APIs and mobile OAuth packages
- pure-Dart consumers could hit dependency resolution and import problems even if they only wanted the non-Flutter parts

This PR addresses the full flow by:
- keeping package-side networking/auth/model logic pure Dart
- moving Flutter-only OAuth callback capture into the Flutter app
- preserving Flutter functionality through the dedicated Flutter entrypoint
- adding tests so the separation is enforced going forward

## Verification

Verified locally in WSL by:
- running pure-Dart compatibility tests for:
  - `packages/better_networking`
  - `packages/genai`
- validating a temporary pure-Dart CLI consumer against the local package graph

## Related Issue

- Closes #1591

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [ ] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [ ] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [x] Yes
- [ ] No

## OS on which you have developed and tested the feature?

- [ ] Windows
- [ ] macOS
- [x] Linux
