### PR TITLE
fix: safely handle stale activeEnvironmentId in getVariableStatus

### DIFF
--- a/lib/utils/envvar_utils.dart
+++ b/lib/utils/envvar_utils.dart
@@ -249,7 +249,7 @@ EnvironmentVariableSuggestion getVariableStatus(
     String key,
     Map<String, List<EnvironmentVariableModel>> envMap,
     String? activeEnvironmentId) {
-  if (activeEnvironmentId != null) {
+  if (activeEnvironmentId != null && envMap[activeEnvironmentId] != null) {
     final variable =
         envMap[activeEnvironmentId]!.firstWhereOrNull((v) => v.key == key);
     if (variable != null) {

--- a/test/utils/envvar_utils_test.dart
+++ b/test/utils/envvar_utils_test.dart
@@ -438,6 +438,40 @@ void main() {
       );
       expect(getVariableStatus(query, envMap, activeEnvironmentId), expected);
     });
+
+    test(
+        "Testing getVariableStatus with stale activeEnvironmentId not in envMap",
+        () {
+      const query = "num";
+      Map<String, List<EnvironmentVariableModel>> envMap = {
+        kGlobalEnvironmentId: globalVars,
+        "activeEnvId": activeEnvVars,
+      };
+      const staleActiveEnvironmentId = "deletedEnvId";
+      const expected = EnvironmentVariableSuggestion(
+        environmentId: kGlobalEnvironmentId,
+        variable: EnvironmentVariableModel(key: "num", value: "5670000"),
+      );
+      expect(
+        getVariableStatus(query, envMap, staleActiveEnvironmentId),
+        expected,
+      );
+    });
+
+    test(
+        "Testing getVariableStatus with null activeEnvironmentId falls back to global",
+        () {
+      const query = "token";
+      Map<String, List<EnvironmentVariableModel>> envMap = {
+        kGlobalEnvironmentId: globalVars,
+        "activeEnvId": activeEnvVars,
+      };
+      const expected = EnvironmentVariableSuggestion(
+        environmentId: kGlobalEnvironmentId,
+        variable: EnvironmentVariableModel(key: "token", value: "token"),
+      );
+      expect(getVariableStatus(query, envMap, null), expected);
+    });
   });
 
   group("Testing auth model environment variable substitution", () {


### PR DESCRIPTION
## Summary
`getVariableStatus` in `lib/utils/envvar_utils.dart` force-unwrapped `envMap[activeEnvironmentId]` with `!`. Since `Map[key]` returns `V?` (null when the key is absent), this threw:

```
Null check operator used on a null value
```

whenever `activeEnvironmentId` was non-null but missing from `envMap` — for example, when an environment was deleted while still set as the active environment. The null check on the original line only guarded `activeEnvironmentId != null`, not that the key exists in the map.

## Fix
Guard the lookup with a key-existence check (`envMap[activeEnvironmentId] != null`), matching the existing pattern already used by `getEnvironmentTriggerSuggestions` in the same file. When the key is absent, the function now falls through to the global-environment lookup and the unknown fallback instead of crashing.

## Verification
Added regression tests to `test/utils/envvar_utils_test.dart`:
- `getVariableStatus` with a stale `activeEnvironmentId` not present in `envMap` (the crash path) → falls back to global
- `getVariableStatus` with `null` `activeEnvironmentId` → falls back to global

`flutter test test/utils/envvar_utils_test.dart` → **All tests passed!** (39 tests, including the 2 new ones).

Fixes #1740.