### PR TITLE
Fix getEnabledRows incorrectly filtering duplicate rows (Fixes #1724)

### DIFF
--- a/packages/better_networking/lib/utils/http_request_utils.dart
+++ b/packages/better_networking/lib/utils/http_request_utils.dart
@@ -81,9 +81,12 @@ List<NameValueModel>? getEnabledRows(
     return rows;
   }
   List<NameValueModel> finalRows = rows
-      .where((element) => isRowEnabledList[rows.indexOf(element)])
+      .asMap()
+      .entries
+      .where((entry) => isRowEnabledList[entry.key])
+      .map((entry) => entry.value)
       .toList();
-  return finalRows == [] ? null : finalRows;
+  return finalRows;
 }
 
 String? getRequestBody(APIType type, HttpRequestModel httpRequestModel) {

--- a/packages/better_networking/test/utils/http_request_utils_test.dart
+++ b/packages/better_networking/test/utils/http_request_utils_test.dart
@@ -197,6 +197,19 @@ void main() {
         [kvRow1, kvRow3],
       );
     });
+    test('Testing with duplicate rows (same name+value) at different positions',
+        () {
+      // kvRow1 appears at index 0 (disabled) and index 2 (enabled).
+      // The old indexOf()-based implementation would look up the first
+      // occurrence for both, effectively disabling index 2 as well.
+      expect(
+        getEnabledRows(
+          [kvRow1, kvRow2, kvRow1, kvRow4],
+          [false, true, true, false],
+        ),
+        [kvRow2, kvRow1], // kvRow1 at index 2 must be included
+      );
+    });
   });
 
   group('Testing getRequestBody', () {


### PR DESCRIPTION
# Fix `getEnabledRows` incorrectly filtering duplicate rows 

## Summary

This PR fixes an issue where `getEnabledRows` incorrectly filtered duplicate headers/parameters when identical rows existed in the request.

Fixes #1441

## Root Cause

The previous implementation determined whether a row was enabled using:

```dart
rows.indexOf(element)
```

Since `indexOf` always returns the index of the **first matching element**, duplicate rows with the same name and value were mapped to the wrong entry in `isRowEnabledList`.

This resulted in incorrect behavior such as:

* A later duplicate marked as enabled being excluded because the first duplicate was disabled.
* A later duplicate marked as disabled being included because the first duplicate was enabled.

Additionally, the function contained a dead code path:

```dart
finalRows == [] ? null : finalRows;
```

Since Dart lists use reference equality for `==`, this condition could never evaluate to `true`.

## Solution

* Replaced the `indexOf` lookup with index-based iteration using `asMap().entries`, ensuring each row is evaluated against its actual position in the list.
* Removed the unused reference equality check for empty lists.

This preserves the existing behavior while correctly handling duplicate rows.

## Tests

Added a unit test in:

```
packages/better_networking/test/utils/http_request_utils_test.dart
```

The new test verifies that duplicate rows with identical content but different enabled/disabled states are filtered according to their respective indices.

## Impact

* ✅ Fixes incorrect filtering of duplicate headers/parameters.
* ✅ Preserves existing behavior for non-duplicate rows.
* ✅ Removes unreachable code.
* ✅ Adds regression test coverage to prevent future regressions.

---

**Reviewer:** @animator
