### PR TITLE
fix: handle empty CSV data and empty collection on startup

### DIFF
--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -56,9 +56,9 @@ class CollectionStateNotifier
       if (status) {
         ref.read(requestSequenceProvider.notifier).state = [state!.keys.first];
       }
-      ref.read(selectedIdStateProvider.notifier).state = ref.read(
-        requestSequenceProvider,
-      )[0];
+      final ids = ref.read(requestSequenceProvider);
+      ref.read(selectedIdStateProvider.notifier).state =
+          ids.isNotEmpty ? ids[0] : null;
     });
   }
 

--- a/lib/widgets/previewer_csv.dart
+++ b/lib/widgets/previewer_csv.dart
@@ -15,6 +15,7 @@ class CsvPreviewer extends StatelessWidget {
   Widget build(BuildContext context) {
     try {
       final List<List<dynamic>> csvData = csv.decode(body);
+      if (csvData.isEmpty) return errorWidget;
       return SingleChildScrollView(
         scrollDirection: Axis.vertical,
         child: SingleChildScrollView(


### PR DESCRIPTION
Fixes two RangeError crashes:

**Fix 1 -- CsvPreviewer crashes on empty CSV response (closes #1647)**

`lib/widgets/previewer_csv.dart` accessed `csvData[0]` without checking if the list was empty. Any API response returning empty or malformed CSV would crash the app.

```dart
// before
final List<List<dynamic>> csvData = csv.decode(body);
return SingleChildScrollView(...) // crashes if csvData is empty

// after
final List<List<dynamic>> csvData = csv.decode(body);
if (csvData.isEmpty) return errorWidget;
return SingleChildScrollView(...)
```

**Fix 2 -- CollectionStateNotifier crashes on empty collection (closes #1640)**

`lib/providers/collection_providers.dart` accessed `requestSequenceProvider[0]` unconditionally. On first launch or after clearing all requests, this crashed with `RangeError: Index out of range`.

```dart
// before
ref.read(selectedIdStateProvider.notifier).state = ref.read(
  requestSequenceProvider,
)[0];

// after
final ids = ref.read(requestSequenceProvider);
ref.read(selectedIdStateProvider.notifier).state =
    ids.isNotEmpty ? ids[0] : null;
```