### PR TITLE
fix: guard against `RangeError` when collection is empty on startup

### DIFF
--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -56,9 +56,9 @@ class CollectionStateNotifier
       if (status) {
         ref.read(requestSequenceProvider.notifier).state = [state!.keys.first];
       }
-      ref.read(selectedIdStateProvider.notifier).state = ref.read(
-        requestSequenceProvider,
-      )[0];
+      final ids = ref.read(requestSequenceProvider);
+      ref.read(selectedIdStateProvider.notifier).state =
+          ids.isNotEmpty ? ids[0] : null;
     });
   }
 


### PR DESCRIPTION
## PR Description

On first launch (or when all requests have been deleted), `requestSequenceProvider` returns an empty list. The `CollectionStateNotifier` constructor was unconditionally accessing `[0]` on that list, causing a `RangeError` crash before the app could render.

**Fix:** Read the list into a variable and only select `ids[0]` when the list is non-empty, otherwise set `selectedIdStateProvider` to `null`.

**Changed file:** `lib/providers/collection_providers.dart` (~line 59)

```dart
// Before
ref.read(selectedIdStateProvider.notifier).state = ref.read(
  requestSequenceProvider,
)[0];

// After
final ids = ref.read(requestSequenceProvider);
ref.read(selectedIdStateProvider.notifier).state =
    ids.isNotEmpty ? ids[0] : null;
```

## Related Issues

- Closes #1640

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: The fix is a one-line guard on an index access in the constructor. The existing startup behavior (first request auto-selected when collection is non-empty) is fully preserved; the new path (empty collection → null selection) requires integration-level or widget testing with an empty Hive box, which is outside the scope of the current unit test suite.

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux
