### PR TITLE
sniff magic bytes for application/octet-stream to select correct previewer

### DIFF
--- a/lib/widgets/previewer.dart
+++ b/lib/widgets/previewer.dart
@@ -13,6 +13,17 @@ import 'previewer_video.dart';
 import 'uint8_audio_player.dart';
 import '../consts.dart';
 import '../utils/file_utils.dart';
+import 'package:mime/mime.dart';
+
+/// Sniffs the first bytes of [bytes] using the `mime` package's built-in
+/// magic-number database. Returns a (type, subtype) pair, or null if unknown.
+(String, String)? _sniffMimeFromBytes(Uint8List bytes) {
+  final mimeStr = lookupMimeType('', headerBytes: bytes);
+  if (mimeStr == null) return null;
+  final parts = mimeStr.split('/');
+  if (parts.length != 2) return null;
+  return (parts[0], parts[1]);
+}
 
 class Previewer extends StatefulWidget {
   const Previewer({
@@ -38,7 +49,19 @@ class _PreviewerState extends State<Previewer> {
   @override
   Widget build(BuildContext context) {
     var errorTemplate = jj.Template(kMimeTypeRaiseIssue);
-    if (widget.type == kTypeApplication && widget.subtype == kSubTypeJson) {
+
+    // Sniff magic bytes when server reports a generic binary type.
+    var type = widget.type;
+    var subtype = widget.subtype;
+    if (type == kTypeApplication && subtype == kSubTypeOctetStream) {
+      final sniffed = _sniffMimeFromBytes(widget.bytes);
+      if (sniffed != null) {
+        type = sniffed.$1;
+        subtype = sniffed.$2;
+      }
+    }
+
+    if (type == kTypeApplication && subtype == kSubTypeJson) {
       try {
         var preview = JsonPreviewer(code: jsonDecode(widget.body));
         return preview;
@@ -46,7 +69,7 @@ class _PreviewerState extends State<Previewer> {
         // pass
       }
     }
-    if (widget.type == kTypeImage && widget.subtype == kSubTypeSvg) {
+    if (type == kTypeImage && subtype == kSubTypeSvg) {
       final String rawSvg = widget.body;
       try {
         parseWithoutOptimizers(rawSvg);
@@ -62,7 +85,7 @@ class _PreviewerState extends State<Previewer> {
         );
       }
     }
-    if (widget.type == kTypeImage) {
+    if (type == kTypeImage) {
       return Image.memory(
         widget.bytes,
         errorBuilder: (context, _, stackTrace) {
@@ -76,7 +99,7 @@ class _PreviewerState extends State<Previewer> {
         },
       );
     }
-    if (widget.type == kTypeApplication && widget.subtype == kSubTypePdf) {
+    if (type == kTypeApplication && subtype == kSubTypePdf) {
       return PdfPreview(
         build: (_) => widget.bytes,
         useActions: false,
@@ -91,11 +114,11 @@ class _PreviewerState extends State<Previewer> {
         },
       );
     }
-    if (widget.type == kTypeAudio) {
+    if (type == kTypeAudio) {
       return Uint8AudioPlayer(
         bytes: widget.bytes,
-        type: widget.type!,
-        subtype: widget.subtype!,
+        type: type!,
+        subtype: subtype!,
         errorBuilder: (context, error, stacktrace) {
           return ErrorMessage(
             message: errorTemplate.render({
@@ -107,7 +130,7 @@ class _PreviewerState extends State<Previewer> {
         },
       );
     }
-    if (widget.type == kTypeText && widget.subtype == kSubTypeCsv) {
+    if (type == kTypeText && subtype == kSubTypeCsv) {
       return CsvPreviewer(
         body: widget.body,
         errorWidget: ErrorMessage(
@@ -119,12 +142,12 @@ class _PreviewerState extends State<Previewer> {
         ),
       );
     }
-    if (widget.type == kTypeVideo) {
+    if (type == kTypeVideo) {
       try {
         var preview = VideoPreviewer(
           videoBytes: widget.bytes,
           videoFileExtension: getFileExtension(
-            '${widget.type}/${widget.subtype}',
+            '$type/$subtype',
           ),
         );
         return preview;
@@ -141,7 +164,7 @@ class _PreviewerState extends State<Previewer> {
     var errorText = errorTemplate.render({
       "showRaw": widget.hasRaw,
       "showContentType": true,
-      "type": "${widget.type}/${widget.subtype}",
+      "type": "$type/$subtype",
     });
     return ErrorMessage(message: errorText);
   }

--- a/lib/widgets/previewer.dart
+++ b/lib/widgets/previewer.dart
@@ -6,6 +6,7 @@ import 'package:jinja/jinja.dart' as jj;
 import 'package:printing/printing.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:vector_graphics_compiler/vector_graphics_compiler.dart';
+import 'package:mime/mime.dart';
 import 'error_message.dart';
 import 'previewer_csv.dart';
 import 'previewer_json.dart';
@@ -13,7 +14,6 @@ import 'previewer_video.dart';
 import 'uint8_audio_player.dart';
 import '../consts.dart';
 import '../utils/file_utils.dart';
-import 'package:mime/mime.dart';
 
 /// Sniffs the first bytes of [bytes] using the `mime` package's built-in
 /// magic-number database. Returns a (type, subtype) pair, or null if unknown.
@@ -146,9 +146,7 @@ class _PreviewerState extends State<Previewer> {
       try {
         var preview = VideoPreviewer(
           videoBytes: widget.bytes,
-          videoFileExtension: getFileExtension(
-            '$type/$subtype',
-          ),
+          videoFileExtension: getFileExtension('$type/$subtype'),
         );
         return preview;
       } catch (e) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1120,7 +1120,7 @@ packages:
     source: hosted
     version: "1.17.0"
   mime:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: mime
       sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   media_kit_libs_windows_audio: any
   lottie: ^3.3.2
   markdown: ^7.3.0
+  mime: ^2.0.0
   mime_dart: ^3.0.0
   multi_split_view: ^3.6.1
   multi_trigger_autocomplete_plus: any


### PR DESCRIPTION
## PR Description

This PR sniffs the first bytes of the response body using lookupMimeType from the mime package (already a transitive dependency via dio and share_plus) to detect the true format and route it to the correct previewer. The mime package is also added as a direct dependency to make the usage explicit.

The sniffing only applies when the declared type is exactly application/octet-stream and falls back gracefully if the format cannot be identified.
Sniffing is  kept in the Previewer widget rather than the model layer because the sniffed type is a local rendering hint only, and i think moving it to the model would create an inconsistency between the persisted headers (which correctly reflect what the server sent) and the mediaType getter.

## Related Issues

- Closes #1382 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [x] No, and this is why: The fix delegates entirely to mime's lookupMimeType which is well-tested upstream.Also , the approach first needs to be reviewed.

## OS on which you have developed and tested the feature?

- [ ] Windows
- [ ] macOS
- [x] Linux
