### PR TITLE
Fix #1765: Prevent stale WebSocket connections from causing resource …

### DIFF
--- a/lib/services/connection_manager.dart
+++ b/lib/services/connection_manager.dart
@@ -25,6 +25,8 @@ class ConnectionManager {
   /// does not expose the inner socket).
   final Map<String, WebSocket> _sockets = {};
 
+  final Map<String, Object> _connectionTokens = {};
+
   /// Whether there is an active connection for [requestId].
   bool hasConnection(String requestId) => _channels.containsKey(requestId);
 
@@ -50,7 +52,15 @@ class ConnectionManager {
     // IOWebSocketChannel.connect) so we keep a reference to the underlying
     // socket. WebSocket.pingInterval is mutable at runtime, which lets us
     // change the heartbeat on a live connection (see [updatePingInterval]).
+    final currentToken =
+        Object(); // A totally unique ID for this specific attempt
+    _connectionTokens[requestId] = currentToken;
     final webSocket = await WebSocket.connect(url, headers: headers);
+    // If the token changed while the connection was being established, abort.
+    if (_connectionTokens[requestId] != currentToken) {
+      webSocket.close();
+      throw StateError('Stable connection attempt aborted');
+    }
     webSocket.pingInterval = pingInterval;
     final channel = IOWebSocketChannel(webSocket);
     _channels[requestId] = channel;

--- a/test/widgets/window_caption_test.dart
+++ b/test/widgets/window_caption_test.dart
@@ -32,6 +32,8 @@ void main() {
         }
         if (methodCall.method == 'close') return true;
         if (methodCall.method == 'startDragging') return true;
+        if (methodCall.method == 'isFullScreen') return false;
+        if (methodCall.method == 'isPreventClose') return false;
         return null;
       },
     );


### PR DESCRIPTION
Closes:  #1765

What changed?

Introduced a _connectionTokens map in ConnectionManager to track unique generation IDs for every connect() attempt.
Before establishing a new WebSocket.connect, a unique Object() token is generated.
After the asynchronous connection completes, the token is verified. If the token no longer matches, the connection attempt is considered stale (e.g. the user clicked "Connect" rapidly multiple times) and the socket is immediately closed, throwing a StateError.
Also patched a failing mock in window_caption_test.dart to fix type 'Null' is not a subtype of type 'FutureOr<bool>' on the main branch.
Why was this changed? Previously, concurrent connection attempts could overwrite the active channel in _channels, leaving the older connection alive but completely untracked. This orphaned socket could lead to duplicate incoming events and memory/resource leaks.
