### PR TITLE
fix: dedupe recently sent WebSocket messages and show repeat count

### DIFF
--- a/lib/screens/home_page/editor_pane/details_card/request_pane/ws/ws_recently_sent.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/ws/ws_recently_sent.dart
@@ -29,13 +29,26 @@ class WsRecentlySent extends ConsumerWidget {
             .select((value) => value?.wsRequestModel?.messageHistory)) ??
         const <WebSocketMessage>[];
 
-    final sentHistory = messageHistory
-        .where((m) => m.outgoing && m.messageType == WebSocketMessageType.sent && m.payload != "Heartbeat ping")
+    // Newest-first, so the first time we see a payload while counting is
+    // also its most recent send.
+    final reversedPayloads = messageHistory
+        .where((m) =>
+            m.outgoing &&
+            m.messageType == WebSocketMessageType.sent &&
+            m.payload != "Heartbeat ping")
         .map((m) => m.payload)
         .toList()
-        .reversed
-        .take(10)
-        .toList();
+        .reversed;
+
+    // Dedupe by payload while counting how many times each was sent.
+    // A LinkedHashMap (the default Map literal) preserves insertion order,
+    // so the most-recently-sent unique payloads stay first.
+    final Map<String, int> sentCounts = {};
+    for (final payload in reversedPayloads) {
+      sentCounts[payload] = (sentCounts[payload] ?? 0) + 1;
+    }
+
+    final sentHistory = sentCounts.entries.take(10).toList();
 
     return Column(
       mainAxisSize: MainAxisSize.min,
@@ -58,7 +71,9 @@ class WsRecentlySent extends ConsumerWidget {
               itemCount: sentHistory.length,
               separatorBuilder: (_, __) => kHSpacer10,
               itemBuilder: (context, index) {
-                final payload = sentHistory[index];
+                final entry = sentHistory[index];
+                final payload = entry.key;
+                final count = entry.value;
 
                 Map<String, String>? matchingTemplate;
                 try {
@@ -134,6 +149,24 @@ class WsRecentlySent extends ConsumerWidget {
                                       ),
                                     ),
                               ),
+                              if (count > 1) ...[
+                                const SizedBox(width: 6),
+                                Container(
+                                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                                  decoration: BoxDecoration(
+                                    color: Theme.of(context).colorScheme.primary.withOpacity(0.15),
+                                    borderRadius: BorderRadius.circular(10),
+                                  ),
+                                  child: Text(
+                                    '×$count',
+                                    style: TextStyle(
+                                      fontSize: 10,
+                                      fontWeight: FontWeight.bold,
+                                      color: Theme.of(context).colorScheme.primary,
+                                    ),
+                                  ),
+                                ),
+                              ],
                             ],
                           ),
                           const SizedBox(height: 8),


### PR DESCRIPTION
## PR Description

Fixes duplicate cards in the WebSocket "Recently Sent" strip when the
same message is sent more than once (e.g. sending "hi" twice
previously showed two separate "hi" cards).

**Root cause:** `sentHistory` in `ws_recently_sent.dart` was built by
mapping every outgoing sent message's payload into a list with no
deduplication, so identical payloads each got their own card.

**Fix:** payloads are now counted while deduping (most recent send of
a given payload determines its position in the strip). Identical
messages now collapse into a single card, and a small `×N` badge is
shown when a message was sent more than once.

## Related Issues

- Closes #1750

## Video Demo

https://github.com/user-attachments/assets/16ce53b1-84a6-4e04-b411-a516c3a1e7b5

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [x] No, and this is why: _Straightforward UI/dedup logic fix; happy to add a widget test covering the duplicate-message case if requested._

## OS on which you have developed and tested the feature?

- [ ] Windows
- [x] macOS
- [ ] Linux
