### PR TITLE
fix: escape regex keys in substituteVariables and await Hive writes in history providers

### DIFF
--- a/lib/providers/history_providers.dart
+++ b/lib/providers/history_providers.dart
@@ -82,26 +82,26 @@ class HistoryMetaStateNotifier
     }
   }
 
-  void addHistoryRequest(HistoryRequestModel model) async {
+  Future<void> addHistoryRequest(HistoryRequestModel model) async {
     final id = model.historyId;
     state = {...state ?? {}, id: model.metaData};
     final List<String> updatedHistoryKeys = state == null
         ? [id]
         : [...state!.keys, id];
-    hiveHandler.setHistoryIds(updatedHistoryKeys);
-    hiveHandler.setHistoryMeta(id, model.metaData.toJson());
+    await hiveHandler.setHistoryIds(updatedHistoryKeys);
+    await hiveHandler.setHistoryMeta(id, model.metaData.toJson());
     await hiveHandler.setHistoryRequest(id, model.toJson());
     await loadHistoryRequest(id);
   }
 
-  void editHistoryRequest(HistoryRequestModel model) async {
+  Future<void> editHistoryRequest(HistoryRequestModel model) async {
     final id = model.historyId;
     state = {...state ?? {}, id: model.metaData};
     final existingKeys = state?.keys.toList() ?? [];
     if (!existingKeys.contains(id)) {
-      hiveHandler.setHistoryIds([...existingKeys, id]);
+      await hiveHandler.setHistoryIds([...existingKeys, id]);
     }
-    hiveHandler.setHistoryMeta(id, model.metaData.toJson());
+    await hiveHandler.setHistoryMeta(id, model.metaData.toJson());
     await hiveHandler.setHistoryRequest(id, model.toJson());
     await loadHistoryRequest(id);
   }

--- a/lib/utils/envvar_utils.dart
+++ b/lib/utils/envvar_utils.dart
@@ -44,7 +44,8 @@ String? substituteVariables(
   if (envVarMap.keys.isEmpty) {
     return input;
   }
-  final regex = RegExp("{{(${envVarMap.keys.join('|')})}}");
+  final escapedKeys = envVarMap.keys.map(RegExp.escape).join('|');
+  final regex = RegExp("{{($escapedKeys)}}");
 
   String result = input.replaceAllMapped(regex, (match) {
     final key = match.group(1)?.trim() ?? '';


### PR DESCRIPTION
Fixes two of the three issues reported in #1642.

**Fix 1 -- envvar_utils.dart**

`substituteVariables` built a regex from env var keys without escaping them. Keys containing regex metacharacters like `api.key` (dot) or `base+url` (plus) caused a `FormatException` crash before the request was sent.

```dart
// Before
final regex = RegExp("{{(${envVarMap.keys.join('|')})}}");

// After
final escapedKeys = envVarMap.keys.map(RegExp.escape).join('|');
final regex = RegExp("{{($escapedKeys)}}");
```

**Fix 2 -- history_providers.dart**

`addHistoryRequest` and `editHistoryRequest` called `setHistoryIds()` and `setHistoryMeta()` without `await`. This created a race condition where the app could be closed before the history index was persisted, leaving orphaned records and causing data loss on restart. Also changed both method return types from `void` to `Future<void>`.

```dart
// Before
hiveHandler.setHistoryIds(updatedHistoryKeys);
hiveHandler.setHistoryMeta(id, model.metaData.toJson());

// After
await hiveHandler.setHistoryIds(updatedHistoryKeys);
await hiveHandler.setHistoryMeta(id, model.metaData.toJson());
```

Note: the third issue in #1642 (getEnabledRows duplicate row bug) was already fixed in #1465.