### PR TITLE
Clear expired history via isolate

### DIFF
--- a/lib/services/history_service.dart
+++ b/lib/services/history_service.dart
@@ -1,3 +1,5 @@
+import 'dart:isolate';
+
 import 'package:apidash/models/models.dart';
 import 'package:apidash/utils/utils.dart';
 import 'hive_services.dart';
@@ -8,35 +10,41 @@ Future<void> autoClearHistory({SettingsModel? settingsModel}) async {
 
   if (retentionDate == null) {
     return;
-  } else {
-    List<String>? historyIds = hiveHandler.getHistoryIds();
-    List<String> toRemoveIds = [];
-
-    if (historyIds == null || historyIds.isEmpty) {
-      return;
-    }
-
-    for (var historyId in historyIds) {
-      var jsonModel = hiveHandler.getHistoryMeta(historyId);
-      if (jsonModel != null) {
-        var jsonMap = Map<String, Object?>.from(jsonModel);
-        HistoryMetaModel historyMetaModelFromJson =
-            HistoryMetaModel.fromJson(jsonMap);
-        if (historyMetaModelFromJson.timeStamp.isBefore(retentionDate)) {
-          toRemoveIds.add(historyId);
-        }
-      }
-    }
-
-    if (toRemoveIds.isEmpty) {
-      return;
-    }
-
-    for (var id in toRemoveIds) {
-      await hiveHandler.deleteHistoryRequest(id);
-      hiveHandler.deleteHistoryMeta(id);
-    }
-    hiveHandler.setHistoryIds(
-        historyIds..removeWhere((id) => toRemoveIds.contains(id)));
   }
+
+  List<String>? historyIds = hiveHandler.getHistoryIds();
+  if (historyIds == null || historyIds.isEmpty) {
+    return;
+  }
+
+  // Collect serializable meta maps on the main isolate (Hive is not isolate-safe).
+  final metas = <String, Map<String, Object?>>{};
+  for (final historyId in historyIds) {
+    final jsonModel = hiveHandler.getHistoryMeta(historyId);
+    if (jsonModel != null) {
+      metas[historyId] = Map<String, Object?>.from(jsonModel);
+    }
+  }
+
+  if (metas.isEmpty) {
+    return;
+  }
+
+  // Heavy filtering of expired entries off the UI/main thread.
+  final toRemoveIds = await Isolate.run(
+    () => findExpiredHistoryIds(metas, retentionDate),
+  );
+
+  if (toRemoveIds.isEmpty) {
+    return;
+  }
+
+  for (final id in toRemoveIds) {
+    await hiveHandler.deleteHistoryRequest(id);
+    await hiveHandler.deleteHistoryMeta(id);
+  }
+
+  await hiveHandler.setHistoryIds(
+    historyIds..removeWhere((id) => toRemoveIds.contains(id)),
+  );
 }

--- a/lib/utils/history_utils.dart
+++ b/lib/utils/history_utils.dart
@@ -131,3 +131,31 @@ DateTime? getRetentionDate(HistoryRetentionPeriod? retentionPeriod) {
       return null;
   }
 }
+
+/// Returns history IDs whose meta `timeStamp` is strictly before [retentionDate].
+///
+/// Pure/sync helper so it can run inside an isolate without touching Hive.
+/// [metas] maps historyId -> raw Hive JSON map for [HistoryMetaModel].
+List<String> findExpiredHistoryIds(
+  Map<String, Map<String, Object?>> metas,
+  DateTime retentionDate,
+) {
+  final toRemoveIds = <String>[];
+
+  for (final entry in metas.entries) {
+    final timeStampRaw = entry.value['timeStamp'];
+    DateTime? timeStamp;
+
+    if (timeStampRaw is DateTime) {
+      timeStamp = timeStampRaw;
+    } else if (timeStampRaw is String) {
+      timeStamp = DateTime.tryParse(timeStampRaw);
+    }
+
+    if (timeStamp != null && timeStamp.isBefore(retentionDate)) {
+      toRemoveIds.add(entry.key);
+    }
+  }
+
+  return toRemoveIds;
+}

--- a/test/utils/history_utils_test.dart
+++ b/test/utils/history_utils_test.dart
@@ -278,4 +278,61 @@ void main() {
       expect(result, null);
     });
   });
+
+  group('Testing findExpiredHistoryIds function', () {
+    final retentionDate = DateTime(2026, 1, 1);
+
+    test('returns ids with timeStamp before retention date', () {
+      final metas = {
+        'old': <String, Object?>{
+          'timeStamp': DateTime(2025, 12, 1).toIso8601String(),
+        },
+        'keep': <String, Object?>{
+          'timeStamp': DateTime(2026, 2, 1).toIso8601String(),
+        },
+        'boundary': <String, Object?>{
+          'timeStamp': retentionDate.toIso8601String(),
+        },
+      };
+
+      final result = findExpiredHistoryIds(metas, retentionDate);
+
+      expect(result, ['old']);
+    });
+
+    test('accepts DateTime values stored directly in maps', () {
+      final metas = {
+        'old': <String, Object?>{'timeStamp': DateTime(2025, 6, 1)},
+        'keep': <String, Object?>{'timeStamp': DateTime(2026, 6, 1)},
+      };
+
+      final result = findExpiredHistoryIds(metas, retentionDate);
+
+      expect(result, ['old']);
+    });
+
+    test('skips entries with missing or invalid timestamps', () {
+      final metas = {
+        'missing': <String, Object?>{'name': 'x'},
+        'invalid': <String, Object?>{'timeStamp': 'not-a-date'},
+        'old': <String, Object?>{
+          'timeStamp': DateTime(2024, 1, 1).toIso8601String(),
+        },
+      };
+
+      final result = findExpiredHistoryIds(metas, retentionDate);
+
+      expect(result, ['old']);
+    });
+
+    test('returns empty list when nothing expired', () {
+      final metas = {
+        'a': <String, Object?>{
+          'timeStamp': DateTime(2026, 3, 1).toIso8601String(),
+        },
+      };
+
+      expect(findExpiredHistoryIds(metas, retentionDate), isEmpty);
+    });
+  });
 }


### PR DESCRIPTION
## PR Description

Currently `autoClearHistory` walks every history meta entry and decides what to delete on the main isolate. With a large history that filter work can sit on the UI thread.

This PR keeps Hive reads/writes on the main isolate (Hive is not isolate-safe) and moves the expired-ID scan into `Isolate.run` via a pure helper `findExpiredHistoryIds`. Deletion + `setHistoryIds` still happen on the main isolate after the worker returns.

Also awaits `deleteHistoryMeta` / `setHistoryIds`, which were previously fire-and-forget Futures.

## Related Issues

- Closes #551

## Video Demo

- N/A — no UI surface change. This is a background retention-path optimization. Behavior is covered by unit tests on `findExpiredHistoryIds` (expired / DateTime / invalid / empty cases).

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_

## OS on which you have developed and tested the feature?

- [x] Windows
- [ ] macOS
- [ ] Linux