### PR TITLE
Fix: optimize SSE stream rendering with throttle and rolling window

### DIFF
--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -892,7 +892,6 @@ class CollectionStateNotifier
           httpResponseModel = httpResponseModel?.copyWith(
             time: duration,
             sseOutput: [
-              ...(httpResponseModel?.sseOutput ?? []),
               if (response != null) response.body,
             ],
           );

--- a/packages/better_networking/lib/services/http_service.dart
+++ b/packages/better_networking/lib/services/http_service.dart
@@ -308,14 +308,24 @@ Future<Stream<HttpStreamOutput>> streamHttpRequest(
     final contentType =
         getMediaTypeFromHeaders(streamedResponse.headers)?.mimeType ?? '';
     final chunkList = <List<int>>[];
+    int lastUpdate = 0;
 
     subscription = streamedResponse.stream.listen(
       (bytes) async {
         if (controller.isClosed) return;
         final isStreaming = kStreamingResponseTypes.contains(contentType);
         if (isStreaming) {
-          final response = _createResponseFromBytes(bytes);
-          controller.add((true, response, stopwatch.elapsed, null));
+          chunkList.add(bytes);
+          if (chunkList.length > 30) {
+            chunkList.removeAt(0);
+          }
+          final currentMs = stopwatch.elapsedMilliseconds;
+          if (currentMs - lastUpdate > 100) {
+            lastUpdate = currentMs;
+            final allBytes = chunkList.expand((x) => x).toList();
+            final response = _createResponseFromBytes(allBytes);
+            controller.add((true, response, stopwatch.elapsed, null));
+          }
         } else {
           chunkList.add(bytes);
         }


### PR DESCRIPTION
### PR Description
This PR fixes significant memory, CPU lag, and storage leak issues when streaming high-throughput Server-Sent Events (SSE).

Previously, rapid SSE streams (like Wikipedia's recent changes stream) caused the application to freeze and the local Hive database to bloat infinitely. This occurred because the stream was pushing UI updates on every single chunk, and the `CollectionStateNotifier` was infinitely accumulating the fully concatenated response body into an array on every tick.

This change introduces three optimizations:
1. **Throttled Updates:** Limits UI redraws during streaming to a maximum of once every 100 milliseconds to prevent Flutter UI thread starvation.
2. **Rolling Window Limit:** Caps the accumulated chunk list in `better_networking` at 30 items to keep the raw text block readable without manual scrolling and to prevent RAM exhaustion.
3. **Double Accumulation Fix:** Updates `CollectionStateNotifier` to store the precisely accumulated body instead of appending the entire string into an ever-growing list array, which resolves the exponential Hive database disk writes.

### Related Issues
Fixes #873

### Checklist
- [x] I have gone through the contributing guide
- [x] I have updated my branch and synced it with project main branch before making this PR
- [x] I am using the latest Flutter stable branch
- [x] I have run the tests (`flutter test`) and all tests are passing

### Added/updated tests?
- [ ] Yes
- [x] No, and this is why: This change improves existing streaming response handling logic and performance, but does not introduce new isolated testable units.

### OS on which you have developed and tested the feature?
- [ ] Windows
- [ ] macOS
- [x] Linux


### Video
https://github.com/user-attachments/assets/c0d44713-1ad1-4b03-8348-56306c03ef07


