### PR TITLE
fix: prevent WebSocket reconnect storms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,6 +259,9 @@ Hive boxes:
 - `packages/better_networking/lib/services/http_service.dart` owns HTTP, GraphQL, multipart, auth application, cancellation, and streaming response handling.
 - `cancelHttpRequest(id)` delegates to `HttpClientManager`.
 - Streaming is MIME-driven through `kStreamingResponseTypes`; do not add protocol-specific behavior in UI widgets.
+- WebSocket sockets are tracked by `ConnectionManager` in `lib/services/connection_manager.dart` and driven by `CollectionStateNotifier`.
+- Append to `WebSocketRequestModel.messageHistory` only through `appendWebSocketMessage`/`appendWebSocketMessages` in `lib/utils/websocket_utils.dart`. A spread append bypasses the `kMaxWebSocketMessages` retention cap and lets the list, and its Hive record, grow without bound.
+- WebSocket auto-reconnect must stay a single pending `Timer` per request id, delayed by `webSocketReconnectDelay` and bounded by `kWsMaxReconnectAttempts`. Do not reconnect directly from a socket callback; that is what produced the reconnect storm in issue #1759. Reset the attempt counter only on user intent or a connection that lasted `kWsConnectionStableAfter`, never on a bare handshake.
 
 ### Environment Variables
 
@@ -375,6 +378,7 @@ Docs should be specific, short enough to stay useful, and tied to real source pa
 - Running only `flutter test` and assuming package tests ran. Use `melos test` for packages.
 - Editing generated files without updating source models.
 - Mutating Riverpod maps/lists in place.
+- Growing `WebSocketRequestModel.messageHistory` with a spread instead of the capped append helpers.
 - Saving request data outside `HiveHandler`.
 - Adding UI that works on desktop but breaks `context.isMediumWindow` branches.
 - Treating GSoC proposal docs as implementation.

--- a/doc/dev_guide/architecture.md
+++ b/doc/dev_guide/architecture.md
@@ -275,6 +275,16 @@ state = {...state!, id: updatedModel};
 // state![id] = updatedModel;
 ```
 
+### WebSocket Message Retention and Reconnect
+
+`CollectionStateNotifier` keeps a WebSocket conversation in `WebSocketRequestModel.messageHistory`, which is also persisted to Hive. Two bounds are enforced so a long-lived or chatty connection cannot grow without limit:
+
+- **Retention.** Every append goes through `appendWebSocketMessage`/`appendWebSocketMessages` in `lib/utils/websocket_utils.dart`, which returns a new list holding at most `kMaxWebSocketMessages` entries and drops the oldest to make room. Do not append to `messageHistory` with a spread (`[...history, msg]`) — that bypasses the cap.
+- **Auto-reconnect.** When a connection drops and `autoReconnect` is on, the notifier schedules a *single* pending `Timer` per request id. The delay comes from `webSocketReconnectDelay`: exponential from `kWsReconnectBaseDelay` up to `kWsMaxReconnectDelay`, with equal jitter. A retry that is refused escalates the same ladder, so a server that is briefly down is retried too. After `kWsMaxReconnectAttempts` consecutive failures the request gives up, emits an error message, and stops streaming.
+- **Ladder reset.** The attempt counter is cleared on a user-initiated connect or disconnect, and when a dropped connection had stayed up for at least `kWsConnectionStableAfter` — a session that outlived the longest backoff counts as recovered. A successful handshake alone does *not* reset it: the storm case is a server that accepts and immediately closes, which would otherwise reset the ladder every time and be retried at a fixed rate forever.
+
+Because at most one reconnect is ever pending per request, a server that accepts and immediately closes cannot fan out into overlapping connections.
+
 ### Platform Checks
 ```dart
 // From lib/consts.dart

