### PR TITLE
fix: prevent AI JSON parse from leaving request stuck in isWorking

### DIFF
--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -506,10 +506,17 @@ class CollectionStateNotifier
       if (!streamingMode &&
           apiType == APIType.ai &&
           response.statusCode == 200) {
-        final fb = executionRequestModel.aiRequestModel?.getFormattedOutput(
-          kJsonDecoder.convert(httpResponseModel?.body ?? "Error parsing body"),
-        );
-        httpResponseModel = httpResponseModel?.copyWith(formattedBody: fb);
+        final body = httpResponseModel?.body;
+        if (body != null && body.isNotEmpty) {
+          try {
+            final fb = executionRequestModel.aiRequestModel?.getFormattedOutput(
+              kJsonDecoder.convert(body),
+            );
+            httpResponseModel = httpResponseModel?.copyWith(formattedBody: fb);
+          } catch (_) {
+            // Invalid JSON — keep raw response; do not block isWorking clear
+          }
+        }
       }
 
       newRequestModel = newRequestModel.copyWith(


### PR DESCRIPTION
## Summary
- Fixes non-streaming AI responses getting stuck with `isWorking: true` when response JSON decode fails (`#1741`).
- Only decode non-empty bodies, wrap `kJsonDecoder.convert` / formatting in try/catch, and keep the raw response on failure so `isWorking: false` still runs.

## Test plan
- [ ] Create a non-streaming AI request that returns HTTP 200 with invalid JSON (or empty body).
- [ ] Send the request and confirm the UI leaves the working/cancel state (Send is usable again).
- [ ] Confirm a valid JSON AI response still gets `formattedBody` as before.
- [ ] Confirm a normal HTTP (non-AI) request path is unchanged.

## Notes
- Small, focused bugfix only — no dependency bumps or refactors.
- AI-assisted for investigation/drafting; change reviewed and understood before submit.
- No new automated test yet (provider `sendRequest` path is heavy to scaffold); happy to add one if maintainers want it.

Fixes #1741