### PR TITLE
fix: cap terminal entries at 1000 to prevent unbounded memory growth

### DIFF
--- a/lib/providers/terminal_providers.dart
+++ b/lib/providers/terminal_providers.dart
@@ -24,6 +24,7 @@ class TerminalController extends StateNotifier<TerminalState> {
   TerminalController() : super(TerminalState(entries: <TerminalEntry>[]));
 
   static const _uuid = Uuid();
+  static const int _maxEntries = 1000;
 
   String _newId() => _uuid.v4();
 
@@ -33,6 +34,9 @@ class TerminalController extends StateNotifier<TerminalState> {
 
   String append(TerminalEntry entry) {
     final list = [entry, ...state.entries];
+    if (list.length > _maxEntries) {
+      list.removeRange(_maxEntries, list.length);
+    }
     state = TerminalState(entries: list);
     return entry.id;
   }


### PR DESCRIPTION
# Description

The `TerminalController.append` method prepended new entries to the list but never removed old ones. During long sessions with streaming responses, this could accumulate thousands of entries, degrading performance and increasing memory pressure.

Added a `_maxEntries` limit of 1000, removing excess entries from the end of the list (oldest entries) when the limit is exceeded.

Fixes #1648

# Change type

/kind bug