### PR TITLE
fix: prevent crash when filtering collection with AI requests

### DIFF
--- a/lib/screens/home_page/collection_pane.dart
+++ b/lib/screens/home_page/collection_pane.dart
@@ -146,9 +146,10 @@ class _RequestListState extends ConsumerState<RequestList> {
               controller: controller,
               children: requestSequence.map((id) {
                 var item = requestItems[id]!;
-                if (item.httpRequestModel!.url.toLowerCase().contains(
-                      filterQuery,
-                    ) ||
+                if ((item.httpRequestModel?.url.toLowerCase().contains(
+                          filterQuery,
+                        ) ??
+                        false) ||
                     item.name.toLowerCase().contains(filterQuery)) {
                   return Padding(
                     padding: kP1,

--- a/lib/utils/envvar_utils.dart
+++ b/lib/utils/envvar_utils.dart
@@ -44,7 +44,8 @@ String? substituteVariables(
   if (envVarMap.keys.isEmpty) {
     return input;
   }
-  final regex = RegExp("{{(${envVarMap.keys.join('|')})}}");
+  final escapedKeys = envVarMap.keys.map((key) => RegExp.escape(key)).join('|');
+  final regex = RegExp("{{($escapedKeys)}}");
 
   String result = input.replaceAllMapped(regex, (match) {
     final key = match.group(1)?.trim() ?? '';

--- a/test/utils/envvar_utils_test.dart
+++ b/test/utils/envvar_utils_test.dart
@@ -168,6 +168,41 @@ void main() {
       String expected = "{{url1}}/humanize/social?num=8940000";
       expect(substituteVariables(input, combinedEnvVarsMap), expected);
     });
+
+    test("Testing substituteVariables with special characters in variable keys", () {
+      Map<String, String> envMap = {
+        "api.key": "value_with_dot",
+        "user+id": "value_with_plus",
+        "var*name": "value_with_asterisk",
+        "test[0]": "value_with_brackets",
+      };
+      String input = "API: {{api.key}}, User: {{user+id}}, Var: {{var*name}}, Test: {{test[0]}}";
+      String expected = "API: value_with_dot, User: value_with_plus, Var: value_with_asterisk, Test: value_with_brackets";
+      expect(substituteVariables(input, envMap), expected);
+    });
+
+    test("Testing substituteVariables with regex metacharacters in keys", () {
+      Map<String, String> envMap = {
+        "api\$key": "dollar_value",
+        "var^name": "caret_value",
+        "test|pipe": "pipe_value",
+        "back\\slash": "backslash_value",
+      };
+      String input = "Dollar: {{api\$key}}, Caret: {{var^name}}, Pipe: {{test|pipe}}, Backslash: {{back\\slash}}";
+      String expected = "Dollar: dollar_value, Caret: caret_value, Pipe: pipe_value, Backslash: backslash_value";
+      expect(substituteVariables(input, envMap), expected);
+    });
+
+    test("Testing substituteVariables with mixed special and normal characters", () {
+      Map<String, String> envMap = {
+        "normal_var": "normal",
+        "api.key": "dotted",
+        "user-id": "dashed",
+      };
+      String input = "{{normal_var}}/{{api.key}}/{{user-id}}";
+      String expected = "normal/dotted/dashed";
+      expect(substituteVariables(input, envMap), expected);
+    });
   });
 
   group("Testing substituteHttpRequestModel function", () {


### PR DESCRIPTION
Fixes #1113

## Bug

`httpRequestModel` is `null` for `APIType.ai` requests. The filter ListView was force-unwrapping it to access `.url`, crashing the app the moment the user types anything in the search box with an AI request in the collection.

## Fix

```dart
// before
item.httpRequestModel!.url.toLowerCase().contains(filterQuery)

// after
item.httpRequestModel?.url.toLowerCase().contains(filterQuery) ?? false
```
## Video after the fix
https://github.com/user-attachments/assets/66591f78-19ef-453d-b9b1-dbfe43d95bd3



AI requests are now matched by name only, which is correct since they have no HTTP URL.