### PR TITLE
fix: escape special characters in environment variable keys for regex substitution

### DIFF
--- a/lib/utils/envvar_utils.dart
+++ b/lib/utils/envvar_utils.dart
@@ -44,7 +44,8 @@ String? substituteVariables(
   if (envVarMap.keys.isEmpty) {
     return input;
   }
-  final regex = RegExp("{{(${envVarMap.keys.join('|')})}}");
+  final escapedKeys = envVarMap.keys.map((key) => RegExp.escape(key)).join('|');
+  final regex = RegExp("{{($escapedKeys)}}");
 
   String result = input.replaceAllMapped(regex, (match) {
     final key = match.group(1)?.trim() ?? '';

--- a/test/utils/envvar_utils_test.dart
+++ b/test/utils/envvar_utils_test.dart
@@ -168,6 +168,41 @@ void main() {
       String expected = "{{url1}}/humanize/social?num=8940000";
       expect(substituteVariables(input, combinedEnvVarsMap), expected);
     });
+
+    test("Testing substituteVariables with special characters in variable keys", () {
+      Map<String, String> envMap = {
+        "api.key": "value_with_dot",
+        "user+id": "value_with_plus",
+        "var*name": "value_with_asterisk",
+        "test[0]": "value_with_brackets",
+      };
+      String input = "API: {{api.key}}, User: {{user+id}}, Var: {{var*name}}, Test: {{test[0]}}";
+      String expected = "API: value_with_dot, User: value_with_plus, Var: value_with_asterisk, Test: value_with_brackets";
+      expect(substituteVariables(input, envMap), expected);
+    });
+
+    test("Testing substituteVariables with regex metacharacters in keys", () {
+      Map<String, String> envMap = {
+        "api\$key": "dollar_value",
+        "var^name": "caret_value",
+        "test|pipe": "pipe_value",
+        "back\\slash": "backslash_value",
+      };
+      String input = "Dollar: {{api\$key}}, Caret: {{var^name}}, Pipe: {{test|pipe}}, Backslash: {{back\\slash}}";
+      String expected = "Dollar: dollar_value, Caret: caret_value, Pipe: pipe_value, Backslash: backslash_value";
+      expect(substituteVariables(input, envMap), expected);
+    });
+
+    test("Testing substituteVariables with mixed special and normal characters", () {
+      Map<String, String> envMap = {
+        "normal_var": "normal",
+        "api.key": "dotted",
+        "user-id": "dashed",
+      };
+      String input = "{{normal_var}}/{{api.key}}/{{user-id}}";
+      String expected = "normal/dotted/dashed";
+      expect(substituteVariables(input, envMap), expected);
+    });
   });
 
   group("Testing substituteHttpRequestModel function", () {


### PR DESCRIPTION
## Description

This PR fixes a critical bug where environment variable keys containing regex metacharacters caused the application to crash with a `FormatException`.

The `substituteVariables` function in `lib/utils/envvar_utils.dart` was building regex patterns by joining environment variable keys without escaping special characters. This meant that keys like `api.key`, `user+id`, `test[0]`, etc. would either create incorrect regex patterns or throw exceptions during pattern compilation.

## Changes Made

### 1. Core Fix (`lib/utils/envvar_utils.dart`)
- Added `RegExp.escape()` to properly escape all special characters in environment variable keys before building the regex pattern
- Changed from: `final regex = RegExp("{{(${envVarMap.keys.join('|')})}}");`
- To: `final escapedKeys = envVarMap.keys.map((key) => RegExp.escape(key)).join('|'); final regex = RegExp("{{($escapedKeys)}}");`

### 2. Test Coverage (`test/utils/envvar_utils_test.dart`)
Added comprehensive test cases to verify the fix handles:
- **Special characters**: `api.key`, `user+id`, `var*name`, `test[0]`
- **Regex metacharacters**: `api$key`, `var^name`, `test|pipe`, `back\slash`
- **Mixed scenarios**: Normal variables combined with special character variables

## Testing

All existing tests continue to pass, and new tests verify the fix works correctly for edge cases.

### Test Results
- ✅ All original test cases pass
- ✅ New test case: Special characters in variable keys
- ✅ New test case: Regex metacharacters in variable keys  
- ✅ New test case: Mixed special and normal characters

## Related Issue

Fixes #1645

## Impact

**Before:** Users would experience app crashes when using environment variables with special characters in their names, which is a common naming convention (e.g., dot notation like `api.key`).

**After:** Environment variables now support all common naming conventions including dots, dashes, plus signs, brackets, and other special characters without any issues.

## Checklist

- [x] Bug fix implemented with proper escaping
- [x] Comprehensive test cases added
- [x] All existing tests continue to pass
- [x] Code follows project conventions
- [x] No breaking changes introduced
