### PR TITLE
Fix json explorer hover jitter on large trees

### DIFF
--- a/packages/json_explorer/lib/src/json_explorer.dart
+++ b/packages/json_explorer/lib/src/json_explorer.dart
@@ -281,11 +281,11 @@ class JsonAttribute extends StatelessWidget {
     return MouseRegion(
       cursor: hasInteraction ? SystemMouseCursors.click : MouseCursor.defer,
       onEnter: (event) {
-        node.highlight();
+        node.highlight(cascade: false);
         node.focus();
       },
       onExit: (event) {
-        node.highlight(isHighlighted: false);
+        node.highlight(isHighlighted: false, cascade: false);
         node.focus(isFocused: false);
       },
       child: GestureDetector(

--- a/packages/json_explorer/lib/src/json_explorer_store.dart
+++ b/packages/json_explorer/lib/src/json_explorer_store.dart
@@ -184,13 +184,15 @@ class NodeViewModelState extends ChangeNotifier {
     return [];
   }
 
-  /// Sets the highlight property of this node and all of its children.
+  /// Sets the highlight property of this node.
   ///
   /// [notifyListeners] is called to notify all registered listeners.
-  void highlight({bool isHighlighted = true}) {
+  void highlight({bool isHighlighted = true, bool cascade = true}) {
     _isHighlighted = isHighlighted;
-    for (final children in children) {
-      children.highlight(isHighlighted: isHighlighted);
+    if (cascade) {
+      for (final children in children) {
+        children.highlight(isHighlighted: isHighlighted, cascade: true);
+      }
     }
     notifyListeners();
   }

--- a/packages/json_explorer/test/unit/node_view_model_state_test.dart
+++ b/packages/json_explorer/test/unit/node_view_model_state_test.dart
@@ -204,6 +204,45 @@ void main() {
           isFalse,
         );
       });
+
+      test('highlight can avoid cascading to children', () {
+        final viewModel = NodeViewModelState.fromClass(
+          treeDepth: 0,
+          key: 'classKey',
+          parent: null,
+        );
+
+        final child = NodeViewModelState.fromClass(
+          treeDepth: 1,
+          key: 'childClass',
+          parent: viewModel,
+        );
+
+        final classMap = {
+          'childClass': child,
+        };
+
+        child.value = {
+          'leaf': NodeViewModelState.fromProperty(
+            treeDepth: 2,
+            key: 'leaf',
+            value: 123,
+            parent: child,
+          ),
+        };
+
+        viewModel.value = classMap;
+        viewModel.highlight(cascade: false);
+
+        expect(viewModel.isHighlighted, isTrue);
+        expect(child.isHighlighted, isFalse);
+        expect(child.value['leaf']!.isHighlighted, isFalse);
+
+        viewModel.highlight(isHighlighted: false, cascade: false);
+        expect(viewModel.isHighlighted, isFalse);
+        expect(child.isHighlighted, isFalse);
+        expect(child.value['leaf']!.isHighlighted, isFalse);
+      });
     });
 
     group('Array', () {


### PR DESCRIPTION
Closes #1350\n\nThis narrows hover highlight/focus handling so mouse enter/leave no longer cascades through the entire JSON tree. That keeps the hover state local and reduces the scroll churn that shows up as jitter in Preview mode.\n\nValidation:\n- git diff --check\n- code review of touched json_explorer path\n\nNote: Flutter/Dart tooling was not available in this environment, so I could not run the package test suite locally.