### PR TITLE
feat: watch JSON values in WebSocket responses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,6 +280,8 @@ Hive boxes:
 - Desktop uses `Dashboard` with a navigation rail and `IndexedStack`.
 - Mobile uses `MobileDashboard`, `PageBranch`, bottom navigation, and mobile-specific request/response pages.
 - `HomePage` switches between `DashboardSplitView` and mobile `RequestResponsePage` using `context.isMediumWindow`.
+- WebSocket responses use `RealtimeEventStreamView`; its optional JSON watch mode renders a timestamped value series without modifying stored message history.
+- JSON watch parsing belongs in `lib/utils/json_watch_utils.dart`. Plain keys search recursively; explicit JSONPath selectors support child keys, bracket keys, array indexes, wildcards, and recursive child keys.
 - Reusable design primitives belong in `packages/apidash_design_system`.
 - Feature widgets belong near their feature under `lib/screens/` or in `lib/widgets/` when they are truly reusable.
 - Preserve desktop and mobile behavior unless the task is explicitly platform-scoped.

--- a/doc/dev_guide/architecture.md
+++ b/doc/dev_guide/architecture.md
@@ -257,6 +257,10 @@ Key differences:
 - **Desktop:** Resizable split pane with collection sidebar and editor side-by-side. Drag handles for reordering.
 - **Mobile:** Tab-based navigation with full-screen views. Long-press for drag-to-reorder with a delay for scroll disambiguation.
 
+### WebSocket response inspection
+
+`RealtimeEventStreamView` displays the stored WebSocket message history on both desktop and mobile. Its JSON watch control can switch the response pane to a timestamped series extracted from received JSON messages. The watch expression is view-local state, so enabling or clearing it never changes the persisted request or its full message history. Plain keys search nested objects recursively, while explicit JSONPath expressions are evaluated by `lib/utils/json_watch_utils.dart`.
+
 ## Key Patterns
 
 ### UUID Generation

--- a/lib/screens/home_page/editor_pane/details_card/realtime_event_stream_view.dart
+++ b/lib/screens/home_page/editor_pane/details_card/realtime_event_stream_view.dart
@@ -3,7 +3,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:apidash/providers/providers.dart';
 import 'package:apidash/models/ws_request_model.dart';
+import 'package:apidash/utils/json_watch_utils.dart';
 import 'package:apidash/widgets/button_copy.dart';
+import 'realtime_json_watch_view.dart';
 /// A real-time, log-style view of WebSocket messages.
 ///
 /// Each entry shows direction (sent / received), a timestamp, a label, and
@@ -23,6 +25,7 @@ class RealtimeEventStreamView extends ConsumerStatefulWidget {
 class _RealtimeEventStreamViewState extends ConsumerState<RealtimeEventStreamView> {
   final TextEditingController _filterController = TextEditingController();
   String _filterQuery = "";
+  String _watchExpression = "";
 
   @override
   void dispose() {
@@ -83,6 +86,20 @@ class _RealtimeEventStreamViewState extends ConsumerState<RealtimeEventStreamVie
               },
             ),
           ),
+          kHSpacer5,
+          IconButton(
+            key: const ValueKey('websocket-watch-button'),
+            icon: Icon(
+              _watchExpression.isEmpty
+                  ? Icons.visibility_outlined
+                  : Icons.visibility,
+              size: 18,
+            ),
+            tooltip: _watchExpression.isEmpty
+                ? 'Watch a JSON value'
+                : 'Watching $_watchExpression',
+            onPressed: () => _configureWatch(context),
+          ),
           if (widget.historyMessages == null) ...[
             kHSpacer5,
             IconButton(
@@ -111,10 +128,36 @@ class _RealtimeEventStreamViewState extends ConsumerState<RealtimeEventStreamVie
                     style: TextStyle(color: Colors.grey),
                   ),
                 )
+              : _watchExpression.isNotEmpty
+              ? RealtimeJsonWatchView(
+                  history: history,
+                  expression: _watchExpression,
+                  maxEvents: maxEvents,
+                )
               : _buildLogView(context, displayHistory),
         ),
       ],
     );
