### PR TITLE
feat: add in-app update check (#373)

### DIFF
--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -516,6 +516,8 @@ const kLabelHistory = "History";
 const kLabelLogs = "Logs";
 const kLabelAbout = "About";
 const kLabelSettings = "Settings";
+const kLabelUpdateAvailable = "Update Available";
+const kLabelSkipUpdate = "Skip this version";
 
 // Settings Page
 const kLabelSwitchThemeMode = "Switch Theme Mode";

--- a/lib/providers/providers.dart
+++ b/lib/providers/providers.dart
@@ -6,3 +6,4 @@ export 'terminal_providers.dart';
 export 'settings_providers.dart';
 export 'ui_providers.dart';
 export 'js_runtime_notifier.dart';
+export 'update_providers.dart';

--- a/lib/providers/update_providers.dart
+++ b/lib/providers/update_providers.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import '../services/services.dart';
+import '../consts.dart';
+
+@immutable
+class UpdateState {
+  const UpdateState({this.info, this.skippedVersion});
+
+  final AppUpdateInfo? info;
+  final String? skippedVersion;
+
+  /// Whether the update indicator (red dot) should be shown. True only when an
+  /// update is available and the user has not skipped that specific version.
+  bool get showBadge =>
+      info != null &&
+      info!.isUpdateAvailable &&
+      info!.latestVersion != skippedVersion;
+
+  bool get isUpdateAvailable => info?.isUpdateAvailable ?? false;
+
+  UpdateState copyWith({AppUpdateInfo? info, String? skippedVersion}) {
+    return UpdateState(
+      info: info ?? this.info,
+      skippedVersion: skippedVersion ?? this.skippedVersion,
+    );
+  }
+}
+
+final updateProvider = StateNotifierProvider<UpdateNotifier, UpdateState>(
+  (ref) => UpdateNotifier()..check(),
+);
+
+class UpdateNotifier extends StateNotifier<UpdateState> {
+  UpdateNotifier() : super(const UpdateState());
+
+  /// Silently checks GitHub for a newer release in the background. Any failure
+  /// leaves the state untouched so the UI never reacts to a failed check.
+  Future<void> check() async {
+    if (kIsRunningTests) return;
+    final skipped = await getSkippedUpdateVersionFromSharedPrefs();
+    final currentVersion = (await PackageInfo.fromPlatform()).version;
+    final info = await checkForUpdate(currentVersion);
+    if (info == null) return;
+    state = UpdateState(info: info, skippedVersion: skipped);
+  }
+
+  /// Persists the latest version as skipped so the badge is dismissed until a
+  /// newer version is released.
+  Future<void> skipCurrentVersion() async {
+    final latest = state.info?.latestVersion;
+    if (latest == null) return;
+    await setSkippedUpdateVersionToSharedPrefs(latest);
+    state = state.copyWith(skippedVersion: latest);
+  }
+}

--- a/lib/screens/common_widgets/button_navbar.dart
+++ b/lib/screens/common_widgets/button_navbar.dart
@@ -13,6 +13,7 @@ class NavbarButton extends ConsumerWidget {
     required this.label,
     this.showLabel = true,
     this.isCompact = false,
+    this.showBadge = false,
     this.onTap,
   });
   final int railIdx;
@@ -23,6 +24,7 @@ class NavbarButton extends ConsumerWidget {
   final bool showLabel;
   final Function()? onTap;
   final bool isCompact;
+  final bool showBadge;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -58,9 +60,12 @@ class NavbarButton extends ConsumerWidget {
                       : null,
                 ),
                 onPressed: onPress,
-                child: Icon(
-                  isSelected ? selectedIcon : icon,
-                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                child: Badge(
+                  isLabelVisible: showBadge,
+                  child: Icon(
+                    isSelected ? selectedIcon : icon,
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
                 ),
               ),
             ),

--- a/lib/screens/dashboard.dart
+++ b/lib/screens/dashboard.dart
@@ -130,6 +130,9 @@ class Dashboard extends ConsumerWidget {
                           label: kLabelSettings,
                           showLabel: false,
                           isCompact: true,
+                          showBadge: ref.watch(
+                            updateProvider.select((s) => s.showBadge),
+                          ),
                         ),
                       ),
                     ],

