### PR TITLE
fix: select previous item correctly when deleting from 2-item collection

### DIFF
--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -128,7 +128,7 @@ class CollectionStateNotifier
     String? newId;
     if (idx == 0 && itemIds.isNotEmpty) {
       newId = itemIds[0];
-    } else if (itemIds.length > 1) {
+    } else if (idx > 0) {
       newId = itemIds[idx - 1];
     } else {
       newId = null;


### PR DESCRIPTION
## PR Description

When exactly 2 requests exist and the non-first one is deleted, 
`itemIds.length > 1` evaluates to false (1 item remains), so `newId` 
falls through to null  leaving the main panel blank even though one 
request still exists.

Fix: Replace `itemIds.length > 1` with `idx > 0`, mirroring the 
existing `removeEnvironment` logic.

## Related Issues

- Closes #1710

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [x] No, This is a one-line logic fix with no new functionality. Existing tests cover this path.
## OS on which you have developed and tested the feature?

- [ ] Windows
- [x] macOS
- [ ] Linux
