### PR TITLE
Fix: pause video playback on screen change natively using Riverpod

### DIFF
--- a/lib/widgets/previewer_video.dart
+++ b/lib/widgets/previewer_video.dart
@@ -3,6 +3,8 @@ import 'package:apidash/consts.dart';
 import 'package:fvp/fvp.dart' as fvp;
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:apidash/providers/providers.dart';
 import 'package:jinja/jinja.dart' as jj;
 import 'package:video_player/video_player.dart';
 import 'package:path_provider/path_provider.dart';
@@ -23,7 +25,7 @@ String getVideoTempFileSuffix(String? extension) {
   return extension.startsWith('.') ? extension : '.$extension';
 }
 
-class VideoPreviewer extends StatefulWidget {
+class VideoPreviewer extends ConsumerStatefulWidget {
   const VideoPreviewer({
     super.key,
     required this.videoBytes,
@@ -34,10 +36,10 @@ class VideoPreviewer extends StatefulWidget {
   final String? videoFileExtension;
 
   @override
-  State<VideoPreviewer> createState() => _VideoPreviewerState();
+  ConsumerState<VideoPreviewer> createState() => _VideoPreviewerState();
 }
 
-class _VideoPreviewerState extends State<VideoPreviewer> {
+class _VideoPreviewerState extends ConsumerState<VideoPreviewer> {
   VideoPlayerController? _videoController;
   late Future<void> _initializeVideoPlayerFuture;
   File? _tempVideoFile;
@@ -123,6 +125,13 @@ class _VideoPreviewerState extends State<VideoPreviewer> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen(navRailIndexStateProvider, (previous, next) {
+      if (previous != next && _videoController?.value.isPlaying == true) {
+        _videoController?.pause();
+        setState(() {});
+      }
+    });
+
     final iconColor = Theme.of(context).iconTheme.color;
     final progressBarColors = VideoProgressColors(
       playedColor: iconColor!,


### PR DESCRIPTION
## PR Description

This PR fixes the issue where the video player continued playing audio in the background after navigating away from the screen.

Previously, because the Dashboard uses an `IndexedStack` to preserve state, switching tabs did not dispose of the `VideoPreviewer` widget, allowing the `VideoPlayerController` to remain active. A previous attempt (PR #868) tried to solve this by introducing an external `visibility_detector` package. 

This change solves the problem natively by leveraging the app's existing Riverpod architecture:
* Converted `VideoPreviewer` to a `ConsumerStatefulWidget`.
* Added a `ref.listen` hook to actively watch `navRailIndexStateProvider`.
* Whenever the user switches tabs, the index change is intercepted and `_videoController?.pause()` is explicitly called.
* This approach adds zero new dependencies and perfectly integrates with the existing global state management.

## Related Issues

- Closes #848

## Video Demo

https://github.com/user-attachments/assets/989334ca-97df-4f20-a0c2-0a0089035ce4


### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?
_We encourage you to add relevant test cases._

- [ ] Yes
- [x] No, and this is why: This is a UI lifecycle behavior that taps into the existing `navRailIndexStateProvider`. It has been manually verified with test videos to ensure background audio pauses correctly.

## OS on which you have developed and tested the feature?

- [ ] Windows
- [ ] macOS
- [x] Linux