### PR TITLE
fix: prevent CsvPreviewer crash when CSV data is empty

### DIFF
--- a/lib/widgets/previewer_csv.dart
+++ b/lib/widgets/previewer_csv.dart
@@ -15,6 +15,11 @@ class CsvPreviewer extends StatelessWidget {
   Widget build(BuildContext context) {
     try {
       final List<List<dynamic>> csvData = csv.decode(body);
+      if (csvData.isEmpty) {
+        return const Center(
+          child: Text('No CSV data available'),
+        );
+      }
       return SingleChildScrollView(
         scrollDirection: Axis.vertical,
         child: SingleChildScrollView(


### PR DESCRIPTION
## PR Description

This PR fixes a crash in the CsvPreviewer when the CSV response is empty.

## Related Issues

Closes #1647

## What I changed

* Added a guard condition to check if the parsed CSV data is empty
* Prevented accessing `csvData[0]` when the list is empty
* Introduced a simple fallback UI to handle empty CSV data safely

## Result

* The app no longer crashes with a RangeError when CSV data is empty
* A user-friendly message is displayed instead

## Checklist

* [x] I have gone through the contributing guidelines
* [x] I have updated my branch and synced it with project `main` branch before making this PR
* [x] I am using the latest Flutter stable branch
* [x] I have run the tests and ensured everything works as expected

## Notes

* Only minimal changes were made
* No unrelated files were modified
