### PR TITLE
fix: auto-select remaining request after deleting second of two

### DIFF
--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -128,7 +128,7 @@ class CollectionStateNotifier
     String? newId;
     if (idx == 0 && itemIds.isNotEmpty) {
       newId = itemIds[0];
-    } else if (itemIds.length > 1) {
+    } else if (idx > 0) {
       newId = itemIds[idx - 1];
     } else {
       newId = null;


### PR DESCRIPTION
Fixes a bug where deleting the second request when only two exist leaves the UI with no request selected, even though one remains in the sidebar.

##  Video before resolving the bug
https://github.com/user-attachments/assets/20df16b6-2850-451d-b853-ae7a0c0e0b98

## Video after resolving the bug 
https://github.com/user-attachments/assets/43d5efda-00c5-4bfb-900a-473f9d1e574c



**Root cause:** `lib/providers/collection_providers.dart` line 131

```dart
// Before
} else if (itemIds.length > 1) {

// After
} else if (idx > 0) {
```

After removing the item, `itemIds.length` is 1 — so `1 > 1` is false and nothing gets selected. Using `idx > 0` correctly selects the previous item regardless of list length.