--- a/lib/consts.dart
+++ b/lib/consts.dart
@@ -72,6 +72,31 @@ final kIconRemoveLight = Icon(
 
 const kCodePreviewLinesLimit = 500;
 
+/// Maximum number of messages retained in a WebSocket request's
+/// `messageHistory`. Once the cap is reached the oldest messages are dropped,
+/// so a long-lived or chatty connection cannot grow the list (nor the Hive
+/// record backing it) without bound.
+const kMaxWebSocketMessages = 1000;
+
+/// Auto-reconnect gives up after this many consecutive attempts.
+const kWsMaxReconnectAttempts = 10;
+
+/// Delay before the first auto-reconnect attempt. Each subsequent attempt
+/// doubles it, jittered, up to [kWsMaxReconnectDelay].
+const kWsReconnectBaseDelay = Duration(seconds: 1);
+
+/// Upper bound on the auto-reconnect backoff delay.
+const kWsMaxReconnectDelay = Duration(seconds: 30);
+
+/// How long a connection must stay up before it counts as recovered, resetting
+/// the backoff ladder. Matches [kWsMaxReconnectDelay]: a session that outlived
+/// the longest backoff is a working connection, not a flapping one.
+///
+/// Without this, a server that accepts and immediately closes would reset the
+/// ladder on every handshake and be retried at a fixed rate forever, never
+/// reaching [kWsMaxReconnectAttempts].
+const kWsConnectionStableAfter = kWsMaxReconnectDelay;
+
 enum HistoryRetentionPeriod {
   oneWeek("1 Week", Icons.calendar_view_week_rounded),
   oneMonth("1 Month", Icons.calendar_view_month_rounded),

--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -524,12 +524,13 @@ class CollectionStateNotifier
       outgoing: false,
       messageType: WebSocketMessageType.disconnected,
     );
-    update(
-      id: requestId,
-      wsRequestModel: ws.copyWith(
-        messageHistory: appendWebSocketMessage(ws.messageHistory, reconnMsg),
-      ),
+    final updatedWs = ws.copyWith(
+      messageHistory: appendWebSocketMessage(ws.messageHistory, reconnMsg),
     );
+    update(id: requestId, wsRequestModel: updatedWs);
+    if (historyId != null) {
+      _updateWebSocketHistoryRecord(historyId, updatedWs);
+    }
 
     _cancelPendingWsReconnect(requestId);
     _wsReconnectTimers[requestId] = Timer(delay, () async {

--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -67,12 +67,31 @@ class CollectionStateNotifier
   final baseHttpResponseModel = const HttpResponseModel();
   final Map<String, Timer> _appHeartbeatTimers = {};
 
+  /// Pending auto-reconnect timer per request id. At most one entry per id
+  /// exists, which is what keeps repeated closes from fanning out into a
+  /// reconnect storm.
+  final Map<String, Timer> _wsReconnectTimers = {};
+
+  /// Consecutive auto-reconnect attempts per request id, used to compute the
+  /// backoff delay. Cleared once a connection proves stable.
+  final Map<String, int> _wsReconnectAttempts = {};
+
+  /// When the current connection for a request id was established, used to tell
+  /// a recovered session from a flapping one (see [kWsConnectionStableAfter]).
+  final Map<String, DateTime> _wsConnectedAt = {};
+
   @override
   void dispose() {
     for (final timer in _appHeartbeatTimers.values) {
       timer.cancel();
     }
     _appHeartbeatTimers.clear();
+    for (final timer in _wsReconnectTimers.values) {
+      timer.cancel();
+    }
+    _wsReconnectTimers.clear();
+    _wsReconnectAttempts.clear();
+    _wsConnectedAt.clear();
     super.dispose();
   }
 
@@ -135,6 +154,7 @@ class CollectionStateNotifier
 
     // Cleanup active connections
     _stopMessageHeartbeat(rId);
+    _resetWsReconnect(rId);
     ConnectionManager.instance.disconnect(rId);
     cancelHttpRequest(rId);
 
@@ -431,6 +451,110 @@ class CollectionStateNotifier
     _appHeartbeatTimers.remove(requestId)?.cancel();
   }
 
+  /// Cancel a queued auto-reconnect for [requestId], leaving the attempt
+  /// counter intact so an in-progress backoff keeps escalating.
+  void _cancelPendingWsReconnect(String requestId) {
+    _wsReconnectTimers.remove(requestId)?.cancel();
+  }
+
+  /// Cancel a queued auto-reconnect for [requestId] and clear its backoff
+  /// ladder, so the next connect starts again from [kWsReconnectBaseDelay].
+  void _resetWsReconnect(String requestId) {
+    _cancelPendingWsReconnect(requestId);
+    _wsReconnectAttempts.remove(requestId);
+    _wsConnectedAt.remove(requestId);
+  }
+
+  /// Queue the next auto-reconnect attempt for [requestId] after an
+  /// exponentially increasing, jittered delay.
+  ///
+  /// Reconnects are driven solely by this timer, and only one is ever pending
+  /// per request, so a server that accepts and immediately closes can no longer
+  /// spin up an unbounded number of connections. After
+  /// [kWsMaxReconnectAttempts] consecutive attempts the request gives up and
+  /// stops streaming.
+  ///
+  /// [lead] opens the user-visible message and names what triggered the retry
+  /// (a close from the server vs. a refused connect).
+  void _scheduleWebSocketReconnect(
+    String requestId, {
+    String? historyId,
+    String lead = "Connection closed.",
+  }) {
+    final currentRequest = state?[requestId];
+    final ws = currentRequest?.wsRequestModel;
+    if (currentRequest == null || ws == null) return;
+
+    final attempt = (_wsReconnectAttempts[requestId] ?? 0) + 1;
+
+    if (attempt > kWsMaxReconnectAttempts) {
+      _resetWsReconnect(requestId);
+      final giveUpMsg = WebSocketMessage(
+        payload:
+            "Reconnect failed after $kWsMaxReconnectAttempts attempts. "
+            "Giving up.",
+        timestamp: DateTime.now(),
+        outgoing: false,
+        messageType: WebSocketMessageType.error,
+      );
+      final updatedWs = ws.copyWith(
+        messageHistory: appendWebSocketMessage(ws.messageHistory, giveUpMsg),
+      );
+      update(
+        id: requestId,
+        isStreaming: false,
+        isWorking: false,
+        wsRequestModel: updatedWs,
+      );
+      if (historyId != null) {
+        _updateWebSocketHistoryRecord(historyId, updatedWs);
+      }
+      return;
+    }
+
+    _wsReconnectAttempts[requestId] = attempt;
+    final delay = webSocketReconnectDelay(attempt);
+
+    final reconnMsg = WebSocketMessage(
+      payload:
+          "$lead Reconnecting in "
+          "${(delay.inMilliseconds / 1000).toStringAsFixed(1)}s "
+          "(attempt $attempt of $kWsMaxReconnectAttempts)...",
+      timestamp: DateTime.now(),
+      outgoing: false,
+      messageType: WebSocketMessageType.disconnected,
+    );
+    update(
+      id: requestId,
+      wsRequestModel: ws.copyWith(
+        messageHistory: appendWebSocketMessage(ws.messageHistory, reconnMsg),
+      ),
+    );
+
+    _cancelPendingWsReconnect(requestId);
+    _wsReconnectTimers[requestId] = Timer(delay, () async {
+      _wsReconnectTimers.remove(requestId);
+      if (!mounted) return;
+      final latestReq = state?[requestId];
+      final latestWs = latestReq?.wsRequestModel;
+      // Re-check intent: during the backoff the user may have disconnected,
+      // switched auto-reconnect off, or removed the request entirely.
+      if (latestReq == null ||
+          latestWs == null ||
+          !latestReq.isStreaming ||
+          !latestWs.autoReconnect) {
+        _wsReconnectAttempts.remove(requestId);
+        return;
+      }
+      await _connectWebSocket(
+        requestId,
+        latestReq,
+        latestWs,
+        historyId: historyId,
+      );
+    });
+  }
+
   /// Start (or restart) the app-level (repeating-message) heartbeat for
   /// [requestId]. Sends [WebSocketRequestModel.messageHeartbeatPayload]
   /// (with {{vars}} substituted) as a normal Sent message on each tick.
@@ -482,7 +606,10 @@ class CollectionStateNotifier
       update(
         id: requestId,
         wsRequestModel: wsModel.copyWith(
-          messageHistory: [...wsModel.messageHistory, newMessage],
+          messageHistory: appendWebSocketMessage(
+            wsModel.messageHistory,
+            newMessage,
+          ),
         ),
       );
     } catch (e) {
@@ -493,9 +620,14 @@ class CollectionStateNotifier
   Future<void> _connectWebSocket(
     String requestId,
     RequestModel requestModel,
-    WebSocketRequestModel wsModel,
-    {String? historyId}
-  ) async {
+    WebSocketRequestModel wsModel, {
+    String? historyId,
+  }) async {
+    // A connect is starting for this id, so any queued reconnect for it is
+    // stale. The attempt counter is left alone: when this call came from the
+    // backoff timer the ladder must keep escalating.
+    _cancelPendingWsReconnect(requestId);
+
     final Map<String, String> combinedEnvVarMap = _buildCombinedEnvVarMap();
 
     final substitutedUrl =
@@ -573,6 +705,12 @@ class CollectionStateNotifier
       // handshake; the `state` reads/writes below would throw otherwise.
       if (!mounted) return;
 
+      // Note the connect time rather than clearing the ladder outright: a
+      // handshake alone proves nothing, since the storm case is a server that
+      // accepts and immediately closes. The ladder resets on close, but only if
+      // the session lasted (see [kWsConnectionStableAfter]).
+      _wsConnectedAt[requestId] = DateTime.now();
+
       final latestRequest = state?[requestId];
       final currentWs = latestRequest?.wsRequestModel ?? wsModel;
 
@@ -589,7 +727,10 @@ class CollectionStateNotifier
           isWorking: false,
           isStreaming: true,
           wsRequestModel: currentWs.copyWith(
-            messageHistory: [...currentWs.messageHistory, connectedMessage],
+            messageHistory: appendWebSocketMessage(
+              currentWs.messageHistory,
+              connectedMessage,
+            ),
           ),
         ),
       };
@@ -614,7 +755,10 @@ class CollectionStateNotifier
               update(
                 id: requestId,
                 wsRequestModel: currentWs.copyWith(
-                  messageHistory: [...currentWs.messageHistory, newMessage],
+                  messageHistory: appendWebSocketMessage(
+                    currentWs.messageHistory,
+                    newMessage,
+                  ),
                 ),
               );
             }
@@ -634,16 +778,12 @@ class CollectionStateNotifier
               outgoing: false,
               messageType: WebSocketMessageType.error,
             );
