### PR TITLE
fix: prevent RangeError crash when collection is empty

### DIFF
--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -58,7 +58,9 @@ class CollectionStateNotifier
       }
       ref.read(selectedIdStateProvider.notifier).state = ref.read(
         requestSequenceProvider,
-      )[0];
+      ).isNotEmpty
+          ? ref.read(requestSequenceProvider)[0]
+          : null;
     });
   }
 


### PR DESCRIPTION
# Description

The `CollectionStateNotifier` constructor unconditionally accessed index `[0]` of `requestSequenceProvider`. When the collection is empty (e.g. first launch or after clearing all data), this caused a `RangeError` crash on startup with the message "Index out of range: index should be less than 1: 0".

Added an `isNotEmpty` check, falling back to `null` when no requests exist. When requests do exist, the first request is still auto-selected as before (no regression).

Fixes #1640

# Change type

/kind bug