+  }
+
+  Future<void> _configureWatch(BuildContext context) async {
+    final expression = await showJsonWatchDialog(
+      context,
+      currentExpression: _watchExpression,
+    );
+    if (expression == null || !mounted) return;
+
+    final validationError = expression.isEmpty
+        ? null
+        : validateJsonWatchExpression(expression);
+    if (validationError != null) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text(validationError)));
+      }
+      return;
+    }
+    setState(() => _watchExpression = expression);
   }
 
   Widget _buildLogView(

--- a/lib/screens/home_page/editor_pane/details_card/realtime_json_watch_view.dart
+++ b/lib/screens/home_page/editor_pane/details_card/realtime_json_watch_view.dart
@@ -1,0 +1,164 @@
+import 'package:apidash/models/ws_request_model.dart';
+import 'package:apidash/utils/json_watch_utils.dart';
+import 'package:apidash/widgets/button_copy.dart';
+import 'package:apidash_design_system/apidash_design_system.dart';
+import 'package:flutter/material.dart';
+
+Future<String?> showJsonWatchDialog(
+  BuildContext context, {
+  required String currentExpression,
+}) async {
+  var draftExpression = currentExpression;
+  return showDialog<String>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: const Text('Watch a JSON value'),
+      content: TextFormField(
+        key: const ValueKey('websocket-watch-field'),
+        initialValue: draftExpression,
+        autofocus: true,
+        decoration: const InputDecoration(
+          hintText: r'Key or JSONPath, for example $.price',
+          helperText: 'Plain keys search nested objects automatically.',
+        ),
+        onChanged: (value) => draftExpression = value,
+        onFieldSubmitted: (value) => Navigator.pop(context, value.trim()),
+      ),
+      actions: [
+        if (currentExpression.isNotEmpty)
+          TextButton(
+            onPressed: () => Navigator.pop(context, ''),
+            child: const Text('Stop watching'),
+          ),
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.pop(context, draftExpression.trim()),
+          child: const Text('Watch'),
+        ),
+      ],
+    ),
+  );
+}
+
+class RealtimeJsonWatchView extends StatelessWidget {
+  const RealtimeJsonWatchView({
+    super.key,
+    required this.history,
+    required this.expression,
+    required this.maxEvents,
+  });
+
+  final List<WebSocketMessage> history;
+  final String expression;
+  final int maxEvents;
+
+  @override
+  Widget build(BuildContext context) {
+    final matches = <_WatchedValue>[];
+    for (final message in history) {
+      if (message.messageType != WebSocketMessageType.received) continue;
+      final result = extractJsonWatchValue(message.payload, expression);
+      if (result.found) {
+        matches.add(
+          _WatchedValue(
+            timestamp: message.timestamp,
+            displayValue: result.displayValue,
+          ),
+        );
+      }
+    }
+
+    final visibleMatches = matches.length > maxEvents
+        ? matches.sublist(matches.length - maxEvents)
+        : matches;
+    if (visibleMatches.isEmpty) {
+      return Center(
+        child: Text(
+          'No values found for "$expression" in received JSON messages.',
+          textAlign: TextAlign.center,
+        ),
+      );
+    }
+
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Row(
+            children: [
+              Text('Time', style: Theme.of(context).textTheme.labelMedium),
+              const SizedBox(width: 32),
+              Expanded(
+                child: Text(
+                  '$expression (${visibleMatches.length})',
+                  style: Theme.of(context).textTheme.labelMedium,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+        ),
+        const Divider(height: 1),
+        Expanded(
+          child: ListView.builder(
+            itemCount: visibleMatches.length,
+            itemBuilder: (context, index) {
+              final match = visibleMatches[visibleMatches.length - 1 - index];
+              return _WatchValueRow(value: match);
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _WatchedValue {
+  const _WatchedValue({required this.timestamp, required this.displayValue});
+
+  final DateTime? timestamp;
+  final String displayValue;
+}
+
+class _WatchValueRow extends StatelessWidget {
+  const _WatchValueRow({required this.value});
+
+  final _WatchedValue value;
+
+  @override
+  Widget build(BuildContext context) {
+    final timestamp = value.timestamp;
+    final time = timestamp == null
+        ? '--:--:--'
+        : '${timestamp.hour.toString().padLeft(2, '0')}:'
+              '${timestamp.minute.toString().padLeft(2, '0')}:'
+              '${timestamp.second.toString().padLeft(2, '0')}';
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 72,
+            child: Text(
+              time,
+              style: kCodeStyle.copyWith(fontSize: 12, color: Colors.grey),
+            ),
+          ),
+          Expanded(
+            child: SelectableText(
+              value.displayValue,
+              key: ValueKey('watched-value-${value.displayValue}'),
+              style: kCodeStyle.copyWith(fontSize: 12),
+            ),
+          ),
+          CopyButton(toCopy: value.displayValue, showLabel: false),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/utils/json_watch_utils.dart
+++ b/lib/utils/json_watch_utils.dart
@@ -1,0 +1,258 @@
+import 'dart:convert';
+
+/// The result of evaluating a JSON watch expression against one message.
+class JsonWatchResult {
+  const JsonWatchResult._({this.value, required this.found, this.error});
+
+  const JsonWatchResult.found(Object? value)
+    : this._(value: value, found: true);
+
+  const JsonWatchResult.notFound() : this._(found: false);
+
+  const JsonWatchResult.invalid(String error)
+    : this._(found: false, error: error);
+
+  final Object? value;
+  final bool found;
+  final String? error;
+
+  String get displayValue {
+    final currentValue = value;
+    if (currentValue is String) return currentValue;
+    return jsonEncode(currentValue);
+  }
+}
+
+/// Validates the key or JSONPath syntax accepted by [extractJsonWatchValue].
+String? validateJsonWatchExpression(String expression) {
+  try {
+    _JsonWatchExpression.parse(expression);
+    return null;
+  } on FormatException catch (error) {
+    return error.message;
+  }
+}
+
+/// Extracts a watched value from a JSON WebSocket [payload].
+///
+/// A plain key such as `price` searches recursively for matching keys.
+/// JSONPath expressions support root (`$`), child (`.name`), bracket-key
+/// (`['name']`), array-index (`[0]`), wildcard (`[*]`), and recursive child
+/// (`..name`) selectors. Multiple matches are returned as a list.
+JsonWatchResult extractJsonWatchValue(String payload, String expression) {
+  final _JsonWatchExpression parsedExpression;
+  try {
+    parsedExpression = _JsonWatchExpression.parse(expression);
+  } on FormatException catch (error) {
+    return JsonWatchResult.invalid(error.message);
+  }
+
+  final Object? decoded;
+  try {
+    decoded = jsonDecode(payload);
+  } on FormatException {
+    return const JsonWatchResult.invalid('Message is not valid JSON');
+  }
+
+  final values = parsedExpression.evaluate(decoded);
+  if (values.isEmpty) return const JsonWatchResult.notFound();
+  if (values.length == 1) return JsonWatchResult.found(values.single);
+  return JsonWatchResult.found(values);
+}
+
+enum _JsonWatchTokenType { key, arrayIndex, wildcard, recursiveKey }
+
+class _JsonWatchToken {
+  const _JsonWatchToken(this.type, this.value);
+
+  final _JsonWatchTokenType type;
+  final Object? value;
+}
+
+class _JsonWatchExpression {
+  const _JsonWatchExpression(this.tokens);
+
+  final List<_JsonWatchToken> tokens;
+
+  static _JsonWatchExpression parse(String source) {
+    final expression = source.trim();
+    if (expression.isEmpty) {
+      throw const FormatException('Enter a key or JSONPath');
+    }
+
+    final hasPathSyntax =
+        expression.startsWith(r'$') ||
+        expression.contains('.') ||
+        expression.contains('[') ||
+        expression.contains(']');
+    if (!hasPathSyntax) {
+      return _JsonWatchExpression([
+        _JsonWatchToken(_JsonWatchTokenType.recursiveKey, expression),
+      ]);
+    }
+
+    final tokens = <_JsonWatchToken>[];
+    var index = expression.startsWith(r'$') ? 1 : 0;
+
+    while (index < expression.length) {
+      if (expression[index] == '.') {
+        final recursive =
+            index + 1 < expression.length && expression[index + 1] == '.';
+        index += recursive ? 2 : 1;
+        final parsedKey = _readKey(expression, index);
+        if (parsedKey.$1.isEmpty) {
+          throw const FormatException('Expected a key after "."');
+        }
+        tokens.add(
+          _JsonWatchToken(
+            recursive
+                ? _JsonWatchTokenType.recursiveKey
+                : _JsonWatchTokenType.key,
+            parsedKey.$1,
+          ),
+        );
+        index = parsedKey.$2;
+        continue;
+      }
+
+      if (expression[index] == '[') {
+        final closeIndex = _findBracketEnd(expression, index);
+        if (closeIndex == -1) {
+          throw const FormatException('Missing closing "]"');
+        }
+        final content = expression.substring(index + 1, closeIndex).trim();
+        if (content == '*') {
+          tokens.add(const _JsonWatchToken(_JsonWatchTokenType.wildcard, null));
+        } else if (RegExp(r'^\d+$').hasMatch(content)) {
+          tokens.add(
+            _JsonWatchToken(_JsonWatchTokenType.arrayIndex, int.parse(content)),
+          );
+        } else {
+          final key = _parseBracketKey(content);
+          tokens.add(_JsonWatchToken(_JsonWatchTokenType.key, key));
+        }
+        index = closeIndex + 1;
+        continue;
+      }
+
+      final parsedKey = _readKey(expression, index);
+      if (parsedKey.$1.isEmpty) {
+        throw FormatException(
+          'Unexpected character "${expression[index]}" at position $index',
+        );
+      }
+      tokens.add(_JsonWatchToken(_JsonWatchTokenType.key, parsedKey.$1));
+      index = parsedKey.$2;
+    }
+
+    return _JsonWatchExpression(tokens);
+  }
+
+  List<Object?> evaluate(Object? root) {
+    var currentValues = <Object?>[root];
+    for (final token in tokens) {
+      final nextValues = <Object?>[];
+      for (final currentValue in currentValues) {
+        switch (token.type) {
+          case _JsonWatchTokenType.key:
+            if (currentValue is Map && currentValue.containsKey(token.value)) {
+              nextValues.add(currentValue[token.value]);
+            }
+          case _JsonWatchTokenType.arrayIndex:
+            final index = token.value! as int;
+            if (currentValue is List && index < currentValue.length) {
+              nextValues.add(currentValue[index]);
+            }
+          case _JsonWatchTokenType.wildcard:
+            if (currentValue is List) {
+              nextValues.addAll(currentValue);
+            } else if (currentValue is Map) {
+              nextValues.addAll(currentValue.values);
+            }
+          case _JsonWatchTokenType.recursiveKey:
+            _findRecursiveValues(
+              currentValue,
+              token.value! as String,
+              nextValues,
+            );
+        }
+      }
+      currentValues = nextValues;
+      if (currentValues.isEmpty) break;
+    }
+    return currentValues;
+  }
+}
+
+(String, int) _readKey(String expression, int start) {
+  var index = start;
+  while (index < expression.length &&
+      expression[index] != '.' &&
+      expression[index] != '[' &&
+      expression[index] != ']') {
+    index++;
+  }
+  return (expression.substring(start, index).trim(), index);
+}
+
+int _findBracketEnd(String expression, int start) {
+  String? quote;
+  var escaped = false;
+  for (var index = start + 1; index < expression.length; index++) {
+    final character = expression[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character == r'\') {
+      escaped = true;
+      continue;
+    }
+    if (quote != null) {
+      if (character == quote) quote = null;
+      continue;
+    }
+    if (character == '"' || character == "'") {
+      quote = character;
+    } else if (character == ']') {
+      return index;
+    }
+  }
+  return -1;
+}
+
+String _parseBracketKey(String content) {
+  if (content.length < 2 ||
+      !((content.startsWith('"') && content.endsWith('"')) ||
+          (content.startsWith("'") && content.endsWith("'")))) {
+    throw const FormatException(
+      'Bracket keys must be quoted, for example [\'price\']',
+    );
+  }
+
+  if (content.startsWith('"')) {
+    try {
+      return jsonDecode(content) as String;
+    } on FormatException {
+      throw const FormatException('Invalid quoted bracket key');
+    }
+  }
+
+  return content
+      .substring(1, content.length - 1)
+      .replaceAll(r"\'", "'")
+      .replaceAll(r'\\', r'\');
+}
+
+void _findRecursiveValues(Object? value, String key, List<Object?> matches) {
+  if (value is Map) {
+    if (value.containsKey(key)) matches.add(value[key]);
+    for (final child in value.values) {
+      _findRecursiveValues(child, key, matches);
+    }
+  } else if (value is List) {
+    for (final child in value) {
+      _findRecursiveValues(child, key, matches);
+    }
+  }
+}

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -6,6 +6,7 @@ export 'header_utils.dart';
 export 'history_utils.dart';
 export 'http_utils.dart';
 export 'js_utils.dart';
+export 'json_watch_utils.dart';
 export 'save_utils.dart';
 export 'ui_utils.dart';
 export 'validation_utils.dart';

--- a/test/screens/home_page/editor_pane/realtime_event_stream_view_test.dart
+++ b/test/screens/home_page/editor_pane/realtime_event_stream_view_test.dart
@@ -1,0 +1,103 @@
+import 'package:apidash/models/ws_request_model.dart';
+import 'package:apidash/screens/home_page/editor_pane/details_card/realtime_event_stream_view.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('watches a JSON value across received messages', (tester) async {
+    final messages = [
+      WebSocketMessage(
+        payload: '{"ticker":{"price":10}}',
+        timestamp: DateTime(2026, 8, 24, 10, 0, 1),
+        outgoing: false,
+        messageType: WebSocketMessageType.received,
+      ),
+      WebSocketMessage(
+        payload: '{"ticker":{"price":999}}',
+        timestamp: DateTime(2026, 8, 24, 10, 0, 2),
+        messageType: WebSocketMessageType.sent,
+      ),
+      WebSocketMessage(
+        payload: '{"ticker":{"price":20}}',
+        timestamp: DateTime(2026, 8, 24, 10, 0, 3),
+        outgoing: false,
+        messageType: WebSocketMessageType.received,
+      ),
+    ];
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 600,
+              height: 500,
+              child: RealtimeEventStreamView(historyMessages: messages),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const ValueKey('websocket-watch-button')));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('websocket-watch-field')),
+      'price',
+    );
+    await tester.tap(find.widgetWithText(FilledButton, 'Watch'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('price (2)'), findsOneWidget);
+    expect(find.byKey(const ValueKey('watched-value-10')), findsOneWidget);
+    expect(find.byKey(const ValueKey('watched-value-20')), findsOneWidget);
+    expect(find.byKey(const ValueKey('watched-value-999')), findsNothing);
+    expect(find.text('10:00:03'), findsOneWidget);
+  });
+
+  testWidgets('stopping a watch restores the full event stream', (
+    tester,
+  ) async {
+    const payload = '{"price":10}';
+    final messages = [
+      WebSocketMessage(
+        payload: payload,
+        timestamp: DateTime(2026, 8, 24, 10),
+        outgoing: false,
+        messageType: WebSocketMessageType.received,
+      ),
+    ];
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 600,
+              height: 500,
+              child: RealtimeEventStreamView(historyMessages: messages),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const ValueKey('websocket-watch-button')));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('websocket-watch-field')),
+      'price',
+    );
+    await tester.tap(find.widgetWithText(FilledButton, 'Watch'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('websocket-watch-button')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, 'Stop watching'));
+    await tester.pumpAndSettle();
+
+    expect(find.text(payload), findsOneWidget);
+    expect(find.text('price (1)'), findsNothing);
+  });
+}