-            update(
-              id: requestId,
-              wsRequestModel: ws.copyWith(
-                messageHistory: [...ws.messageHistory, errMsg],
-              ),
+            final updatedWs = ws.copyWith(
+              messageHistory: appendWebSocketMessage(ws.messageHistory, errMsg),
             );
+            update(id: requestId, wsRequestModel: updatedWs);
             if (historyId != null) {
-              _updateWebSocketHistoryRecord(historyId, ws.copyWith(
-                messageHistory: [...ws.messageHistory, errMsg],
-              ));
+              _updateWebSocketHistoryRecord(historyId, updatedWs);
             }
           }
         },
@@ -659,38 +799,40 @@ class CollectionStateNotifier
           // successful connect (auto-reconnect calls _connectWebSocket again).
           _stopMessageHeartbeat(requestId);
 
+          // A session that stayed up long enough counts as recovered, so the
+          // next drop starts a fresh ladder. A short-lived one leaves the ladder
+          // escalating, which is what makes a flapping server eventually give up
+          // instead of reconnecting at a fixed rate forever.
+          final connectedAt = _wsConnectedAt.remove(requestId);
+          if (connectedAt != null &&
+              webSocketConnectionWasStable(connectedAt, DateTime.now())) {
+            _wsReconnectAttempts.remove(requestId);
+          }
+
           if (ws.autoReconnect && currentRequest.isStreaming) {
-            final reconnMsg = WebSocketMessage(
-              payload: "Connection closed. Reconnecting...",
-              timestamp: DateTime.now(),
-              outgoing: false,
-              messageType: WebSocketMessageType.disconnected,
-            );
-            final updatedWs = ws.copyWith(
-              messageHistory: [...ws.messageHistory, reconnMsg],
-            );
-            final latestReq = state?[requestId];
-            if (latestReq != null) {
-              _connectWebSocket(requestId, latestReq, updatedWs, historyId: historyId);
-            }
+            _scheduleWebSocketReconnect(requestId, historyId: historyId);
           } else {
+            // Closed for good: nothing is queued, so clear the ladder.
+            _resetWsReconnect(requestId);
             final discMsg = WebSocketMessage(
               payload: "Connection closed",
               timestamp: DateTime.now(),
               outgoing: false,
               messageType: WebSocketMessageType.disconnected,
             );
+            final updatedWs = ws.copyWith(
+              messageHistory: appendWebSocketMessage(
+                ws.messageHistory,
+                discMsg,
+              ),
+            );
             update(
               id: requestId,
               isStreaming: false,
-              wsRequestModel: ws.copyWith(
-                messageHistory: [...ws.messageHistory, discMsg],
-              ),
+              wsRequestModel: updatedWs,
             );
             if (historyId != null) {
-              _updateWebSocketHistoryRecord(historyId, ws.copyWith(
-                messageHistory: [...ws.messageHistory, discMsg],
-              ));
+              _updateWebSocketHistoryRecord(historyId, updatedWs);
             }
           }
         },
