### PR TITLE
fix: guard missing env key in getVariableStatus to prevent null-check crash (#1699)

### DIFF
--- a/lib/utils/envvar_utils.dart
+++ b/lib/utils/envvar_utils.dart
@@ -9,37 +9,42 @@ String getEnvironmentTitle(String? name) {
 }
 
 List<EnvironmentVariableModel> getEnvironmentVariables(
-    EnvironmentModel? environment,
-    {bool removeEmptyModels = false}) {
+  EnvironmentModel? environment, {
+  bool removeEmptyModels = false,
+}) {
   if (environment == null) {
     return [];
   }
   return environment.values
-      .where((element) =>
-          element.type == EnvironmentVariableType.variable &&
-          (removeEmptyModels
-              ? element != kEnvironmentVariableEmptyModel
-              : true))
+      .where(
+        (element) =>
+            element.type == EnvironmentVariableType.variable &&
+            (removeEmptyModels
+                ? element != kEnvironmentVariableEmptyModel
+                : true),
+      )
       .toList();
 }
 
 List<EnvironmentVariableModel> getEnvironmentSecrets(
-    EnvironmentModel? environment,
-    {bool removeEmptyModels = false}) {
+  EnvironmentModel? environment, {
+  bool removeEmptyModels = false,
+}) {
   if (environment == null) {
     return [];
   }
   return environment.values
-      .where((element) =>
-          element.type == EnvironmentVariableType.secret &&
-          (removeEmptyModels ? element != kEnvironmentSecretEmptyModel : true))
+      .where(
+        (element) =>
+            element.type == EnvironmentVariableType.secret &&
+            (removeEmptyModels
+                ? element != kEnvironmentSecretEmptyModel
+                : true),
+      )
       .toList();
 }
 
-String? substituteVariables(
-  String? input,
-  Map<String, String> envVarMap,
-) {
+String? substituteVariables(String? input, Map<String, String> envVarMap) {
   if (input == null) return null;
   if (envVarMap.keys.isEmpty) {
     return input;
@@ -91,14 +96,18 @@ HttpRequestModel substituteHttpRequestModel(
       );
     }).toList(),
     body: substituteVariables(httpRequestModel.body, combinedEnvVarMap),
-    authModel:
-        substituteAuthModel(httpRequestModel.authModel, combinedEnvVarMap),
+    authModel: substituteAuthModel(
+      httpRequestModel.authModel,
+      combinedEnvVarMap,
+    ),
   );
   return newRequestModel;
 }
 
 AuthModel? substituteAuthModel(
-    AuthModel? authModel, Map<String, String> envVarMap) {
+  AuthModel? authModel,
+  Map<String, String> envVarMap,
+) {
   if (authModel == null) return null;
 
   switch (authModel.type) {
@@ -141,7 +150,8 @@ AuthModel? substituteAuthModel(
           jwt: jwt.copyWith(
             secret: substituteVariables(jwt.secret, envVarMap)!,
             privateKey:
-                substituteVariables(jwt.privateKey, envVarMap) ?? jwt.privateKey,
+                substituteVariables(jwt.privateKey, envVarMap) ??
+                jwt.privateKey,
             payload: substituteVariables(jwt.payload, envVarMap)!,
           ),
         );
@@ -168,11 +178,20 @@ AuthModel? substituteAuthModel(
         return authModel.copyWith(
           oauth1: oauth1.copyWith(
             consumerKey: substituteVariables(oauth1.consumerKey, envVarMap)!,
-            consumerSecret: substituteVariables(oauth1.consumerSecret, envVarMap)!,
-            credentialsFilePath: substituteVariables(oauth1.credentialsFilePath, envVarMap)!,
+            consumerSecret: substituteVariables(
+              oauth1.consumerSecret,
+              envVarMap,
+            )!,
+            credentialsFilePath: substituteVariables(
+              oauth1.credentialsFilePath,
+              envVarMap,
+            )!,
             accessToken: substituteVariables(oauth1.accessToken, envVarMap)!,
             tokenSecret: substituteVariables(oauth1.tokenSecret, envVarMap)!,
-            parameterLocation: substituteVariables(oauth1.parameterLocation, envVarMap)!,
+            parameterLocation: substituteVariables(
+              oauth1.parameterLocation,
+              envVarMap,
+            )!,
             version: substituteVariables(oauth1.version, envVarMap)!,
             realm: substituteVariables(oauth1.realm, envVarMap)!,
             callbackUrl: substituteVariables(oauth1.callbackUrl, envVarMap)!,
@@ -188,21 +207,39 @@ AuthModel? substituteAuthModel(
         final oauth2 = authModel.oauth2!;
         return authModel.copyWith(
           oauth2: oauth2.copyWith(
-            authorizationUrl: substituteVariables(oauth2.authorizationUrl, envVarMap)!,
-            accessTokenUrl: substituteVariables(oauth2.accessTokenUrl, envVarMap)!,
+            authorizationUrl: substituteVariables(
+              oauth2.authorizationUrl,
+              envVarMap,
+            )!,
+            accessTokenUrl: substituteVariables(
+              oauth2.accessTokenUrl,
+              envVarMap,
+            )!,
             clientId: substituteVariables(oauth2.clientId, envVarMap)!,
             clientSecret: substituteVariables(oauth2.clientSecret, envVarMap)!,
-            credentialsFilePath: substituteVariables(oauth2.credentialsFilePath, envVarMap)!,
+            credentialsFilePath: substituteVariables(
+              oauth2.credentialsFilePath,
+              envVarMap,
+            )!,
             redirectUrl: substituteVariables(oauth2.redirectUrl, envVarMap)!,
             scope: substituteVariables(oauth2.scope, envVarMap)!,
             state: substituteVariables(oauth2.state, envVarMap)!,
-            codeChallengeMethod: substituteVariables(oauth2.codeChallengeMethod, envVarMap)!,
+            codeChallengeMethod: substituteVariables(
+              oauth2.codeChallengeMethod,
+              envVarMap,
+            )!,
             codeVerifier: substituteVariables(oauth2.codeVerifier, envVarMap)!,
-            codeChallenge: substituteVariables(oauth2.codeChallenge, envVarMap)!,
+            codeChallenge: substituteVariables(
+              oauth2.codeChallenge,
+              envVarMap,
+            )!,
             username: substituteVariables(oauth2.username, envVarMap)!,
             password: substituteVariables(oauth2.password, envVarMap)!,
             refreshToken: substituteVariables(oauth2.refreshToken, envVarMap)!,
-            identityToken: substituteVariables(oauth2.identityToken, envVarMap)!,
+            identityToken: substituteVariables(
+              oauth2.identityToken,
+              envVarMap,
+            )!,
             accessToken: substituteVariables(oauth2.accessToken, envVarMap)!,
           ),
         );
@@ -216,9 +253,10 @@ AuthModel? substituteAuthModel(
 }
 
 List<EnvironmentVariableSuggestion>? getEnvironmentTriggerSuggestions(
-    String query,
-    Map<String, List<EnvironmentVariableModel>> envMap,
-    String? activeEnvironmentId) {
+  String query,
+  Map<String, List<EnvironmentVariableModel>> envMap,
+  String? activeEnvironmentId,
+) {
   final suggestions = <EnvironmentVariableSuggestion>[];
   final Set<String> addedVariableKeys = {};
 
@@ -226,8 +264,12 @@ List<EnvironmentVariableSuggestion>? getEnvironmentTriggerSuggestions(
     for (final variable in envMap[activeEnvironmentId]!) {
       if ((query.isEmpty || variable.key.contains(query)) &&
           !addedVariableKeys.contains(variable.key)) {
-        suggestions.add(EnvironmentVariableSuggestion(
-            environmentId: activeEnvironmentId, variable: variable));
+        suggestions.add(
+          EnvironmentVariableSuggestion(
+            environmentId: activeEnvironmentId,
+            variable: variable,
+          ),
+        );
         addedVariableKeys.add(variable.key);
       }
     }
@@ -236,8 +278,12 @@ List<EnvironmentVariableSuggestion>? getEnvironmentTriggerSuggestions(
   envMap[kGlobalEnvironmentId]?.forEach((variable) {
     if ((query.isEmpty || variable.key.contains(query)) &&
         !addedVariableKeys.contains(variable.key)) {
-      suggestions.add(EnvironmentVariableSuggestion(
-          environmentId: kGlobalEnvironmentId, variable: variable));
+      suggestions.add(
+        EnvironmentVariableSuggestion(
+          environmentId: kGlobalEnvironmentId,
+          variable: variable,
+        ),
+      );
       addedVariableKeys.add(variable.key);
     }
   });
@@ -246,12 +292,14 @@ List<EnvironmentVariableSuggestion>? getEnvironmentTriggerSuggestions(
 }
 
 EnvironmentVariableSuggestion getVariableStatus(
-    String key,
-    Map<String, List<EnvironmentVariableModel>> envMap,
-    String? activeEnvironmentId) {
-  if (activeEnvironmentId != null) {
-    final variable =
-        envMap[activeEnvironmentId]!.firstWhereOrNull((v) => v.key == key);
+  String key,
+  Map<String, List<EnvironmentVariableModel>> envMap,
+  String? activeEnvironmentId,
+) {
+  if (activeEnvironmentId != null && envMap[activeEnvironmentId] != null) {
+    final variable = envMap[activeEnvironmentId]!.firstWhereOrNull(
+      (v) => v.key == key,
+    );
     if (variable != null) {
       return EnvironmentVariableSuggestion(
         environmentId: activeEnvironmentId,
@@ -261,8 +309,9 @@ EnvironmentVariableSuggestion getVariableStatus(
     }
   }
 
-  final globalVariable =
-      envMap[kGlobalEnvironmentId]?.firstWhereOrNull((v) => v.key == key);
+  final globalVariable = envMap[kGlobalEnvironmentId]?.firstWhereOrNull(
+    (v) => v.key == key,
+  );
   if (globalVariable != null) {
     return EnvironmentVariableSuggestion(
       environmentId: kGlobalEnvironmentId,
@@ -272,8 +321,12 @@ EnvironmentVariableSuggestion getVariableStatus(
   }
 
   return EnvironmentVariableSuggestion(
-      isUnknown: true,
-      environmentId: "unknown",
-      variable: EnvironmentVariableModel(
-          key: key, type: EnvironmentVariableType.variable, value: "unknown"));
+    isUnknown: true,
+    environmentId: "unknown",
+    variable: EnvironmentVariableModel(
+      key: key,
+      type: EnvironmentVariableType.variable,
+      value: "unknown",
+    ),
+  );
 }

--- a/test/utils/envvar_utils_test.dart
+++ b/test/utils/envvar_utils_test.dart
@@ -438,6 +438,22 @@ void main() {
       );
       expect(getVariableStatus(query, envMap, activeEnvironmentId), expected);
     });
+
+    test(
+      "Testing getVariableStatus with activeEnvironmentId absent from envMap",
+      () {
+        const query = "num";
+        Map<String, List<EnvironmentVariableModel>> envMap = {
+          kGlobalEnvironmentId: globalVars,
+        };
+        const activeEnvironmentId = "missingEnvId";
+        const expected = EnvironmentVariableSuggestion(
+          environmentId: kGlobalEnvironmentId,
+          variable: EnvironmentVariableModel(key: "num", value: "5670000"),
+        );
+        expect(getVariableStatus(query, envMap, activeEnvironmentId), expected);
+      },
+    );
   });
 
   group("Testing auth model environment variable substitution", () {


### PR DESCRIPTION
## PR Description

`getVariableStatus()` in `lib/utils/envvar_utils.dart` guarded only `activeEnvironmentId != null` before doing `envMap[activeEnvironmentId]!`. In Dart, `Map.operator[]` returns `null` for a missing key, so when `activeEnvironmentId` is non-null but absent from `envMap`, the `!` threw `Null check operator used on a null value`.

This PR adds the same `&& envMap[activeEnvironmentId] != null` guard that the sibling function `getEnvironmentTriggerSuggestions` already uses. When the active environment has no entry in `envMap`, the lookup now falls through to global variables (and ultimately the "unknown" result) instead of crashing. Behaviour when the key exists is unchanged.

## Related Issues

- Closes #1699

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [x] Yes

Added a regression test in `test/utils/envvar_utils_test.dart` ("Testing getVariableStatus with activeEnvironmentId absent from envMap") that calls `getVariableStatus` with a non-null `activeEnvironmentId` that has no entry in `envMap` and asserts it returns the global match instead of throwing. The full `envvar_utils_test.dart` suite passes locally.

## OS on which you have developed and tested the feature?

- [ ] Windows
- [ ] macOS
- [x] Linux
