### PR TITLE
fix: prevent null crash on empty JWT private key (#1703)

### DIFF
--- a/lib/utils/envvar_utils.dart
+++ b/lib/utils/envvar_utils.dart
@@ -140,7 +140,8 @@ AuthModel? substituteAuthModel(
         return authModel.copyWith(
           jwt: jwt.copyWith(
             secret: substituteVariables(jwt.secret, envVarMap)!,
-            privateKey: substituteVariables(jwt.privateKey, envVarMap)!,
+            privateKey:
+                substituteVariables(jwt.privateKey, envVarMap) ?? jwt.privateKey,
             payload: substituteVariables(jwt.payload, envVarMap)!,
           ),
         );

--- a/test/utils/envvar_utils_test.dart
+++ b/test/utils/envvar_utils_test.dart
@@ -566,6 +566,40 @@ void main() {
       expect(result.authModel?.jwt?.payload, "payload123");
     });
 
+    test("Testing jwt auth with null private key does not crash", () {
+      const httpRequestModel = HttpRequestModel(
+        url: "{{url}}/test",
+        authModel: AuthModel(
+          type: APIAuthType.jwt,
+          jwt: AuthJwtModel(
+            secret: "{{jwt_secret}}",
+            privateKey: null,
+            payload: "{{jwt_payload}}",
+            addTokenTo: "header",
+            algorithm: "HS256",
+            isSecretBase64Encoded: false,
+            headerPrefix: "Bearer",
+            queryParamKey: "token",
+            header: "Authorization",
+          ),
+        ),
+      );
+
+      Map<String?, List<EnvironmentVariableModel>> envMap = {
+        kGlobalEnvironmentId: [
+          EnvironmentVariableModel(key: "url", value: "api.apidash.dev"),
+          EnvironmentVariableModel(key: "jwt_secret", value: "sec123"),
+          EnvironmentVariableModel(key: "jwt_payload", value: "payload123"),
+        ],
+      };
+
+      final result = substituteHttpRequestModel(httpRequestModel, envMap, null);
+
+      expect(result.authModel?.jwt?.secret, "sec123");
+      expect(result.authModel?.jwt?.privateKey, null);
+      expect(result.authModel?.jwt?.payload, "payload123");
+    });
+
     test("Testing digest auth with environment variables", () {
       const httpRequestModel = HttpRequestModel(
         url: "{{url}}/test",


### PR DESCRIPTION
## PR Description

`AuthJwtModel.privateKey` is nullable (`String?`), but `substituteAuthModel()` in `lib/utils/envvar_utils.dart` force-unwraps the result of `substituteVariables(jwt.privateKey, envVarMap)!`. Since `substituteVariables()` returns `null` for `null` input, using JWT auth without a private key crashes with **"Null check operator used on a null value."**

This restores the safe `?? jwt.privateKey` fallback for `privateKey`. `secret` and `payload` keep `!` since they are `required String` (non-nullable) and cannot be null.

```dart
privateKey: substituteVariables(jwt.privateKey, envVarMap) ?? jwt.privateKey,
```

## Related Issues

- Closes #1703

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [x] Yes — added "jwt auth with null private key does not crash" regression test in `test/utils/envvar_utils_test.dart`. Verified locally on Flutter 3.44.4 / Dart 3.12.2 — all tests in `test/utils/envvar_utils_test.dart` pass.

## OS on which you have developed and tested the feature?

- [ ] Windows
- [ ] macOS
- [x] Linux