--- a/test/utils/json_watch_utils_test.dart
+++ b/test/utils/json_watch_utils_test.dart
@@ -1,0 +1,90 @@
+import 'package:apidash/utils/json_watch_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('extractJsonWatchValue', () {
+    test('recursively finds a plain key', () {
+      final result = extractJsonWatchValue(
+        '{"ticker":{"price":42.5}}',
+        'price',
+      );
+
+      expect(result.found, isTrue);
+      expect(result.value, 42.5);
+      expect(result.error, isNull);
+    });
+
+    test('evaluates dot and array-index JSONPath selectors', () {
+      final result = extractJsonWatchValue(
+        '{"items":[{"price":10},{"price":20}]}',
+        r'$.items[1].price',
+      );
+
+      expect(result.found, isTrue);
+      expect(result.value, 20);
+    });
+
+    test('evaluates quoted bracket keys', () {
+      final result = extractJsonWatchValue(
+        '{"market data":{"last-price":99}}',
+        r"$['market data']['last-price']",
+      );
+
+      expect(result.value, 99);
+    });
+
+    test('returns every wildcard match', () {
+      final result = extractJsonWatchValue(
+        '{"items":[{"price":10},{"price":20}]}',
+        r'$.items[*].price',
+      );
+
+      expect(result.value, [10, 20]);
+      expect(result.displayValue, '[10,20]');
+    });
+
+    test('evaluates recursive child selectors', () {
+      final result = extractJsonWatchValue(
+        '{"price":1,"nested":{"price":2}}',
+        r'$..price',
+      );
+
+      expect(result.value, [1, 2]);
+    });
+
+    test('distinguishes JSON null from a missing match', () {
+      final nullResult = extractJsonWatchValue('{"price":null}', 'price');
+      final missingResult = extractJsonWatchValue('{"other":1}', 'price');
+
+      expect(nullResult.found, isTrue);
+      expect(nullResult.displayValue, 'null');
+      expect(missingResult.found, isFalse);
+      expect(missingResult.error, isNull);
+    });
+
+    test('reports invalid JSON without throwing', () {
+      final result = extractJsonWatchValue('not-json', 'price');
+
+      expect(result.found, isFalse);
+      expect(result.error, 'Message is not valid JSON');
+    });
+
+    test('reports invalid JSONPath without throwing', () {
+      final result = extractJsonWatchValue('{"price":1}', r'$.items[');
+
+      expect(result.found, isFalse);
+      expect(result.error, 'Missing closing "]"');
+    });
+  });
+
+  group('validateJsonWatchExpression', () {
+    test('accepts plain keys and supported JSONPath forms', () {
+      expect(validateJsonWatchExpression('price'), isNull);
+      expect(validateJsonWatchExpression(r'$.items[*].price'), isNull);
+    });
+
+    test('rejects empty expressions', () {
+      expect(validateJsonWatchExpression('  '), 'Enter a key or JSONPath');
+    });
+  });
+}


