### PR TITLE
fix: guard null content in saveToDownloads to prevent null-check crash (#1704)

### DIFF
--- a/lib/utils/save_utils.dart
+++ b/lib/utils/save_utils.dart
@@ -31,18 +31,19 @@ Future<void> saveToDownloads(
   String? name,
 }) async {
   var message = "";
-  var path = await getFileDownloadpath(
-    name,
-    ext ?? getFileExtension(mimeType),
-  );
+  var path = await getFileDownloadpath(name, ext ?? getFileExtension(mimeType));
   if (path != null) {
-    try {
-      await saveFile(path, content!);
-      var sp = getShortPath(path);
-      message = 'Saved to $sp';
-    } catch (e) {
-      debugPrint("$e");
-      message = "An error occurred while saving file.";
+    if (content == null) {
+      message = "No content available to save.";
+    } else {
+      try {
+        await saveFile(path, content);
+        var sp = getShortPath(path);
+        message = 'Saved to $sp';
+      } catch (e) {
+        debugPrint("$e");
+        message = "An error occurred while saving file.";
+      }
     }
   } else {
     message = "Unable to determine the download path.";

--- a/test/utils/save_utils_test.dart
+++ b/test/utils/save_utils_test.dart
@@ -123,6 +123,28 @@ void main() {
       expect(find.byType(SnackBar), findsOneWidget);
     });
 
+    testWidgets('saveToDownloads handles null content without crashing', (
+      tester,
+    ) async {
+      final scaffoldKey = GlobalKey<ScaffoldMessengerState>();
+      await tester.pumpWidget(
+        MaterialApp(
+          scaffoldMessengerKey: scaffoldKey,
+          home: Scaffold(body: Container()),
+        ),
+      );
+
+      final sm = scaffoldKey.currentState!;
+
+      await tester.runAsync(() async {
+        await saveToDownloads(sm, content: null, mimeType: 'text/plain');
+      });
+
+      // Wait for snackbar to appear
+      await tester.pump();
+      expect(find.byType(SnackBar), findsOneWidget);
+    });
+
     testWidgets('saveAndShowDialog executes', (tester) async {
       await tester.pumpWidget(
         MaterialApp(


### PR DESCRIPTION
## PR Description

`saveToDownloads()` in `lib/utils/save_utils.dart` accepted a nullable `Uint8List? content` but force-unwrapped it with `content!` inside the `if (path != null)` block. When a save path is resolved (user picks a location) but `content` is `null` (e.g. an empty or failed response body), this threw `Null check operator used on a null value`.

This PR removes the `content!` force-unwrap and adds an explicit null guard: when `content` is `null`, the user now sees a "No content available to save." snackbar instead of an unhandled crash. Behaviour for valid content and for an unresolved path is unchanged.

## Related Issues

- Closes #1704

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [x] Yes

Added a regression test in `test/utils/save_utils_test.dart` ("saveToDownloads handles null content without crashing") that calls `saveToDownloads` with `content: null` and asserts a snackbar is shown rather than an exception being thrown.

## OS on which you have developed and tested the feature?

- [ ] Windows
- [ ] macOS
- [x] Linux
