### PR TITLE
fix(codegen): escape backticks in Go HTTP request bodies

### DIFF
--- a/lib/codegen/go/http.dart
+++ b/lib/codegen/go/http.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:apidash_core/apidash_core.dart';
 import 'package:jinja/jinja.dart' as jj;
 
@@ -25,7 +27,7 @@ func main() {
 """;
 
   String kTemplateBody = """
-  {% if body %}payload := bytes.NewBuffer([]byte(`{{body}}`)){% endif %}
+  {% if body %}payload := bytes.NewBuffer([]byte({{body}})){% endif %}
 
 """;
 
@@ -115,7 +117,10 @@ func main() {
         if (requestModel.hasTextData || requestModel.hasJsonData) {
           hasBody = true;
           var templateRawBody = jj.Template(kTemplateBody);
-          result += templateRawBody.render({"body": requestModel.body});
+          final body = requestModel.body!;
+          result += templateRawBody.render({
+            "body": body.contains('`') ? jsonEncode(body) : '`$body`',
+          });
         } else if (requestModel.hasFormData) {
           hasBody = true;
           var templateFormData = jj.Template(kTemplateFormData);

--- a/test/codegen/go_http_codegen_test.dart
+++ b/test/codegen/go_http_codegen_test.dart
@@ -1,5 +1,6 @@
 import 'package:apidash/codegen/codegen.dart';
 import 'package:apidash/consts.dart';
+import 'package:apidash/models/models.dart';
 import 'package:apidash/screens/common_widgets/common_widgets.dart';
 import 'package:apidash_core/apidash_core.dart';
 import 'package:test/test.dart';
@@ -568,6 +569,56 @@ func main() {
   });
 
   group('POST Request', () {
+    test('escapes a backtick in the request body', () {
+      const requestModel = RequestModel(
+        id: 'post-with-backtick',
+        apiType: APIType.rest,
+        httpRequestModel: HttpRequestModel(
+          method: HTTPVerb.post,
+          url: 'https://api.apidash.dev/messages',
+          body: r'{"message":"Use `code` here"}',
+        ),
+      );
+      const expectedCode = r'''package main
+
+import (
+  "fmt"
+  "io"
+  "net/http"
+  "net/url"
+  "bytes"
+)
+
+func main() {
+  client := &http.Client{}
+  url, _ := url.Parse("https://api.apidash.dev/messages")
+  payload := bytes.NewBuffer([]byte("{\"message\":\"Use `code` here\"}"))
+  req, _ := http.NewRequest("POST", url.String(), payload)
+
+  req.Header.Set("Content-Type", "application/json")
+
+  response, err := client.Do(req)
+  if err != nil {
+    fmt.Println(err)
+    return
+  }
+  defer response.Body.Close()
+
+  fmt.Println("Status Code:", response.StatusCode)
+  body, _ := io.ReadAll(response.Body)
+  fmt.Println("Response body:", string(body))
+}''';
+
+      expect(
+        codeGen.getCode(
+          CodegenLanguage.goHttp,
+          requestModel,
+          SupportedUriSchemes.https,
+        ),
+        expectedCode,
+      );
+    });
+
     test('POST 1', () {
       const expectedCode = r'''package main
 


### PR DESCRIPTION
## PR Description
Fixes Go (net/http) code generation when text or JSON request bodies contain backticks.

Previously, the generator embedded request bodies in a Go raw string literal. A backtick in the body prematurely terminated that literal, producing invalid Go source.

This PR:
- Safely generates an escaped Go string literal when a request body contains a backtick.
- Preserves the existing raw-string output for bodies without backticks.
- Adds a regression test for a JSON request body containing backticks.

## Related Issues
- N/A

## Video Demo

https://github.com/user-attachments/assets/ece217f2-9a34-4f11-93f8-04035b5cd310

## Verification
```bash
flutter test test/codegen/go_http_codegen_test.dart
Result: passed.
```
flutter test was also run, but the full suite currently reports failures outside this change.

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [ ] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
- [x] Yes

Added a regression test for Go HTTP code generation with a JSON request body containing backticks.

## OS on which you have developed and tested the feature?
- [ ] Windows
- [ ] macOS
- [x] Linux