@@ -708,26 +850,55 @@ class CollectionStateNotifier
         outgoing: false,
         messageType: WebSocketMessageType.error,
       );
+
+      // A refused *reconnect* keeps the ladder going instead of giving up on
+      // the first failure: the request is still marked streaming (the backoff
+      // timer verified that before calling) and the user asked for
+      // auto-reconnect, so a server that is briefly down is retried up to
+      // [kWsMaxReconnectAttempts] times. A failed first connect is terminal —
+      // there is no session to restore, so it just reports the error.
+      final isReconnectAttempt =
+          (currentRequest?.isStreaming ?? false) && ws.autoReconnect;
+      if (isReconnectAttempt) {
+        final updatedWs = ws.copyWith(
+          messageHistory: appendWebSocketMessage(ws.messageHistory, errMsg),
+        );
+        update(id: requestId, isWorking: false, wsRequestModel: updatedWs);
+        if (historyId != null) {
+          _updateWebSocketHistoryRecord(historyId, updatedWs);
+        }
+        _scheduleWebSocketReconnect(
+          requestId,
+          historyId: historyId,
+          lead: "Connection failed.",
+        );
+        return;
+      }
+
       final discMsg = WebSocketMessage(
         payload: "Connection failed",
         timestamp: DateTime.now(),
         outgoing: false,
         messageType: WebSocketMessageType.disconnected,
       );
+      // Giving up here, so no retry stays queued and the ladder resets.
+      _resetWsReconnect(requestId);
+      final updatedWs = ws.copyWith(
+        messageHistory: appendWebSocketMessages(ws.messageHistory, [
+          errMsg,
+          discMsg,
+        ]),
+      );
       state = {
         ...state!,
         requestId: (currentRequest ?? requestModel).copyWith(
           isWorking: false,
           isStreaming: false,
-          wsRequestModel: ws.copyWith(
-            messageHistory: [...ws.messageHistory, errMsg, discMsg],
-          ),
+          wsRequestModel: updatedWs,
         ),
       };
       if (historyId != null) {
-        _updateWebSocketHistoryRecord(historyId, ws.copyWith(
-          messageHistory: [...ws.messageHistory, errMsg, discMsg],
-        ));
+        _updateWebSocketHistoryRecord(historyId, updatedWs);
       }
     }
   }
