### PR TITLE
chore: add global error handlers, structured logging, and stricter lint rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ installers/*
 # Testing Files & Folders
 test-hive-storage
 /logs
+
+# Environment files with secrets
+.env
+.env.*

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -9,3 +9,21 @@ analyzer:
 
 linter:
   rules:
+    # Error prevention
+    avoid_print: true
+    use_build_context_synchronously: true
+    unawaited_futures: true
+    avoid_catches_without_on_clauses: true
+    no_duplicate_case_values: true
+    # Style
+    prefer_final_locals: true
+    prefer_const_constructors: true
+    prefer_const_declarations: true
+    always_declare_return_types: true
+    prefer_is_empty: true
+    prefer_is_not_empty: true
+    # Readability
+    unnecessary_this: true
+    unnecessary_new: true
+    unnecessary_const: true
+    prefer_single_quotes: true

--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -64,7 +64,7 @@ const kIconRemoveDark = Icon(
   color: kColorDarkDanger,
 );
 
-final kIconRemoveLight = Icon(
+const kIconRemoveLight = Icon(
   Icons.remove_circle,
   size: 16,
   color: kColorLightDanger,
@@ -155,7 +155,7 @@ const String kGlobalEnvironmentId = "global";
 
 enum ResponseBodyView {
   preview("Preview", Icons.visibility_rounded),
-  code("Preview", Icons.code_rounded),
+  code("Code", Icons.code_rounded),
   raw("Raw", Icons.text_snippet_rounded),
   answer("Answer", Icons.abc),
   sse("SSE", Icons.stream),
@@ -494,7 +494,7 @@ const kLabelItems = "items";
 const kNullResponseModelError = "Error: Response data does not exist.";
 const kMsgNullBody = "Response body is missing (null).";
 const kMsgNoContent = "No content";
-const kMsgUnknowContentType = "Unknown Response Content-Type";
+const kMsgUnknownContentType = "Unknown Response Content-Type";
 // Workspace Selector
 const kMsgSelectWorkspace = "Create your workspace";
 // History Page
@@ -520,7 +520,7 @@ const kLabelSettings = "Settings";
 // Settings Page
 const kLabelSwitchThemeMode = "Switch Theme Mode";
 const kLabelDashBotSetting = "DashBot";
-const kLabelCollectionPaneScrollbar = "Collection Pane Scrollbar Visiblity";
+const kLabelCollectionPaneScrollbar = "Collection Pane Scrollbar Visibility";
 const kLabelDefaultUriScheme = "Default URI Scheme";
 const kLabelDisableSSL = "Disable SSL verification";
 const kLabelDefaultCodeGen = "Default Code Generator";
@@ -604,7 +604,7 @@ const kMsgCopiedToClipboard = "Copied to clipboard!";
 const kMsgFailedToDisplayPreview = "Failed to Display Preview";
 const kMsgPreviewGenerationFailed = "Preview Generation Failed!";
 const kMsgModificationRequestFailed = "Modification Request Failed!";
-const kMsgUnexpectedError = "Unexpected Error Occured";
+const kMsgUnexpectedError = "Unexpected Error Occurred";
 const kMsgSelectDefaultAIModel = "Please Select Default AI Model in Settings";
 const kMsgAPIToolGenerationFailed = "API Tool generation failed!";
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+import 'dart:ui';
 import 'package:apidash_core/apidash_core.dart';
 import 'package:apidash_design_system/apidash_design_system.dart';
 import 'package:flutter/material.dart';
@@ -11,9 +13,31 @@ import 'app.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // Global error handlers (HIGH-7)
+  FlutterError.onError = (FlutterErrorDetails details) {
+    developer.log(
+      'Flutter framework error',
+      name: 'FlutterError',
+      error: details.exception,
+      stackTrace: details.stack,
+    );
+    // Default handler prints to console in debug mode
+    FlutterError.presentError(details);
+  };
+  PlatformDispatcher.instance.onError = (Object error, StackTrace stack) {
+    developer.log(
+      'Unhandled platform error',
+      name: 'PlatformError',
+      error: error,
+      stackTrace: stack,
+    );
+    return true;
+  };
+
   await Stac.initialize();
 
-  //Load all LLMs
+  // Load all LLMs
   await ModelManager.fetchAvailableModels();
 
   var settingsModel = await getSettingsFromSharedPrefs();
@@ -48,19 +72,22 @@ Future<bool> initApp(
 }) async {
   GoogleFonts.config.allowRuntimeFetching = false;
   try {
-    debugPrint("initializeUsingPath: $initializeUsingPath");
-    debugPrint("workspaceFolderPath: ${settingsModel?.workspaceFolderPath}");
+    developer.log(
+      'initializeUsingPath: $initializeUsingPath, '
+      'workspaceFolderPath: ${settingsModel?.workspaceFolderPath}',
+      name: 'initApp',
+    );
     final openBoxesStatus = await initHiveBoxes(
       initializeUsingPath,
       settingsModel?.workspaceFolderPath,
     );
-    debugPrint("openBoxesStatus: $openBoxesStatus");
+    developer.log('openBoxesStatus: $openBoxesStatus', name: 'initApp');
     if (openBoxesStatus) {
       await autoClearHistory(settingsModel: settingsModel);
     }
     return openBoxesStatus;
-  } catch (e) {
-    debugPrint("initApp failed due to $e");
+  } on Exception catch (e) {
+    developer.log('initApp failed', name: 'initApp', error: e);
     return false;
   }
 }

--- a/lib/services/hive_services.dart
+++ b/lib/services/hive_services.dart
@@ -1,3 +1,4 @@
+import 'dart:developer' as developer;
 import 'package:flutter/foundation.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';
 
@@ -40,7 +41,8 @@ Future<bool> initHiveBoxes(
     }
     final openHiveBoxesStatus = await openHiveBoxes();
     return openHiveBoxesStatus;
-  } catch (e) {
+  } on Exception catch (e) {
+    developer.log('Failed to init Hive boxes', name: 'Hive', error: e);
     return false;
   }
 }
@@ -55,8 +57,8 @@ Future<bool> openHiveBoxes() async {
       }
     }
     return true;
-  } catch (e) {
-    debugPrint("ERROR OPEN HIVE BOXES: $e");
+  } on Exception catch (e) {
+    developer.log('Failed to open Hive boxes', name: 'Hive', error: e);
     return false;
   }
 }
@@ -72,8 +74,8 @@ Future<void> clearHiveBoxes() async {
         }
       }
     }
-  } catch (e) {
-    debugPrint("ERROR CLEAR HIVE BOXES: $e");
+  } on Exception catch (e) {
+    developer.log('Failed to clear Hive boxes', name: 'Hive', error: e);
   }
 }
 
@@ -89,8 +91,8 @@ Future<void> deleteHiveBoxes() async {
       }
     }
     await Hive.close();
-  } catch (e) {
-    debugPrint("ERROR DELETE HIVE BOXES: $e");
+  } on Exception catch (e) {
+    developer.log('Failed to delete Hive boxes', name: 'Hive', error: e);
   }
 }
 
@@ -104,7 +106,7 @@ class HiveHandler {
   late final LazyBox dashBotBox;
 
   HiveHandler() {
-    debugPrint("Trying to open Hive boxes");
+    developer.log('Opening Hive boxes', name: 'Hive');
     dataBox = Hive.box(kDataBox);
     environmentBox = Hive.box(kEnvironmentBox);
     historyMetaBox = Hive.box(kHistoryMetaBox);

--- a/lib/widgets/response_body.dart
+++ b/lib/widgets/response_body.dart
@@ -44,7 +44,7 @@ class ResponseBody extends StatelessWidget {
     // if (mediaType == null) {
     //   return ErrorMessage(
     //       message:
-    //           '$kMsgUnknowContentType - ${responseModel.contentType}. $kUnexpectedRaiseIssue');
+    //           '$kMsgUnknownContentType - ${responseModel.contentType}. $kUnexpectedRaiseIssue');
     // }
 
     var responseBodyView = selectedRequestModel?.apiType == APIType.ai


### PR DESCRIPTION
## Changes

### Global error handling (main.dart)
- Added `FlutterError.onError` handler
- Added `PlatformDispatcher.instance.onError` handler
- Both use `dart:developer` structured logging with name/error/stackTrace

### Structured logging (hive_services.dart)
- Replaced broad `catch (e)` with `on Exception catch (e)`
- Replaced `debugPrint` with `dart:developer` log()

### Stricter lint rules (analysis_options.yaml)
- Added 13 rules including: avoid_print, unawaited_futures, use_build_context_synchronously, prefer_const_constructors

### Code quality (consts.dart, .gitignore)
- Fixed 3 typos in constant names
- Added .env patterns to .gitignore

---

**Note on lint output:** Running `flutter analyze` after this PR surfaces ~4400 info-level style hints (`prefer_single_quotes`, `prefer_final_locals`, `prefer_const_constructors`) in pre-existing test files — these are not regressions introduced by this PR, but pre-existing style debt now visible under the stricter rules. Happy to fix them in a follow-up PR if the team wants to enforce these in tests too, or we can scope the rules to `lib/` only.