### PR TITLE
fix: preserve disabled environment variables after JS script execution

### DIFF
--- a/lib/providers/js_runtime_notifier.dart
+++ b/lib/providers/js_runtime_notifier.dart
@@ -309,6 +309,8 @@ class JsRuntimeNotifier extends StateNotifier<JsRuntimeState> {
             ),
           );
           mutableUpdatedEnv.remove(originalVariable.key);
+        } else if (!originalVariable.enabled) {
+          newValues.add(originalVariable);
         }
       }
       for (final entry in mutableUpdatedEnv.entries) {
@@ -371,6 +373,8 @@ class JsRuntimeNotifier extends StateNotifier<JsRuntimeState> {
             ),
           );
           mutableUpdatedEnv.remove(originalVariable.key);
+        } else if (!originalVariable.enabled) {
+          newValues.add(originalVariable);
         }
       }
       for (final entry in mutableUpdatedEnv.entries) {

--- a/test/providers/js_runtime_notifier_test.dart
+++ b/test/providers/js_runtime_notifier_test.dart
@@ -493,8 +493,8 @@ void main() {
         expect(capturedValues, isNotNull);
         expect(
           capturedValues!.length,
-          greaterThanOrEqualTo(2),
-        ); // At least the enabled variables
+          equals(3),
+        ); // All 3 variables preserved
 
         final apiUrlVar = capturedValues!.firstWhere((v) => v.key == 'apiUrl');
         expect(apiUrlVar.value, equals('https://api.apidash.dev'));
@@ -503,6 +503,10 @@ void main() {
         final apiKeyVar = capturedValues!.firstWhere((v) => v.key == 'apiKey');
         expect(apiKeyVar.value, equals('test-api-key'));
         expect(apiKeyVar.enabled, isTrue);
+
+        final disabledVar = capturedValues!.firstWhere((v) => v.key == 'disabledVar');
+        expect(disabledVar.value, equals('disabled-value'));
+        expect(disabledVar.enabled, isFalse);
       },
     );
 
@@ -646,6 +650,12 @@ void main() {
             value: 'old-jwt-token',
             enabled: true,
             type: EnvironmentVariableType.secret,
+          ),
+          EnvironmentVariableModel(
+            key: 'disabledVar',
+            value: 'disabled-value',
+            enabled: false,
+            type: EnvironmentVariableType.variable,
           ),
         ],
       );
@@ -819,11 +829,15 @@ void main() {
 
       // Assert
       expect(capturedValues, isNotNull);
-      expect(capturedValues!.length, greaterThanOrEqualTo(2));
+      expect(capturedValues!.length, equals(3)); // All 3 variables preserved
 
       final baseUrlVar = capturedValues!.firstWhere((v) => v.key == 'baseUrl');
       expect(baseUrlVar.value, equals('https://api.apidash.dev'));
       expect(baseUrlVar.enabled, isTrue);
+
+      final disabledVar = capturedValues!.firstWhere((v) => v.key == 'disabledVar');
+      expect(disabledVar.value, equals('disabled-value'));
+      expect(disabledVar.enabled, isFalse);
     });
 
     test(


### PR DESCRIPTION
## Fixes : #1718 

## PR Description

This PR fixes a bug where disabled environment variables in the active environment were silently deleted after the execution of Pre-Request or Post-Response JavaScript scripts. 

### Rationale & Solution:
- In `js_utils.dart`, the JS setup script is designed to only inject enabled variables into the JS context (`variable.enabled === true`).
- Consequently, disabled variables are never present in the environment map returned by the JS runtime.
- Previously, the merging logic in `JsRuntimeNotifier` (`handlePreRequestScript` and `handlePostResponseScript`) only checked if the returned JS map contained the variable's key, causing all disabled variables to be silently dropped (since they were not returned by JS).
- The solution introduces an `else if (!originalVariable.enabled)` branch in the merging loops to ensure disabled variables are preserved unchanged.

## Related Issues

- Closes # 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux