### PR TITLE
fix: prevent text overflow in form data field name inputs

### DIFF
--- a/lib/screens/common_widgets/env_trigger_field.dart
+++ b/lib/screens/common_widgets/env_trigger_field.dart
@@ -140,8 +140,9 @@ class EnvironmentTriggerFieldState extends State<EnvironmentTriggerField> {
         ),
       ],
       fieldViewBuilder: (context, textEditingController, focusnode) {
-        return ExtendedTextField(
-          controller: textEditingController,
+          return ExtendedTextField(
+            maxLines: 1,
+            controller: textEditingController,
           focusNode: focusnode,
           decoration: widget.decoration,
           style: widget.style,


### PR DESCRIPTION
# Description

The `ExtendedTextField` in `EnvironmentTriggerField` did not set `maxLines`, allowing text to wrap to a second line. With a fixed 36px row height in the form data table, wrapped characters appeared clipped below the first line (e.g. "answer" displaying as "anwe" with "r" pushed down).

Added `maxLines: 1` to prevent wrapping and keep text on a single line.

Fixes #1283

# Change type

/kind bug