### PR TITLE
fix(ci): add required permissions for scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -3,14 +3,17 @@
 # policy, and support documentation.
 
 name: Scorecard supply-chain security
+
 on:
   # For Branch-Protection check. Only the default branch is supported. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
   branch_protection_rule:
+
   # To guarantee Maintained check is occasionally updated. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
     - cron: '30 5 1 * *'
+
   push:
     branches: [ "main" ]
 
@@ -21,16 +24,20 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
-    # `publish_results: true` only works when run from the default branch. conditional can be removed if disabled.
+
+    # `publish_results: true` only works when run from the default branch.
     if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request'
+
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
-      # Needed to publish results and get a badge (see publish_results below).
+
+      # Needed to publish results and get a badge.
       id-token: write
-      # Uncomment the permissions below if installing in a private repository.
-      # contents: read
-      # actions: read
+
+      # Needed for GitHub Copilot Code Review workflow access.
+      actions: read
+      contents: read
 
     steps:
       - name: "Checkout code"
@@ -43,26 +50,13 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
-          # - you want to enable the Branch-Protection check on a *public* repository, or
-          # - you are installing Scorecard on a *private* repository
-          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action?tab=readme-ov-file#authentication-with-fine-grained-pat-optional.
+
+          # (Optional) "write" PAT token.
           # repo_token: ${{ secrets.SCORECARD_TOKEN }}
 
-          # Public repositories:
-          #   - Publish results to OpenSSF REST API for easy access by consumers
-          #   - Allows the repository to include the Scorecard badge.
-          #   - See https://github.com/ossf/scorecard-action#publishing-results.
-          # For private repositories:
-          #   - `publish_results` will always be set to `false`, regardless
-          #     of the value entered here.
           publish_results: true
 
-          # (Optional) Uncomment file_mode if you have a .gitattributes with files marked export-ignore
-          # file_mode: git
-
-      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
-      # format to the repository Actions tab.
+      # Upload the results as artifacts.
       - name: "Upload artifact"
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
@@ -70,8 +64,7 @@ jobs:
           path: results.sarif
           retention-days: 5
 
-      # Upload the results to GitHub's code scanning dashboard (optional).
-      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+      # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
         uses: github/codeql-action/upload-sarif@v3
         with:


### PR DESCRIPTION
## PR Description

This PR updates the `scorecard.yml` GitHub Actions workflow by explicitly adding the required workflow permissions for the Scorecard analysis job.

### Background

The existing workflow was configured with `permissions: read-all` at the top level, but the `analysis` job overrides permissions locally. Due to this override, the workflow did not explicitly grant access to certain scopes required during execution, which could lead to permission-related failures in GitHub Actions integrations and automated code review tooling.

### Changes Made

The following permissions were added under the `analysis` job:

```yml
actions: read
contents: read
```

### Why this change is necessary

* `actions: read` allows the workflow to access metadata related to GitHub Actions runs.
* `contents: read` grants read access to repository contents required by the Scorecard action and related tooling.

Adding these permissions ensures that the workflow operates with the minimum required access while avoiding authorization-related failures during execution.

### Scope

This change is limited strictly to workflow permission configuration and does not modify application logic, runtime behavior, or release artifacts.

## Related Issues

* Closes #1674

### Checklist

* [x] I have gone through the [[contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
* [x] I have updated my branch and synced it with project `main` branch before making this PR
* [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
* [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

*We encourage you to add relevant test cases.*

* [ ] Yes
* [x] No, because this change only updates GitHub Actions workflow permissions and does not affect application logic or runtime functionality.

## OS on which you have developed and tested the feature?

* [x] Windows
* [ ] macOS
* [ ] Linux