### PR TITLE
fix: default the ws/wss scheme when omitted from a WebSocket URL (#1747)

### DIFF
--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -501,10 +501,21 @@ class CollectionStateNotifier
     final substitutedUrl =
         substituteVariables(wsModel.url, combinedEnvVarMap) ?? wsModel.url;
 
-    String finalUrl = substitutedUrl;
+    // Apply the default scheme before parsing: a schemeless URL parses as a
+    // relative Uri (or throws, for bare IPs), which breaks both the query
+    // parameter handling below and WebSocket.connect itself.
+    final schemedUrl = applyWebSocketUriScheme(
+          substitutedUrl,
+          defaultUriScheme: webSocketSchemeFor(
+            ref.read(settingsProvider).defaultUriScheme,
+          ),
+        ) ??
+        substitutedUrl;
+
+    String finalUrl = schemedUrl;
     if (wsModel.params != null && wsModel.isParamEnabledList != null) {
       try {
-        final uri = Uri.parse(substitutedUrl);
+        final uri = Uri.parse(schemedUrl);
         final queryParams = Map<String, dynamic>.from(uri.queryParameters);
         for (int i = 0; i < wsModel.params!.length; i++) {
           if (wsModel.isParamEnabledList![i]) {

--- a/packages/better_networking/lib/consts.dart
+++ b/packages/better_networking/lib/consts.dart
@@ -88,6 +88,14 @@ final kSupportedUriSchemes = SupportedUriSchemes.values
     .map((i) => i.name)
     .toList();
 const kDefaultUriScheme = SupportedUriSchemes.https;
+
+enum SupportedWebSocketUriSchemes { wss, ws }
+
+final kSupportedWebSocketUriSchemes = SupportedWebSocketUriSchemes.values
+    .map((i) => i.name)
+    .toList();
+const kDefaultWebSocketUriScheme = SupportedWebSocketUriSchemes.wss;
+
 final kLocalhostRegex = RegExp(r'^localhost(:\d+)?(/.*)?$');
 final kIPHostRegex = RegExp(
   r'^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}(:\d+)?(/.*)?$',

--- a/packages/better_networking/lib/utils/uri_utils.dart
+++ b/packages/better_networking/lib/utils/uri_utils.dart
@@ -13,6 +13,54 @@ import 'http_request_utils.dart';
   return (null, false);
 }
 
+/// Maps the user's HTTP default-URI-scheme preference onto its WebSocket
+/// equivalent, so `https` implies `wss` and `http` implies `ws`.
+SupportedWebSocketUriSchemes webSocketSchemeFor(SupportedUriSchemes scheme) {
+  return switch (scheme) {
+    SupportedUriSchemes.https => SupportedWebSocketUriSchemes.wss,
+    SupportedUriSchemes.http => SupportedWebSocketUriSchemes.ws,
+  };
+}
+
+/// Applies [defaultUriScheme] to [url] when the scheme is omitted, mirroring
+/// how [getValidRequestUri] defaults HTTP URLs.
+///
+/// Localhost and bare-IP hosts default to `ws://` rather than `wss://`, for the
+/// same reason [getValidRequestUri] forces `http` for those hosts: local
+/// development servers rarely terminate TLS.
+///
+/// A URL that already carries a scheme is returned untouched, including an
+/// unsupported one, so that `WebSocket.connect` can surface its own
+/// "Unsupported URL scheme" error rather than this function guessing at intent.
+///
+/// Returns `null` when [url] is null/blank, matching the "URL is missing"
+/// case callers already handle.
+String? applyWebSocketUriScheme(
+  String? url, {
+  SupportedWebSocketUriSchemes defaultUriScheme = kDefaultWebSocketUriScheme,
+}) {
+  url = url?.trim();
+  if (url == null || url == "") {
+    return null;
+  }
+
+  // Checked before parsing: `Uri.parse("localhost:8765")` yields the scheme
+  // "localhost", and `Uri.parse("127.0.0.1:8765")` throws outright, so neither
+  // can be identified by inspecting the parsed Uri.
+  if (kLocalhostRegex.hasMatch(url) || kIPHostRegex.hasMatch(url)) {
+    return '${SupportedWebSocketUriSchemes.ws.name}://$url';
+  }
+
+  final uri = Uri.tryParse(url);
+  if (uri == null) {
+    return url;
+  }
+  if (uri.hasScheme) {
+    return url;
+  }
+  return '${defaultUriScheme.name}://$url';
+}
+
 String stripUriParams(Uri uri) {
   return "${uri.scheme}://${uri.authority}${uri.path}";
 }

--- a/packages/better_networking/test/utils/uri_utils_test.dart
+++ b/packages/better_networking/test/utils/uri_utils_test.dart
@@ -205,4 +205,105 @@ void main() {
       expect(stripUrlParams(url), "https://example.com/page");
     });
   });
+
+  group("Testing webSocketSchemeFor", () {
+    test('https maps to wss', () {
+      expect(
+        webSocketSchemeFor(SupportedUriSchemes.https),
+        SupportedWebSocketUriSchemes.wss,
+      );
+    });
+
+    test('http maps to ws', () {
+      expect(
+        webSocketSchemeFor(SupportedUriSchemes.http),
+        SupportedWebSocketUriSchemes.ws,
+      );
+    });
+  });
+
+  group("Testing applyWebSocketUriScheme", () {
+    test('applies the default scheme when omitted', () {
+      expect(
+        applyWebSocketUriScheme("echo.websocket.org"),
+        "wss://echo.websocket.org",
+      );
+    });
+
+    test('honours an explicit default scheme', () {
+      expect(
+        applyWebSocketUriScheme(
+          "echo.websocket.org",
+          defaultUriScheme: SupportedWebSocketUriSchemes.ws,
+        ),
+        "ws://echo.websocket.org",
+      );
+    });
+
+    test('leaves an existing ws scheme untouched', () {
+      expect(
+        applyWebSocketUriScheme("ws://echo.websocket.org"),
+        "ws://echo.websocket.org",
+      );
+    });
+
+    test('leaves an existing wss scheme untouched', () {
+      expect(
+        applyWebSocketUriScheme("wss://echo.websocket.org"),
+        "wss://echo.websocket.org",
+      );
+    });
+
+    test('leaves an unsupported scheme untouched for connect to report', () {
+      expect(
+        applyWebSocketUriScheme("http://echo.websocket.org"),
+        "http://echo.websocket.org",
+      );
+    });
+
+    test('defaults localhost to ws, not wss', () {
+      expect(applyWebSocketUriScheme("localhost"), "ws://localhost");
+    });
+
+    test('defaults localhost with a port to ws', () {
+      // Uri.parse("localhost:8765") reports the scheme "localhost", so this
+      // case cannot be detected after parsing.
+      expect(applyWebSocketUriScheme("localhost:8765"), "ws://localhost:8765");
+    });
+
+    test('defaults localhost with a port and path to ws', () {
+      expect(
+        applyWebSocketUriScheme("localhost:8765/socket"),
+        "ws://localhost:8765/socket",
+      );
+    });
+
+    test('defaults a bare IP host to ws', () {
+      // Uri.parse("127.0.0.1:8765") throws, so this case cannot be detected
+      // after parsing either.
+      expect(applyWebSocketUriScheme("127.0.0.1:8765"), "ws://127.0.0.1:8765");
+    });
+
+    test('trims surrounding whitespace', () {
+      expect(
+        applyWebSocketUriScheme("  echo.websocket.org  "),
+        "wss://echo.websocket.org",
+      );
+    });
+
+    test('preserves path and query when defaulting', () {
+      expect(
+        applyWebSocketUriScheme("example.com/socket?topic=a&topic=b"),
+        "wss://example.com/socket?topic=a&topic=b",
+      );
+    });
+
+    test('returns null for a null URL', () {
+      expect(applyWebSocketUriScheme(null), null);
+    });
+
+    test('returns null for a blank URL', () {
+      expect(applyWebSocketUriScheme("   "), null);
+    });
+  });
 }

--- a/test/providers/ws_scheme_defaulting_test.dart
+++ b/test/providers/ws_scheme_defaulting_test.dart
@@ -1,0 +1,94 @@
+import 'dart:io';
+
+import 'package:apidash/models/models.dart';
+import 'package:apidash/providers/providers.dart';
+import 'package:apidash/services/services.dart';
+import 'package:apidash_core/apidash_core.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'helpers.dart';
+
+/// End-to-end coverage for defaulting the ws/wss scheme (#1747).
+///
+/// Uses a scoped loopback echo server rather than the deployed endpoint, so
+/// these stay offline and deterministic. A local server is also the only way
+/// to exercise the case the issue is about: `localhost:<port>` typed without a
+/// scheme, which must resolve to `ws://` rather than `wss://`.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late HttpServer server;
+  late int port;
+
+  setUp(() async {
+    await testSetUpTempDirForHive();
+    server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    port = server.port;
+    server.listen((req) async {
+      final socket = await WebSocketTransformer.upgrade(req);
+      socket.listen(socket.add, onError: (_) {});
+    });
+  });
+
+  tearDown(() async {
+    ConnectionManager.instance.disconnectAll();
+    await server.close(force: true);
+  });
+
+  /// Points the selected request at [url] as a websocket request and connects.
+  Future<RequestModel> connectTo(
+    ProviderContainer container,
+    CollectionStateNotifier notifier,
+    String url,
+  ) async {
+    final id = notifier.state!.entries.first.key;
+    notifier.update(id: id, apiType: APIType.websocket);
+    notifier.update(id: id, wsRequestModel: WebSocketRequestModel(url: url));
+    container.read(selectedIdStateProvider.notifier).state = id;
+    await notifier.sendRequest();
+    await Future.delayed(const Duration(milliseconds: 500));
+    return notifier.getRequestModel(id)!;
+  }
+
+  bool isConnected(RequestModel model) =>
+      model.wsRequestModel!.messageHistory.any(
+        (m) => m.messageType == WebSocketMessageType.connected,
+      );
+
+  test('connects when the ws:// scheme is omitted from a localhost URL',
+      () async {
+    final container = createContainer();
+    final notifier = container.read(collectionStateNotifierProvider.notifier);
+
+    // The URL the issue is about: no scheme at all.
+    final model = await connectTo(container, notifier, 'localhost:$port');
+
+    expect(isConnected(model), true,
+        reason: 'a schemeless localhost URL should default to ws:// and '
+            'connect, rather than failing to parse');
+    expect(model.isStreaming, true);
+  });
+
+  test('connects when the ws:// scheme is omitted from a bare IP URL',
+      () async {
+    final container = createContainer();
+    final notifier = container.read(collectionStateNotifierProvider.notifier);
+
+    // Uri.parse throws on this input, so it has to be handled before parsing.
+    final model = await connectTo(container, notifier, '127.0.0.1:$port');
+
+    expect(isConnected(model), true);
+    expect(model.isStreaming, true);
+  });
+
+  test('still connects when the ws:// scheme is given explicitly', () async {
+    final container = createContainer();
+    final notifier = container.read(collectionStateNotifierProvider.notifier);
+
+    final model = await connectTo(container, notifier, 'ws://localhost:$port');
+
+    expect(isConnected(model), true);
+    expect(model.isStreaming, true);
+  });
+}


