### PR TITLE
fix: cap terminal history entries

### DIFF
--- a/lib/providers/terminal_providers.dart
+++ b/lib/providers/terminal_providers.dart
@@ -24,6 +24,7 @@ class TerminalController extends StateNotifier<TerminalState> {
   TerminalController() : super(TerminalState(entries: <TerminalEntry>[]));
 
   static const _uuid = Uuid();
+  static const int _maxEntries = 1000;
 
   String _newId() => _uuid.v4();
 
@@ -33,6 +34,9 @@ class TerminalController extends StateNotifier<TerminalState> {
 
   String append(TerminalEntry entry) {
     final list = [entry, ...state.entries];
+    if (list.length > _maxEntries) {
+      list.removeRange(_maxEntries, list.length);
+    }
     state = TerminalState(entries: list);
     return entry.id;
   }

--- a/test/providers/terminal_providers_test.dart
+++ b/test/providers/terminal_providers_test.dart
@@ -166,6 +166,26 @@ void main() {
       expect(idxMap[entries.first.id], 0);
     });
 
+    test('append trims terminal history to the latest 1000 entries', () {
+      for (var i = 0; i < 1005; i++) {
+        controller.append(
+          TerminalEntry(
+            id: 'entry-$i',
+            source: TerminalSource.system,
+            level: TerminalLevel.info,
+            system: SystemLogData(category: 'cat', message: 'msg-$i'),
+          ),
+        );
+      }
+
+      final state = container.read(terminalStateProvider);
+      expect(state.entries.length, 1000);
+      expect(state.entries.first.id, 'entry-1004');
+      expect(state.entries.last.id, 'entry-5');
+      expect(state.index['entry-1004'], 0);
+      expect(state.index['entry-5'], 999);
+    });
+
     test('serializeAll with provided entries includes ISO timestamps', () {
       final e1 = TerminalEntry(
         id: 'x1',


### PR DESCRIPTION
Closes #1648\n\nThis caps terminal history at 1000 entries so long-running sessions do not accumulate unbounded state. The controller now trims older entries on append while preserving newest-first ordering.\n\nValidation:\n- git diff --check\n- Source-level review of the terminal provider and regression test\n\nNote: Flutter/Dart SDK binaries were not available in this session, so I could not run flutter test locally.