@@ -763,6 +934,10 @@ class CollectionStateNotifier
     if (requestModel!.apiType == APIType.websocket) {
       final wsModel = requestModel.wsRequestModel;
       if (wsModel != null) {
+        // A user-initiated connect is a clean slate for the backoff ladder;
+        // auto-reconnect calls _connectWebSocket directly so it keeps its own.
+        _resetWsReconnect(requestId);
+
         // Save history for WebSocket connection attempt first
         String newHistoryId = getNewUuid();
         final historyModel = HistoryRequestModel(
@@ -1054,13 +1229,15 @@ class CollectionStateNotifier
           isStreaming: false,
           isWorking: false,
           wsRequestModel: ws.copyWith(
-            messageHistory: [...ws.messageHistory, discMsg],
+            messageHistory: appendWebSocketMessage(ws.messageHistory, discMsg),
           ),
         );
       } else {
         update(id: id, isStreaming: false, isWorking: false);
       }
       _stopMessageHeartbeat(id);
+      // The user asked to stop, so drop any queued reconnect outright.
+      _resetWsReconnect(id);
       ConnectionManager.instance.disconnect(id);
     } else {
       cancelHttpRequest(id);

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -9,4 +9,5 @@ export 'js_utils.dart';
 export 'save_utils.dart';
 export 'ui_utils.dart';
 export 'validation_utils.dart';
+export 'websocket_utils.dart';
 export 'window_utils.dart';

--- a/lib/utils/websocket_utils.dart
+++ b/lib/utils/websocket_utils.dart
@@ -1,0 +1,86 @@
+import 'dart:math';
+import 'package:apidash/consts.dart';
+import 'package:apidash/models/models.dart';
+
+/// Appends [additions] to [history], retaining at most [max] messages.
+///
+/// When the combined length would exceed [max], the oldest messages are
+/// dropped, making the result a bounded sliding window over the conversation.
+/// A new list is always returned, so callers never mutate the list held in
+/// Riverpod state.
+List<WebSocketMessage> appendWebSocketMessages(
+  List<WebSocketMessage> history,
+  List<WebSocketMessage> additions, {
+  int max = kMaxWebSocketMessages,
+}) {
+  if (max <= 0) {
+    return const [];
+  }
+  if (additions.isEmpty) {
+    return history.length <= max
+        ? List<WebSocketMessage>.of(history)
+        : history.sublist(history.length - max);
+  }
+  // Only the trailing [max] additions can survive, so skip building a large
+  // intermediate list when a single call adds more than the cap allows.
+  if (additions.length >= max) {
+    return additions.sublist(additions.length - max);
+  }
+  final keepFromHistory = max - additions.length;
+  final trimmedHistory = history.length <= keepFromHistory
+      ? history
+      : history.sublist(history.length - keepFromHistory);
+  return [...trimmedHistory, ...additions];
+}
+
+/// Single-message form of [appendWebSocketMessages].
+List<WebSocketMessage> appendWebSocketMessage(
+  List<WebSocketMessage> history,
+  WebSocketMessage message, {
+  int max = kMaxWebSocketMessages,
+}) => appendWebSocketMessages(history, [message], max: max);
+
+/// The backoff delay to wait before auto-reconnect attempt number [attempt]
+/// (1-based).
+///
+/// The delay doubles from [kWsReconnectBaseDelay] on each attempt and is capped
+/// at [kWsMaxReconnectDelay]. Half of the resulting delay is fixed and the
+/// other half is random ("equal jitter"): the random part stops many clients
+/// from retrying in lockstep, while the fixed part keeps the delay from
+/// collapsing towards zero.
+///
+/// Pass [random] to make the jitter deterministic in tests.
+Duration webSocketReconnectDelay(int attempt, {Random? random}) {
+  final n = attempt < 1 ? 1 : attempt;
+  final baseMs = kWsReconnectBaseDelay.inMilliseconds;
+  final capMs = kWsMaxReconnectDelay.inMilliseconds;
+
+  // Clamp before shifting: [attempt] is caller-supplied and a large shift
+  // overflows to a negative value rather than saturating.
+  final shift = n - 1;
+  final int scaledMs;
+  if (shift >= 32 || baseMs > capMs >> shift) {
+    scaledMs = capMs;
+  } else {
+    scaledMs = baseMs << shift;
+  }
+  final cappedMs = scaledMs > capMs ? capMs : scaledMs;
+
+  final fixedMs = cappedMs ~/ 2;
+  final jitterMs = (random ?? Random()).nextInt(cappedMs - fixedMs + 1);
+  return Duration(milliseconds: fixedMs + jitterMs);
+}
+
+/// Whether a connection opened at [connectedAt] and closed at [closedAt] stayed
+/// up long enough to count as recovered, which resets the reconnect backoff
+/// ladder.
+///
+/// Sessions shorter than [threshold] leave the ladder escalating, so a server
+/// that accepts and immediately closes keeps backing off (and eventually gives
+/// up) instead of being retried at a fixed rate forever.
+bool webSocketConnectionWasStable(
+  DateTime connectedAt,
+  DateTime closedAt, {
+  Duration threshold = kWsConnectionStableAfter,
+}) =>
+    closedAt.difference(connectedAt) >= threshold;

--- a/test/providers/ws_reconnect_and_cap_test.dart
+++ b/test/providers/ws_reconnect_and_cap_test.dart
@@ -1,0 +1,293 @@
+import 'dart:io';
+
+import 'package:apidash/consts.dart';
+import 'package:apidash/models/models.dart';
+import 'package:apidash/providers/providers.dart';
+import 'package:apidash/services/services.dart';
+import 'package:apidash_core/apidash_core.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'helpers.dart';
+
+/// A loopback WebSocket server that accepts every connection and closes it
+/// immediately: the server behaviour that used to drive the reconnect storm.
+///
+/// It binds to port 0 on the loopback interface, so the tests below stay on the
+/// local machine and never touch the network.
+class _FlappyWsServer {
+  _FlappyWsServer(this._server);
+
+  final HttpServer _server;
+
+  /// How many connections the server has accepted. This is the storm counter:
+  /// before the backoff existed it climbed without bound.
+  int acceptedConnections = 0;
+
+  static Future<_FlappyWsServer> start() async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    final flappy = _FlappyWsServer(server);
+    server.listen((request) async {
+      flappy.acceptedConnections++;
+      final socket = await WebSocketTransformer.upgrade(request);
+      // Accept, then drop straight away.
+      await socket.close();
+    });
+    return flappy;
+  }
+
+  String get url => 'ws://${_server.address.address}:${_server.port}';
+
+  Future<void> stop() => _server.close(force: true);
+}
+
+/// Offline coverage for the WebSocket message-retention cap and the
+/// auto-reconnect backoff, both as applied by the provider itself.
+///
+/// The retention tests use `cancelRequest()` as their entry point because it is
+/// a real append site that needs no socket: no connection is ever opened for the
+/// request id, so `ConnectionManager.disconnect` is a no-op.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await testSetUpTempDirForHive();
+  });
+
+  group('messageHistory retention', () {
+    late ProviderContainer container;
+    late CollectionStateNotifier notifier;
+    late String id;
+
+    setUp(() {
+      container = createContainer();
+      notifier = container.read(collectionStateNotifierProvider.notifier);
+      id = notifier.state!.entries.first.key;
+      // Switching apiType installs a fresh const WebSocketRequestModel(), so
+      // any url/history has to be set in a follow-up update() call.
+      notifier.update(id: id, apiType: APIType.websocket);
+      container.read(selectedIdStateProvider.notifier).state = id;
+    });
+
+    test('cancelRequest() evicts the oldest message when history is full', () {
+      final full = List.generate(
+        kMaxWebSocketMessages,
+        (i) => WebSocketMessage(payload: 'msg-$i'),
+      );
+      notifier.update(
+        id: id,
+        wsRequestModel: WebSocketRequestModel(
+          url: 'wss://example.invalid/ws',
+          messageHistory: full,
+        ),
+        isStreaming: true,
+      );
+      expect(
+        notifier.getRequestModel(id)!.wsRequestModel!.messageHistory,
+        hasLength(kMaxWebSocketMessages),
+      );
+      // Nothing was ever connected, so this stays entirely offline.
+      expect(ConnectionManager.instance.hasConnection(id), isFalse);
+
+      notifier.cancelRequest();
+
+      final model = notifier.getRequestModel(id)!;
+      final history = model.wsRequestModel!.messageHistory;
+      // The append did not grow the list past the cap...
+      expect(history, hasLength(kMaxWebSocketMessages));
+      // ...the new message is still the most recent entry...
+      expect(history.last.payload, 'Disconnected by user');
+      expect(history.last.messageType, WebSocketMessageType.disconnected);
+      // ...and it was the oldest message that made room, not the newest.
+      expect(history.first.payload, 'msg-1');
+      expect(model.isStreaming, isFalse);
+      expect(model.isWorking, isFalse);
+    });
+
+    test('cancelRequest() appends normally when below the cap', () {
+      notifier.update(
+        id: id,
+        wsRequestModel: const WebSocketRequestModel(
+          url: 'wss://example.invalid/ws',
+        ),
+        isStreaming: true,
+      );
+
+      notifier.cancelRequest();
+
+      final history = notifier
+          .getRequestModel(id)!
+          .wsRequestModel!
+          .messageHistory;
+      expect(history, hasLength(1));
+      expect(history.single.payload, 'Disconnected by user');
+    });
+
+    test('repeated connect/disconnect cycles cannot grow history without '
+        'bound', () {
+      notifier.update(
+        id: id,
+        wsRequestModel: WebSocketRequestModel(
+          url: 'wss://example.invalid/ws',
+          messageHistory: List.generate(
+            kMaxWebSocketMessages - 1,
+            (i) => WebSocketMessage(payload: 'msg-$i'),
+          ),
+        ),
+        isStreaming: true,
+      );
+
+      for (var i = 0; i < 5; i++) {
+        notifier.cancelRequest();
+        expect(
+          notifier.getRequestModel(id)!.wsRequestModel!.messageHistory.length,
+          lessThanOrEqualTo(kMaxWebSocketMessages),
+        );
+      }
+
+      final history = notifier
+          .getRequestModel(id)!
+          .wsRequestModel!
+          .messageHistory;
+      expect(history, hasLength(kMaxWebSocketMessages));
+      expect(history.last.payload, 'Disconnected by user');
+    });
+  });
+
+  group('auto-reconnect backoff', () {
+    late ProviderContainer container;
+    late CollectionStateNotifier notifier;
+    late String id;
+    late _FlappyWsServer server;
+
+    setUp(() async {
+      container = createContainer();
+      notifier = container.read(collectionStateNotifierProvider.notifier);
+      id = notifier.state!.entries.first.key;
+      notifier.update(id: id, apiType: APIType.websocket);
+      container.read(selectedIdStateProvider.notifier).state = id;
+
+      server = await _FlappyWsServer.start();
+      addTearDown(() async {
+        // Stop the ladder before the server goes away, so a queued retry cannot
+        // fire against a dead port during another test.
+        notifier.cancelRequest();
+        ConnectionManager.instance.disconnect(id);
+        await server.stop();
+      });
+    });
+
+    /// Connect to the flapping server with auto-reconnect enabled.
+    Future<void> connectWithAutoReconnect() async {
+      notifier.update(
+        id: id,
+        wsRequestModel: WebSocketRequestModel(
+          url: server.url,
+          autoReconnect: true,
+        ),
+      );
+      await notifier.sendRequest();
+    }
+
+    List<String> payloads() => notifier
+        .getRequestModel(id)!
+        .wsRequestModel!
+        .messageHistory
+        .map((m) => m.payload)
+        .toList();
+
+    test('a server that drops every connection gets one queued retry, '
+        'not a storm', () async {
+      await connectWithAutoReconnect();
+      // Long enough for the close to be observed and the retry to be queued,
+      // but shorter than the ~0.5-1.0s first backoff delay.
+      await Future.delayed(const Duration(milliseconds: 400));
+
+      // Pre-fix this reconnected immediately and unboundedly; now the only
+      // connection made so far is the original one.
+      expect(server.acceptedConnections, 1);
+      expect(
+        payloads(),
+        contains(
+          allOf(
+            contains('Reconnecting in'),
+            contains('attempt 1 of $kWsMaxReconnectAttempts'),
+          ),
+        ),
+      );
+      // The request keeps streaming across the gap: the retry is pending, so the
+      // session is recovering rather than finished.
+      expect(notifier.getRequestModel(id)!.isStreaming, isTrue);
+    });
+
+    test('the delay escalates on each successive failure', () async {
+      await connectWithAutoReconnect();
+      // Covers the first retry (~0.5-1.0s) and the scheduling of the second
+      // (~1.0-2.0s), which is appended as soon as the retry's close is seen.
+      await Future.delayed(const Duration(milliseconds: 2500));
+
+      final attemptMsgs = payloads()
+          .where((p) => p.contains('Reconnecting in'))
+          .toList();
+      expect(attemptMsgs.length, greaterThanOrEqualTo(2));
+      expect(attemptMsgs[0], contains('attempt 1 of'));
+      expect(attemptMsgs[1], contains('attempt 2 of'));
+      // Growing delays mean only a couple of connections land in 2.5s. The
+      // immediate-reconnect loop this replaces made hundreds.
+      expect(server.acceptedConnections, lessThanOrEqualTo(3));
+    });
+
+    test('a user disconnect cancels the queued retry', () async {
+      await connectWithAutoReconnect();
+      await Future.delayed(const Duration(milliseconds: 400));
+      expect(server.acceptedConnections, 1);
+
+      notifier.cancelRequest();
+
+      // Well past the first backoff delay: the cancelled timer must not fire.
+      await Future.delayed(const Duration(milliseconds: 1500));
+      expect(server.acceptedConnections, 1);
+      final model = notifier.getRequestModel(id)!;
+      expect(model.isStreaming, isFalse);
+      expect(model.isWorking, isFalse);
+      expect(payloads().last, 'Disconnected by user');
+    });
+
+    test('turning auto-reconnect off mid-backoff stops the retry', () async {
+      await connectWithAutoReconnect();
+      await Future.delayed(const Duration(milliseconds: 400));
+      expect(server.acceptedConnections, 1);
+
+      final ws = notifier.getRequestModel(id)!.wsRequestModel!;
+      notifier.update(
+        id: id,
+        wsRequestModel: ws.copyWith(autoReconnect: false),
+      );
+
+      await Future.delayed(const Duration(milliseconds: 1500));
+      // The timer still fires, but re-checks intent and gives up instead of
+      // reconnecting.
+      expect(server.acceptedConnections, 1);
+    });
+
+    test('history stays capped even while reconnects churn', () async {
+      notifier.update(
+        id: id,
+        wsRequestModel: WebSocketRequestModel(
+          url: server.url,
+          autoReconnect: true,
+          messageHistory: List.generate(
+            kMaxWebSocketMessages - 1,
+            (i) => WebSocketMessage(payload: 'msg-$i'),
+          ),
+        ),
+      );
+      await notifier.sendRequest();
+      await Future.delayed(const Duration(milliseconds: 2500));
+
+      expect(
+        notifier.getRequestModel(id)!.wsRequestModel!.messageHistory,
+        hasLength(kMaxWebSocketMessages),
+      );
+    });
+  });
+}

