### PR TITLE
feat: enable line numbers and improve gutter alignment in script editor

### DIFF
--- a/lib/widgets/editor_code.dart
+++ b/lib/widgets/editor_code.dart
@@ -36,11 +36,14 @@ class CodeEditor extends StatelessWidget {
         smartQuotesType: SmartQuotesType.enabled,
         background: Theme.of(context).colorScheme.surfaceContainerLowest,
         gutterStyle: GutterStyle(
-          width: 0, // TODO: Fix numbers size
-          margin: 2,
-          textAlign: TextAlign.left,
+          margin: 8,
+          textAlign: TextAlign.right,
           showFoldingHandles: false,
-          showLineNumbers: false,
+          showLineNumbers: true,
+          textStyle: kCodeStyle.copyWith(
+            fontSize: Theme.of(context).textTheme.labelSmall?.fontSize,
+            color: Theme.of(context).colorScheme.outline.withOpacity(0.6),
+          ),
         ),
         cursorColor: Theme.of(context).colorScheme.primary,
         controller: controller,


### PR DESCRIPTION
## PR Description

This PR resolves the TODO in `lib/widgets/editor_code.dart` regarding the incorrect sizing and visibility
  of line numbers in the code editor. It enhances the developer experience when writing Pre-request and
  Post-response scripts by providing a functional, IDE-like editing environment.


## before my PR changes

<img width="1366" height="768" alt="Screenshot from 2026-04-20 17-19-38" src="https://github.com/user-attachments/assets/b9e7a09b-2dec-4698-858c-d66e1743ae17" />


## after my PR changes

<img width="1366" height="768" alt="Screenshot from 2026-04-20 17-17-41" src="https://github.com/user-attachments/assets/d4031df0-bfce-4cd3-9d19-3b6038c7347e" />

## Related Issues

- Closes #1664

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [x] Yes ( i test it manually)
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_

## OS on which you have developed and tested the feature?

- [ ] Windows
- [ ] macOS
- [x] Linux