### PR DESCRIPTION
## PR Description

WebSocket URLs currently need the full `ws://` or `wss://` scheme typed out, with no defaulting like HTTP has through the default-URI-scheme setting.

This adds `applyWebSocketUriScheme()` to `better_networking`, mirroring how `getValidRequestUri()` already defaults HTTP URLs, and calls it in `_connectWebSocket` before the URL is parsed.

A few notes on the choices made, all of which I am happy to change:

**Where the default comes from.** The scheme is derived from the existing `defaultUriScheme` setting (`https` implies `wss`, `http` implies `ws`) rather than adding a separate setting, so a user's existing preference carries over and there is no new Settings row to maintain. The issue asked for a dedicated user setting, so if you would prefer that instead, I am glad to add it. I kept the enum (`SupportedWebSocketUriSchemes`) separate specifically so that swap stays easy.

**Why localhost and bare IPs default to `ws://`.** This matches the reason `getValidRequestUri()` forces `http` for those hosts: local development servers rarely terminate TLS, so defaulting them to `wss` would fail for most people running a server on their own machine.

**Why the check happens before parsing.** These two cases cannot be detected from a parsed `Uri`:

```dart
Uri.parse("localhost:8765")   // scheme is "localhost", so hasScheme is true
Uri.parse("127.0.0.1:8765")   // throws FormatException
```

