### PR TITLE
fix: redact sensitive oauth diagnostics

### DIFF
--- a/packages/better_networking/lib/services/oauth_callback_server.dart
+++ b/packages/better_networking/lib/services/oauth_callback_server.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:async';
 import 'dart:developer' show log;
+import 'package:better_networking/utils/sensitive_data_redactor.dart';
 
 /// A lightweight HTTP server for handling OAuth callbacks on desktop platforms.
 /// This provides a standard localhost callback URL that's compatible with most OAuth providers.
@@ -152,7 +153,7 @@ class OAuthCallbackServer {
   }
 
   void _handleRequest(HttpRequest request) {
-    log('OAuth request received: ${request.uri}');
+    log('OAuth request received: ${redactSensitiveUri(request.uri)}');
 
     try {
       // Handle OPTIONS preflight requests for CORS

--- a/packages/better_networking/lib/utils/auth/handle_auth.dart
+++ b/packages/better_networking/lib/utils/auth/handle_auth.dart
@@ -5,6 +5,7 @@ import 'package:better_networking/utils/auth/jwt_auth_utils.dart';
 import 'package:better_networking/utils/auth/digest_auth_utils.dart';
 import 'package:better_networking/better_networking.dart';
 import 'package:better_networking/utils/auth/oauth2_utils.dart';
+import 'package:better_networking/utils/sensitive_data_redactor.dart';
 import 'package:flutter/foundation.dart';
 
 import 'oauth1_utils.dart';
@@ -221,7 +222,13 @@ Future<HttpRequestModel> handleAuth(
             }
           }
 
-          debugPrint(res.$1.credentials.accessToken);
+          debugPrint(
+            'OAuth2 authorization code token: '
+            '${redactSensitiveValue(
+              res.$1.credentials.accessToken,
+              name: 'access_token',
+            )}',
+          );
 
           // Add the access token to the request headers
           updatedHeaders.add(
@@ -238,7 +245,13 @@ Future<HttpRequestModel> handleAuth(
             oauth2Model: oauth2,
             credentialsFile: credentialsFile,
           );
-          debugPrint(client.credentials.accessToken);
+          debugPrint(
+            'OAuth2 client credentials token: '
+            '${redactSensitiveValue(
+              client.credentials.accessToken,
+              name: 'access_token',
+            )}',
+          );
 
           // Add the access token to the request headers
           updatedHeaders.add(
@@ -255,7 +268,13 @@ Future<HttpRequestModel> handleAuth(
             oauth2Model: oauth2,
             credentialsFile: credentialsFile,
           );
-          debugPrint(client.credentials.accessToken);
+          debugPrint(
+            'OAuth2 resource owner password token: '
+            '${redactSensitiveValue(
+              client.credentials.accessToken,
+              name: 'access_token',
+            )}',
+          );
 
           // Add the access token to the request headers
           updatedHeaders.add(

--- a/packages/better_networking/lib/utils/sensitive_data_redactor.dart
+++ b/packages/better_networking/lib/utils/sensitive_data_redactor.dart
@@ -1,0 +1,84 @@
+const String _redactedValue = '[REDACTED]';
+
+const Set<String> _sensitiveQueryKeys = {
+  'access_token',
+  'api_key',
+  'apikey',
+  'auth',
+  'authorization',
+  'client_secret',
+  'code',
+  'id_token',
+  'key',
+  'password',
+  'refresh_token',
+  'secret',
+  'session',
+  'signature',
+  'state',
+  'token',
+};
+
+const Set<String> _sensitiveHeaderNames = {
+  'authorization',
+  'cookie',
+  'proxy-authorization',
+  'set-cookie',
+  'x-api-key',
+  'x-auth-token',
+  'x-csrf-token',
+};
+
+/// Redacts common secrets before values are written to diagnostics or logs.
+String redactSensitiveValue(
+  Object? value, {
+  String? name,
+}) {
+  if (value == null) {
+    return '';
+  }
+
+  if (name != null && _isSensitiveName(name)) {
+    return _redactedValue;
+  }
+
+  return value
+      .toString()
+      .replaceAllMapped(
+        RegExp(
+          r'(?i)\b(bearer|basic)\s+[A-Za-z0-9._~+/=-]+',
+        ),
+        (match) => '${match.group(1)} $_redactedValue',
+      )
+      .replaceAllMapped(
+        RegExp(
+          r'(?i)\b(access_token|api_?key|auth|authorization|client_secret|'
+          r'id_token|password|refresh_token|secret|token)=([^&\s]+)',
+        ),
+        (match) => '${match.group(1)}=$_redactedValue',
+      );
+}
+
+/// Redacts sensitive query parameters while preserving the non-secret URI shape.
+String redactSensitiveUri(Uri uri) {
+  if (!uri.hasQuery) {
+    return uri.toString();
+  }
+
+  final redactedQueryParameters = uri.queryParametersAll.map(
+    (key, values) {
+      final nextValues = _isSensitiveName(key)
+          ? List<String>.filled(values.length, _redactedValue)
+          : values;
+      return MapEntry(key, nextValues);
+    },
+  );
+
+  return uri.replace(queryParameters: redactedQueryParameters).toString();
+}
+
+bool _isSensitiveName(String name) {
+  final normalized = name.toLowerCase().replaceAll('-', '_');
+  return _sensitiveQueryKeys.contains(normalized) ||
+      _sensitiveHeaderNames.contains(name.toLowerCase());
+}

--- a/packages/better_networking/lib/utils/utils.dart
+++ b/packages/better_networking/lib/utils/utils.dart
@@ -3,6 +3,7 @@ export 'graphql_utils.dart';
 export 'http_request_utils.dart';
 export 'http_response_utils.dart';
 export 'platform_utils.dart';
+export 'sensitive_data_redactor.dart';
 export 'string_utils.dart' hide RandomStringGenerator;
 export 'uri_utils.dart';
 export 'auth/handle_auth.dart';

--- a/packages/better_networking/test/utils/sensitive_data_redactor_test.dart
+++ b/packages/better_networking/test/utils/sensitive_data_redactor_test.dart
@@ -1,0 +1,58 @@
+import 'package:better_networking/utils/sensitive_data_redactor.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('redactSensitiveValue', () {
+    test('redacts values when the field name is sensitive', () {
+      expect(
+        redactSensitiveValue('super-secret-token', name: 'Authorization'),
+        '[REDACTED]',
+      );
+      expect(redactSensitiveValue('abc123', name: 'x-api-key'), '[REDACTED]');
+    });
+
+    test('redacts bearer and basic credentials in free-form text', () {
+      expect(
+        redactSensitiveValue('Authorization: Bearer abc.def.ghi'),
+        'Authorization: Bearer [REDACTED]',
+      );
+      expect(
+        redactSensitiveValue('auth Basic dXNlcjpwYXNz'),
+        'auth Basic [REDACTED]',
+      );
+    });
+
+    test('redacts secret key-value pairs in free-form text', () {
+      expect(
+        redactSensitiveValue('url?access_token=abc123&safe=yes'),
+        'url?access_token=[REDACTED]&safe=yes',
+      );
+    });
+
+    test('keeps ordinary values readable', () {
+      expect(redactSensitiveValue('status=ok&safe=yes'), 'status=ok&safe=yes');
+    });
+  });
+
+  group('redactSensitiveUri', () {
+    test('redacts sensitive OAuth callback parameters', () {
+      final redacted = redactSensitiveUri(
+        Uri.parse(
+          'http://localhost:8080/callback?code=abc&state=visible&token=xyz',
+        ),
+      );
+
+      expect(redacted, contains('code=%5BREDACTED%5D'));
+      expect(redacted, contains('state=%5BREDACTED%5D'));
+      expect(redacted, contains('token=%5BREDACTED%5D'));
+      expect(redacted, isNot(contains('abc')));
+      expect(redacted, isNot(contains('visible')));
+      expect(redacted, isNot(contains('xyz')));
+    });
+
+    test('preserves URI without query parameters', () {
+      const value = 'http://localhost:8080/callback';
+      expect(redactSensitiveUri(Uri.parse(value)), value);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- redact OAuth access tokens before debug logging in auth handling
- redact sensitive OAuth callback query parameters before logging callback requests
- add unit coverage for the shared redaction helper

## Validation
- git diff --check
- Could not run Dart/Flutter tests locally because dart and flutter are not installed in this environment.

Fixes #1686