--- a/lib/screens/mobile/navbar.dart
+++ b/lib/screens/mobile/navbar.dart
@@ -73,6 +73,9 @@ class BottomNavBar extends ConsumerWidget {
                     selectedIcon: Icons.settings,
                     icon: Icons.settings_outlined,
                     label: 'Settings',
+                    showBadge: ref.watch(
+                      updateProvider.select((s) => s.showBadge),
+                    ),
                   ),
                 ),
               ],

--- a/lib/screens/settings_page.dart
+++ b/lib/screens/settings_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:apidash_design_system/apidash_design_system.dart';
+import 'package:url_launcher/url_launcher.dart';
 import '../providers/providers.dart';
 import '../services/services.dart';
 import '../utils/utils.dart';
@@ -16,6 +17,7 @@ class SettingsPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final settings = ref.watch(settingsProvider);
+    final update = ref.watch(updateProvider);
     final clearingData = ref.watch(clearDataStateProvider);
     var sm = ScaffoldMessenger.of(context);
     return Column(
@@ -258,6 +260,35 @@ class SettingsPage extends ConsumerWidget {
                   ),
                 ),
               ),
+              if (update.isUpdateAvailable && update.info != null)
+                ListTile(
+                  hoverColor: kColorTransparent,
+                  title: const Text(kLabelUpdateAvailable),
+                  subtitle: Text(
+                    'Version ${update.info!.latestVersion} is available',
+                  ),
+                  trailing: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      TextButton(
+                        onPressed: () {
+                          ref
+                              .read(updateProvider.notifier)
+                              .skipCurrentVersion();
+                        },
+                        child: const Text(kLabelSkipUpdate),
+                      ),
+                      kHSpacer8,
+                      FilledButton.icon(
+                        onPressed: () {
+                          launchUrl(Uri.parse(update.info!.releaseUrl));
+                        },
+                        label: const Text(kLabelDownload),
+                        icon: const Icon(Icons.download_rounded, size: 20),
+                      ),
+                    ],
+                  ),
+                ),
               ListTile(
                 title: const Text(kLabelAbout),
                 subtitle: const Text(kLabelAboutSubtitle),

--- a/lib/services/services.dart
+++ b/lib/services/services.dart
@@ -2,3 +2,4 @@ export 'hive_services.dart';
 export 'history_service.dart';
 export 'window_services.dart';
 export 'shared_preferences_services.dart';
+export 'update_service.dart';

--- a/lib/services/shared_preferences_services.dart
+++ b/lib/services/shared_preferences_services.dart
@@ -4,6 +4,7 @@ import '../models/models.dart';
 
 const String kSharedPrefSettingsKey = 'apidash-settings';
 const String kSharedPrefOnboardingKey = 'apidash-onboarding-status';
+const String kSharedPrefSkippedUpdateKey = 'apidash-skipped-update-version';
 
 Future<SettingsModel?> getSettingsFromSharedPrefs() async {
   final prefs = await SharedPreferences.getInstance();
@@ -33,6 +34,16 @@ Future<bool> getOnboardingStatusFromSharedPrefs() async {
   final prefs = await SharedPreferences.getInstance();
   final onboardingStatus = prefs.getBool(kSharedPrefOnboardingKey) ?? false;
   return onboardingStatus;
+}
+
+Future<void> setSkippedUpdateVersionToSharedPrefs(String version) async {
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.setString(kSharedPrefSkippedUpdateKey, version);
+}
+
+Future<String?> getSkippedUpdateVersionFromSharedPrefs() async {
+  final prefs = await SharedPreferences.getInstance();
+  return prefs.getString(kSharedPrefSkippedUpdateKey);
 }
 
 Future<void> clearSharedPrefs() async {

--- a/lib/services/update_service.dart
+++ b/lib/services/update_service.dart
@@ -1,0 +1,64 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:pub_semver/pub_semver.dart';
+
+const String kLatestReleaseApiUrl =
+    'https://api.github.com/repos/foss42/apidash/releases/latest';
+const String kReleasesUrl = 'https://github.com/foss42/apidash/releases';
+
+class AppUpdateInfo {
+  const AppUpdateInfo({
+    required this.isUpdateAvailable,
+    required this.latestVersion,
+    required this.releaseUrl,
+  });
+
+  final bool isUpdateAvailable;
+  final String latestVersion;
+  final String releaseUrl;
+}
+
+String normalizeVersion(String version) {
+  final trimmed = version.trim();
+  return trimmed.startsWith('v') ? trimmed.substring(1) : trimmed;
+}
+
+/// Returns `true` when [latest] is a strictly newer semantic version than
+/// [current]. A leading `v` (e.g. `v0.5.0`) is tolerated. Returns `false`
+/// for any unparseable input so the caller never surfaces a false positive.
+bool isUpdateAvailable(String current, String latest) {
+  try {
+    return Version.parse(normalizeVersion(latest)) >
+        Version.parse(normalizeVersion(current));
+  } catch (_) {
+    return false;
+  }
+}
+
+/// Fetches the latest GitHub release and compares it with [currentVersion].
+/// Returns `null` on any network or parsing error so the check can fail
+/// silently without disturbing the user.
+Future<AppUpdateInfo?> checkForUpdate(
+  String currentVersion, {
+  http.Client? client,
+}) async {
+  final httpClient = client ?? http.Client();
+  try {
+    final response = await httpClient
+        .get(Uri.parse(kLatestReleaseApiUrl))
+        .timeout(const Duration(seconds: 10));
+    if (response.statusCode != 200) return null;
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    final tag = data['tag_name'] as String?;
+    if (tag == null) return null;
+    return AppUpdateInfo(
+      isUpdateAvailable: isUpdateAvailable(currentVersion, tag),
+      latestVersion: normalizeVersion(tag),
+      releaseUrl: (data['html_url'] as String?) ?? kReleasesUrl,
+    );
+  } catch (_) {
+    return null;
+  } finally {
+    if (client == null) httpClient.close();
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -843,7 +843,7 @@ packages:
     source: hosted
     version: "2.0.0"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   highlighter: ^0.1.1
   hive_ce_flutter: ^2.3.4
   hooks_riverpod: ^3.2.1
+  http: ^1.6.0
   intl: ^0.20.2
   jinja: ^0.6.5
   json_annotation: ^4.11.0

--- a/test/services/update_service_test.dart
+++ b/test/services/update_service_test.dart
@@ -1,0 +1,37 @@
+import 'package:apidash/services/update_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('normalizeVersion', () {
+    test('strips a leading v', () {
+      expect(normalizeVersion('v0.5.0'), '0.5.0');
+    });
+    test('trims surrounding whitespace', () {
+      expect(normalizeVersion('  1.2.3 '), '1.2.3');
+    });
+    test('leaves a plain version untouched', () {
+      expect(normalizeVersion('1.2.3'), '1.2.3');
+    });
+  });
+
+  group('isUpdateAvailable', () {
+    test('true when latest is newer', () {
+      expect(isUpdateAvailable('0.5.0', '0.5.1'), isTrue);
+      expect(isUpdateAvailable('0.5.0', '1.0.0'), isTrue);
+    });
+    test('false when versions are equal', () {
+      expect(isUpdateAvailable('0.5.0', '0.5.0'), isFalse);
+    });
+    test('false when latest is older', () {
+      expect(isUpdateAvailable('0.6.0', '0.5.9'), isFalse);
+    });
+    test('tolerates a leading v on either side', () {
+      expect(isUpdateAvailable('v0.5.0', 'v0.5.1'), isTrue);
+      expect(isUpdateAvailable('0.5.0', 'v0.5.0'), isFalse);
+    });
+    test('false for unparseable input', () {
+      expect(isUpdateAvailable('not-a-version', '0.5.1'), isFalse);
+      expect(isUpdateAvailable('0.5.0', 'garbage'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## PR Description

Adds an in-app update check that runs once on launch.

- On startup, queries the GitHub *latest release* API and compares the tag against the running app version (semver, tolerates a leading `v`).
- When a newer version exists, a badge appears on the Settings nav icon and a tile in Settings shows the new version with **Download** (opens the release page) and **Skip this version** actions.
- Skipped versions are persisted, so the badge stays hidden until an even newer release ships.
- The check fails silently on any network/parse error and is disabled during tests, so it never disturbs the user or test runs.

Implementation:
- `services/update_service.dart` — release fetch + version comparison (pure, injectable `http.Client`).
- `providers/update_providers.dart` — `UpdateNotifier` runs the background check and tracks skip state.
- Settings tile + nav badge wiring; skip persisted via shared preferences.

## Related Issues

- Closes #373

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_

## OS on which you have developed and tested the feature?

- [ ] Windows
- [ ] macOS
- [x] Linux
