### PR TITLE
Fix parseFormData dropping form-data values containing '='

### DIFF
--- a/packages/apidash_core/lib/import_export/har_io.dart
+++ b/packages/apidash_core/lib/import_export/har_io.dart
@@ -116,12 +116,12 @@ class HarParserIO {
 
     // Loop through the pairs and split them into keys and values
     for (var pair in pairs) {
-      var keyValue = pair.split('=');
+      var separatorIndex = pair.indexOf('=');
 
       // Ensure the pair contains both key and value
-      if (keyValue.length == 2) {
-        var key = Uri.decodeComponent(keyValue[0]);
-        var value = Uri.decodeComponent(keyValue[1]);
+      if (separatorIndex != -1) {
+        var key = Uri.decodeComponent(pair.substring(0, separatorIndex));
+        var value = Uri.decodeComponent(pair.substring(separatorIndex + 1));
 
         result[key] = value;
       }

--- a/packages/apidash_core/test/import_export/har_io_test.dart
+++ b/packages/apidash_core/test/import_export/har_io_test.dart
@@ -1,0 +1,53 @@
+import 'package:test/test.dart';
+import 'package:apidash_core/apidash_core.dart';
+
+void main() {
+  group('HarParserIO parseFormData', () {
+    late HarParserIO harParser;
+
+    setUp(() {
+      harParser = HarParserIO();
+    });
+
+    test('parses a simple key-value pair', () {
+      expect(harParser.parseFormData('name=apidash'), {'name': 'apidash'});
+    });
+
+    test('keeps values containing a trailing = (base64)', () {
+      expect(
+        harParser.parseFormData('token=YWJjZA=='),
+        {'token': 'YWJjZA=='},
+      );
+    });
+
+    test('keeps values containing = in the middle', () {
+      expect(
+        harParser.parseFormData('filter=a=b'),
+        {'filter': 'a=b'},
+      );
+    });
+
+    test('preserves all pairs when a value contains =', () {
+      expect(
+        harParser.parseFormData('user=deepak&token=abc==&role=admin'),
+        {'user': 'deepak', 'token': 'abc==', 'role': 'admin'},
+      );
+    });
+
+    test('decodes percent-encoded keys and values', () {
+      expect(
+        harParser.parseFormData('full%20name=John%20Doe'),
+        {'full name': 'John Doe'},
+      );
+    });
+
+    test('handles an empty value', () {
+      expect(harParser.parseFormData('key='), {'key': ''});
+    });
+
+    test('returns an empty map for null or empty input', () {
+      expect(harParser.parseFormData(null), {});
+      expect(harParser.parseFormData(''), {});
+    });
+  });
+}


### PR DESCRIPTION
## PR Description

`parseFormData` in `har_io.dart` split each `key=value` pair with `pair.split('=')` and only kept it when the result had exactly two elements. Any form-data value containing a literal `=` (base64 tokens ending in `=`/`==`, OAuth tokens, checksums, `a=b` style values) produced a list with more than two elements, so the whole pair was silently dropped when importing `application/x-www-form-urlencoded` HAR bodies.

This splits on the first `=` only using `indexOf`/`substring`, so the key is everything before it and the value keeps any remaining `=` characters intact. Behavior for normal pairs, empty values, and null/empty input is unchanged.

Verified with `dart analyze` (no issues) and the added unit tests covering trailing `=`, mid-value `=`, multiple pairs where one value contains `=`, percent-decoding, empty value, and null/empty input.

## Related Issues

- Closes #1735

## Video Demo

- Not applicable; this is a data-parsing fix. The added unit tests cover the before/after behavior (values with `=` were dropped before, preserved now).

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [ ] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [ ] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [x] Yes

## OS on which you have developed and tested the feature?

- [ ] Windows
- [ ] macOS
- [x] Linux