--- a/test/utils/websocket_utils_test.dart
+++ b/test/utils/websocket_utils_test.dart
@@ -1,0 +1,277 @@
+import 'dart:math';
+
+import 'package:apidash/consts.dart';
+import 'package:apidash/models/models.dart';
+import 'package:apidash/utils/websocket_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// [n] messages whose payloads count up from [from], so ordering assertions
+/// read unambiguously.
+List<WebSocketMessage> msgs(int n, {int from = 0}) =>
+    List.generate(n, (i) => WebSocketMessage(payload: '${from + i}'));
+
+List<String> payloads(List<WebSocketMessage> list) =>
+    list.map((m) => m.payload).toList();
+
+/// The delay [webSocketReconnectDelay] should cap at for [attempt], derived by
+/// repeated doubling rather than the shift the implementation uses, so this is
+/// an independent check instead of a restatement.
+int expectedCapMs(int attempt) {
+  final capMs = kWsMaxReconnectDelay.inMilliseconds;
+  var ms = kWsReconnectBaseDelay.inMilliseconds;
+  for (var i = 1; i < attempt; i++) {
+    ms *= 2;
+    if (ms >= capMs) return capMs;
+  }
+  return ms > capMs ? capMs : ms;
+}
+
+void main() {
+  group('appendWebSocketMessages', () {
+    test('appends normally while below the cap', () {
+      final result = appendWebSocketMessages(
+        msgs(3),
+        msgs(2, from: 3),
+        max: 10,
+      );
+      expect(payloads(result), ['0', '1', '2', '3', '4']);
+    });
+
+    test('keeps everything when the result lands exactly on the cap', () {
+      final result = appendWebSocketMessages(msgs(4), msgs(1, from: 4), max: 5);
+      expect(result, hasLength(5));
+      expect(payloads(result), ['0', '1', '2', '3', '4']);
+    });
+
+    test('drops the oldest messages once the cap is exceeded', () {
+      final result = appendWebSocketMessages(msgs(5), msgs(2, from: 5), max: 5);
+      expect(result, hasLength(5));
+      // '0' and '1' fell off the front; the newest message is last.
+      expect(payloads(result), ['2', '3', '4', '5', '6']);
+    });
+
+    test('stays at the cap across many successive single appends', () {
+      var history = <WebSocketMessage>[];
+      for (var i = 0; i < 250; i++) {
+        history = appendWebSocketMessage(
+          history,
+          WebSocketMessage(payload: '$i'),
+          max: 100,
+        );
+        expect(history.length, lessThanOrEqualTo(100));
+      }
+      expect(history, hasLength(100));
+      expect(history.first.payload, '150');
+      expect(history.last.payload, '249');
+    });
+
+    test(
+      'keeps only the trailing window when additions alone exceed the cap',
+      () {
+        final result = appendWebSocketMessages(
+          msgs(3),
+          msgs(10, from: 100),
+          max: 4,
+        );
+        expect(result, hasLength(4));
+        // Nothing from history survives — only the last 4 additions.
+        expect(payloads(result), ['106', '107', '108', '109']);
+      },
+    );
+
+    test('trims an already-oversized history even with no additions', () {
+      final result = appendWebSocketMessages(msgs(7), const [], max: 3);
+      expect(payloads(result), ['4', '5', '6']);
+    });
+
+    test('returns a copy, not the original list, when nothing is added', () {
+      final history = msgs(2);
+      final result = appendWebSocketMessages(history, const [], max: 10);
+      expect(result, equals(history));
+      expect(identical(result, history), isFalse);
+    });
+
+    test('does not mutate the history it was given', () {
+      final history = msgs(5);
+      appendWebSocketMessages(history, msgs(5, from: 5), max: 5);
+      expect(payloads(history), ['0', '1', '2', '3', '4']);
+    });
+
+    test('a non-positive cap retains nothing', () {
+      expect(
+        appendWebSocketMessages(msgs(3), msgs(1, from: 3), max: 0),
+        isEmpty,
+      );
+    });
+
+    test('defaults to kMaxWebSocketMessages', () {
+      final result = appendWebSocketMessage(
+        msgs(kMaxWebSocketMessages),
+        const WebSocketMessage(payload: 'newest'),
+      );
+      expect(result, hasLength(kMaxWebSocketMessages));
+      expect(result.last.payload, 'newest');
+      // Exactly one message was evicted to make room.
+      expect(result.first.payload, '1');
+    });
+  });
+
+  group('webSocketReconnectDelay', () {
+    test('grows exponentially from the base delay', () {
+      // With equal jitter the delay lands in [cap/2, cap] for that attempt.
+      for (var attempt = 1; attempt <= 15; attempt++) {
+        final capMs = expectedCapMs(attempt);
+        final ms = webSocketReconnectDelay(
+          attempt,
+          random: Random(attempt),
+        ).inMilliseconds;
+        expect(
+          ms,
+          inInclusiveRange(capMs ~/ 2, capMs),
+          reason: 'attempt $attempt should fall within [${capMs ~/ 2}, $capMs]',
+        );
+      }
+    });
+
+    test('reaches the base delay window on the first attempt', () {
+      final baseMs = kWsReconnectBaseDelay.inMilliseconds;
+      final ms = webSocketReconnectDelay(1, random: Random(7)).inMilliseconds;
+      expect(ms, inInclusiveRange(baseMs ~/ 2, baseMs));
+    });
+
+    test(
+      'never exceeds kWsMaxReconnectDelay, including for absurd attempts',
+      () {
+        for (final attempt in [1, 5, 10, 32, 64, 1000, 1 << 40]) {
+          expect(
+            webSocketReconnectDelay(attempt),
+            lessThanOrEqualTo(kWsMaxReconnectDelay),
+            reason: 'attempt $attempt overflowed the cap',
+          );
+        }
+      },
+    );
+
+    test('saturates at the cap once doubling passes it', () {
+      // Anything at or beyond the saturation point shares the same window.
+      final capMs = kWsMaxReconnectDelay.inMilliseconds;
+      for (final attempt in [20, 50, 500]) {
+        expect(expectedCapMs(attempt), capMs);
+        expect(
+          webSocketReconnectDelay(attempt).inMilliseconds,
+          inInclusiveRange(capMs ~/ 2, capMs),
+        );
+      }
+    });
+
+    test('is always positive, so reconnects can never busy-loop', () {
+      for (var attempt = 1; attempt <= 20; attempt++) {
+        expect(
+          webSocketReconnectDelay(attempt),
+          greaterThan(Duration.zero),
+          reason: 'attempt $attempt produced a non-positive delay',
+        );
+      }
+    });
+
+    test('treats non-positive attempts as the first attempt', () {
+      final first = webSocketReconnectDelay(1, random: Random(3));
+      expect(webSocketReconnectDelay(0, random: Random(3)), first);
+      expect(webSocketReconnectDelay(-5, random: Random(3)), first);
+    });
+
+    test('is reproducible for a given seed', () {
+      expect(
+        webSocketReconnectDelay(4, random: Random(99)),
+        webSocketReconnectDelay(4, random: Random(99)),
+      );
+    });
+
+    test('jitter actually varies the delay across attempts', () {
+      // Guards against the jitter term being accidentally dropped: over many
+      // draws at one attempt the delay must not be constant.
+      final random = Random(1234);
+      final seen = <int>{};
+      for (var i = 0; i < 50; i++) {
+        seen.add(webSocketReconnectDelay(5, random: random).inMilliseconds);
+      }
+      expect(seen.length, greaterThan(1));
+    });
+  });
+
+  group('webSocketConnectionWasStable', () {
+    final connectedAt = DateTime(2026, 1, 1, 12);
+
+    test('a session that outlived the threshold counts as recovered', () {
+      expect(
+        webSocketConnectionWasStable(
+          connectedAt,
+          connectedAt.add(kWsConnectionStableAfter * 2),
+        ),
+        isTrue,
+      );
+    });
+
+    test('the threshold itself counts as recovered', () {
+      expect(
+        webSocketConnectionWasStable(
+          connectedAt,
+          connectedAt.add(kWsConnectionStableAfter),
+        ),
+        isTrue,
+      );
+    });
+
+    test('an accept-then-close session does not reset the ladder', () {
+      // The reconnect-storm shape: the handshake succeeds but the connection is
+      // gone milliseconds later.
+      expect(
+        webSocketConnectionWasStable(
+          connectedAt,
+          connectedAt.add(const Duration(milliseconds: 20)),
+        ),
+        isFalse,
+      );
+    });
+
+    test('a session just short of the threshold does not reset the ladder', () {
+      expect(
+        webSocketConnectionWasStable(
+          connectedAt,
+          connectedAt.add(kWsConnectionStableAfter - const Duration(seconds: 1)),
+        ),
+        isFalse,
+      );
+    });
+
+    test('a clock that jumps backwards does not reset the ladder', () {
+      expect(
+        webSocketConnectionWasStable(
+          connectedAt,
+          connectedAt.subtract(const Duration(minutes: 5)),
+        ),
+        isFalse,
+      );
+    });
+
+    test('honours an explicit threshold', () {
+      final closedAt = connectedAt.add(const Duration(seconds: 5));
+      expect(
+        webSocketConnectionWasStable(
+          connectedAt,
+          closedAt,
+          threshold: const Duration(seconds: 2),
+        ),
+        isTrue,
+      );
+      expect(
+        webSocketConnectionWasStable(
+          connectedAt,
+          closedAt,
+          threshold: const Duration(seconds: 10),
+        ),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Fixes #1759 and #1760.

### Changes

- Add delayed WebSocket auto-reconnect with exponential backoff, equal jitter,
  and a cap of `kWsMaxReconnectAttempts` consecutive attempts.
- Drive reconnects solely from a single pending `Timer` per request id, so
  repeated closes can no longer fan out into overlapping connections.
- Cancel a queued reconnect when the request is manually disconnected, removed,
  or the notifier is disposed. If auto-reconnect is switched off mid-backoff,
  the timer re-checks intent when it fires and abandons the attempt.
- Retry a refused reconnect on the same ladder rather than treating it as
  terminal, so a temporarily unavailable server is retried instead of dropping
  the session on the first failure. A failed initial connect remains terminal.
- Reset the ladder only on user intent or a connection that lasted
  `kWsConnectionStableAfter`, never on a bare handshake. This prevents an
  accept-then-immediately-close server from retrying at a fixed rate forever.
- Bound `messageHistory` to `kMaxWebSocketMessages` via the new
  `appendWebSocketMessage(s)` helpers in `lib/utils/websocket_utils.dart`,
  preventing unbounded history growth and repeated large list copies.
- Reconnect status messages now include the delay and attempt number, and a
  terminal error is shown when the retry cap is reached.
- Add offline loopback regression tests for reconnect behaviour and
  message-history retention.
- Update `AGENTS.md` and `doc/dev_guide/architecture.md` for the new policies.

### Verification

- `dart analyze` reports no errors and no new diagnostics in the changed files.
  The repository still has pre-existing warnings/infos in unrelated files.
- `flutter test test/utils/websocket_utils_test.dart test/providers/ws_reconnect_and_cap_test.dart`
  — 32/32 tests pass.
- Full-suite pre-existing failures were not re-run in this final verification.

This contribution was AI-assisted.