### PR DESCRIPTION
## PR Description

Adds an optional JSON value watch mode to the WebSocket realtime response view.

- Open the watch control from the response toolbar and enter either a plain key (for recursive lookup) or a JSONPath expression.
- Supports root, child, bracket-key, array-index, wildcard, and recursive-child selectors.
- Shows matching values from received JSON messages as a newest-first timestamped series with per-value copy actions.
- Ignores sent, non-JSON, and non-matching messages without disrupting the stream.
- Keeps the watch expression as view-local state, so the complete stored message history remains unchanged and can be restored immediately by stopping the watch.

This contribution was developed with AI assistance. The implementation and tests were reviewed and validated locally by the contributor.

## Related Issues

- Closes #1748

## Video Demo

<img width="900" height="620" alt="WebSocket JSON value watch demo" src="https://github.com/user-attachments/assets/3212a712-5e33-411d-bffd-219e0996b8a8" />

### Checklist

- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (Flutter 3.47.1)
- [ ] I have run the tests (`flutter test`) and all tests are passing

The full root suite reached 2,207 passing tests (one skipped) before the existing `ConnectionManager — error / abnormal-close edges connecting to an unreachable endpoint` test failed because `WebSocket.connect` surfaced the localhost connection-refused error directly. The focused and surrounding suites pass:

- `flutter test --no-pub test/utils/json_watch_utils_test.dart test/screens/home_page/editor_pane/realtime_event_stream_view_test.dart` (12 passed)
- `flutter test --no-pub test/screens/home_page/editor_pane/response_pane_test.dart test/screens/history/history_widgets/his_response_pane_test.dart` (6 passed)
- Targeted `flutter analyze --no-pub` for all changed Dart source/test files (no issues)

Full-repository analysis currently reports pre-existing findings outside this change; all changed Dart files analyze cleanly.

## Added/updated tests?

- [x] Yes
- [ ] No

Added parser coverage for supported selectors, null/missing values, malformed payloads and invalid paths, plus widget coverage for received-only extraction and restoring the original event stream.

## OS on which you have developed and tested the feature?

- [ ] Windows
- [x] macOS
- [ ] Linux