So a `!uri.hasScheme` test would miss exactly the URLs people are most likely to type. The fix reuses the existing `kLocalhostRegex` and `kIPHostRegex` guards, which already handle this on the HTTP path.

**Unsupported schemes are left alone.** A URL like `http://example.com` is passed through untouched so `WebSocket.connect` reports its own `Unsupported URL scheme` error, rather than this code silently rewriting what the user typed. Let me know if you would rather it map `http` to `ws` and `https` to `wss`, that is a one line change.

One side benefit: normalising the scheme before `Uri.parse` also fixes the query-parameter block just below it, which previously parsed a schemeless URL as a relative `Uri`.

## Related Issues

- Closes #1747

## Video Demo

I am recording this now and will add it to this comment thread shortly. Opening the PR first so the approach can be looked at, since a couple of the choices below are worth agreeing on before I go further with the two related WebSocket fixes I have queued.

What the recording will show:

- Before: typing `localhost:8765` with no scheme and connecting fails.
- After: the same URL connects, resolved to `ws://localhost:8765`.

In the meantime, the same before and after is captured as an automated test. `test/providers/ws_scheme_defaulting_test.dart` drives `sendRequest()` against a scoped loopback echo server and asserts a `connected` message arrives. Reverting the two changed lines in `_connectWebSocket` makes it fail:

```
connects when the ws:// scheme is omitted from a localhost URL [E]
  Expected: <true>
    Actual: <false>
connects when the ws:// scheme is omitted from a bare IP URL [E]
  Expected: <true>
    Actual: <false>
```

The explicit `ws://` case passes either way, so the tests are pinned to this behaviour rather than to connectivity in general.

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

Test results on this branch:
- `packages/better_networking`: 355 passing
- `flutter test` at the repo root: 2197 passing, 1 skipped, 1 failing
- `flutter analyze` on the changed files: no new issues

That one failure is pre-existing on `main` and unrelated to this change. I checked it on a clean checkout of `main` before opening this, and it fails there identically:

```
test/services/connection_manager_test.dart
  ConnectionManager - error / abnormal-close edges
  connecting to an unreachable endpoint: channel.ready rejects but the channel
  is still registered (connect itself does not throw)
```

It looks like the test has drifted from the implementation rather than catching a real bug. Its comment says "IOWebSocketChannel.connect is lazy: connect() returns synchronously and only channel.ready surfaces the failure", but `ConnectionManager.connect` now awaits `WebSocket.connect` directly so it can hold a reference to the socket for `pingInterval`, and that form throws during the await rather than deferring to `ready`. So `connect` does throw, and the channel is never registered.

I did not touch it here since it is outside the scope of this PR. Happy to open a separate issue for it, or send a fix, whichever you prefer.

## Added/updated tests?

- [x] Yes

18 new tests in total.

15 unit tests in `packages/better_networking/test/utils/uri_utils_test.dart` covering scheme defaulting, an explicitly passed default, existing `ws`/`wss` URLs left untouched, unsupported schemes left untouched, localhost with and without port and path, bare IP hosts, surrounding whitespace, preserved path and query, and null/blank input.

3 end-to-end tests in `test/providers/ws_scheme_defaulting_test.dart` driving `sendRequest()` against a scoped loopback echo server. I used a local server rather than the deployed endpoint so these stay offline and deterministic, and because `localhost:<port>` without a scheme is exactly the case the issue is about and a remote host cannot demonstrate it.

## OS on which you have developed and tested the feature?

- [ ] Windows
- [x] macOS
- [ ] Linux
