### PR TITLE
fix: handle anthropic SSE event chunks

### DIFF
--- a/packages/genai/lib/interface/model_providers/anthropic.dart
+++ b/packages/genai/lib/interface/model_providers/anthropic.dart
@@ -53,6 +53,6 @@ class AnthropicModel extends ModelProvider {
 
   @override
   String? streamOutputFormatter(Map x) {
-    return x['text'];
+    return x['delta']?['text'] ?? x['text'];
   }
 }

--- a/packages/genai/lib/utils/ai_request_utils.dart
+++ b/packages/genai/lib/utils/ai_request_utils.dart
@@ -59,8 +59,22 @@ Future<Stream<String?>> streamGenAIRequest(
         final ans = chunk.body;
 
         final lines = ans.split('\n');
+        String? currentEvent;
         for (final line in lines) {
+          if (line.startsWith('event:')) {
+            currentEvent = line.substring(6).trim();
+            continue;
+          }
+
           if (!line.startsWith('data: ') || line.contains('[DONE]')) continue;
+
+          if (aiRequestModel?.modelApiProvider == ModelAPIProvider.anthropic &&
+              currentEvent != null &&
+              currentEvent != 'content_block_delta') {
+            currentEvent = null;
+            continue;
+          }
+
           final jsonStr = line.substring(6).trim();
           try {
             final jsonData = jsonDecode(jsonStr);
@@ -74,6 +88,7 @@ Future<Stream<String?>> streamGenAIRequest(
             );
             streamController.sink.add(jsonStr);
           }
+          currentEvent = null;
         }
       },
       onError: (error) {

--- a/packages/genai/test/interface/model_providers/anthropic_test.dart
+++ b/packages/genai/test/interface/model_providers/anthropic_test.dart
@@ -46,6 +46,15 @@ void main() {
       );
     });
 
+    test('streamOutputFormatter handles anthropic delta text', () {
+      expect(
+        AnthropicModel.instance.streamOutputFormatter({
+          'delta': {'text': 'hello'},
+        }),
+        'hello',
+      );
+    });
+
     test('defaultAIRequestModel', () {
       expect(
         AnthropicModel.instance.defaultAIRequestModel.modelApiProvider,


### PR DESCRIPTION
Closes #1592\n\nThis makes the GenAI streaming path aware of SSE event lines so Anthropic chunks only emit text for  events. Anthropic stream formatting now reads the nested  payload, which matches the provider response shape.\n\nValidation:\n- git diff --check\n- Source-level review of the stream parser and Anthropic formatter\n\nNote: Flutter/Dart SDK binaries were not available in this session, so I could not run package tests locally.