### PR TITLE
fix: escape regex metacharacters in environment variable keys

### DIFF
--- a/lib/utils/envvar_utils.dart
+++ b/lib/utils/envvar_utils.dart
@@ -44,7 +44,8 @@ String? substituteVariables(
   if (envVarMap.keys.isEmpty) {
     return input;
   }
-  final regex = RegExp("{{(${envVarMap.keys.join('|')})}}");
+  final escapedKeys = envVarMap.keys.map((key) => RegExp.escape(key)).join('|');
+  final regex = RegExp("{{($escapedKeys)}}");
 
   String result = input.replaceAllMapped(regex, (match) {
     final key = match.group(1)?.trim() ?? '';

--- a/test/utils/envvar_utils_test.dart
+++ b/test/utils/envvar_utils_test.dart
@@ -168,6 +168,41 @@ void main() {
       String expected = "{{url1}}/humanize/social?num=8940000";
       expect(substituteVariables(input, combinedEnvVarsMap), expected);
     });
+
+    test("Testing substituteVariables with special characters in variable keys", () {
+      Map<String, String> envMap = {
+        "api.key": "value_with_dot",
+        "user+id": "value_with_plus",
+        "var*name": "value_with_asterisk",
+        "test[0]": "value_with_brackets",
+      };
+      String input = "API: {{api.key}}, User: {{user+id}}, Var: {{var*name}}, Test: {{test[0]}}";
+      String expected = "API: value_with_dot, User: value_with_plus, Var: value_with_asterisk, Test: value_with_brackets";
+      expect(substituteVariables(input, envMap), expected);
+    });
+
+    test("Testing substituteVariables with regex metacharacters in keys", () {
+      Map<String, String> envMap = {
+        "api\$key": "dollar_value",
+        "var^name": "caret_value",
+        "test|pipe": "pipe_value",
+        "back\\slash": "backslash_value",
+      };
+      String input = "Dollar: {{api\$key}}, Caret: {{var^name}}, Pipe: {{test|pipe}}, Backslash: {{back\\slash}}";
+      String expected = "Dollar: dollar_value, Caret: caret_value, Pipe: pipe_value, Backslash: backslash_value";
+      expect(substituteVariables(input, envMap), expected);
+    });
+
+    test("Testing substituteVariables with mixed special and normal characters", () {
+      Map<String, String> envMap = {
+        "normal_var": "normal",
+        "api.key": "dotted",
+        "user-id": "dashed",
+      };
+      String input = "{{normal_var}}/{{api.key}}/{{user-id}}";
+      String expected = "normal/dotted/dashed";
+      expect(substituteVariables(input, envMap), expected);
+    });
   });
 
   group("Testing substituteHttpRequestModel function", () {


### PR DESCRIPTION
## Summary

Fixes #1645

- Environment variable keys are now escaped with `RegExp.escape()` before being joined into the substitution regex
- Prevents `FormatException` when any key contains unclosed metacharacters like `(` or `[`
- Also fixes silent wrong-substitution for keys with `.`, `+`, `*` (previously matched incorrectly due to unescaped regex semantics)

## Root Cause

`substituteVariables()` built a single regex from all active env var keys without escaping:

```dart
// Before — crashes if any key has ( or [
final regex = RegExp("{{(${envVarMap.keys.join('|')})}}");
```

One malformed key corrupts the regex for **every** request in that environment, silently freezing the Send button with no error shown.

## Fix

```dart
// After — keys are safely escaped
final escapedKeys = envVarMap.keys.map((key) => RegExp.escape(key)).join('|');
final regex = RegExp("{{($escapedKeys)}}");
```

## Video for the app after resolve the bug 


https://github.com/user-attachments/assets/6404ec8b-9578-4be1-b1b1-eb03084ea79a

now the current, and subsequent requests is sent appropriately! 

## Test plan

- [x] Existing `substituteVariables` tests pass
- [x] Manually verified: env var key `api(key` no longer freezes all requests
- [x] Manually verified: env var key `api.key` now substitutes correctly (previously matched any char in place of `.`)
- [x] Attach screen recording showing bug and fix (see linked issue #1645)