### PR TITLE
fix: preserve non-request data when clearing requests

### DIFF
--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -1070,11 +1070,11 @@ class CollectionStateNotifier
 
   Future<void> clearData() async {
     ref.read(clearDataStateProvider.notifier).state = true;
+    await hiveHandler.clearRequestData();
     ref.read(selectedIdStateProvider.notifier).state = null;
-    await hiveHandler.clear();
-    ref.read(clearDataStateProvider.notifier).state = false;
     ref.read(requestSequenceProvider.notifier).state = [];
     state = {};
+    ref.read(clearDataStateProvider.notifier).state = false;
     unsave();
   }
 

--- a/lib/screens/settings_page.dart
+++ b/lib/screens/settings_page.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:apidash_design_system/apidash_design_system.dart';
 import '../providers/providers.dart';
-import '../services/services.dart';
 import '../utils/utils.dart';
 import '../widgets/widgets.dart';
 import '../consts.dart';
@@ -249,7 +248,6 @@ class SettingsPage extends ConsumerWidget {
                               TextButton(
                                 onPressed: () async {
                                   Navigator.pop(context, 'Yes');
-                                  await clearSharedPrefs();
                                   await ref
                                       .read(
                                         collectionStateNotifierProvider

--- a/lib/services/hive_services.dart
+++ b/lib/services/hive_services.dart
@@ -168,12 +168,8 @@ class HiveHandler {
     await historyLazyBox.clear();
   }
 
-  Future clear() async {
+  Future<void> clearRequestData() async {
     await dataBox.clear();
-    await environmentBox.clear();
-    await historyMetaBox.clear();
-    await historyLazyBox.clear();
-    await dashBotBox.clear();
   }
 
   Future<void> removeUnused() async {

--- a/test/providers/clear_data_test.dart
+++ b/test/providers/clear_data_test.dart
@@ -1,0 +1,74 @@
+import 'package:apidash/consts.dart';
+import 'package:apidash/models/models.dart';
+import 'package:apidash/providers/providers.dart';
+import 'package:apidash/services/services.dart';
+import 'package:apidash_core/apidash_core.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'helpers.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await testSetUpTempDirForHive();
+    await clearHiveBoxes();
+  });
+
+  test('clearData only clears request collection data', () async {
+    const request = RequestModel(
+      id: 'request-id',
+      httpRequestModel: HttpRequestModel(),
+    );
+    const globalEnvironment = EnvironmentModel(
+      id: kGlobalEnvironmentId,
+      name: 'Global',
+      values: [
+        EnvironmentVariableModel(
+          key: 'baseUrl',
+          value: 'https://example.com',
+          enabled: true,
+        ),
+      ],
+    );
+
+    await hiveHandler.setIds(['request-id']);
+    await hiveHandler.setRequestModel('request-id', request.toJson());
+    await hiveHandler.setEnvironmentIds([kGlobalEnvironmentId]);
+    await hiveHandler.setEnvironment(
+      kGlobalEnvironmentId,
+      globalEnvironment.toJson(),
+    );
+    await hiveHandler.setHistoryIds(['history-id']);
+    await hiveHandler.setHistoryMeta('history-id', {'id': 'history-id'});
+    await hiveHandler.setHistoryRequest('history-id', {'id': 'history-id'});
+    await hiveHandler.saveDashbotMessages('saved messages');
+
+    final container = createContainer();
+    final notifier = container.read(collectionStateNotifierProvider.notifier);
+    container.read(environmentsStateNotifierProvider.notifier);
+
+    await notifier.clearData();
+
+    expect(hiveHandler.getIds(), isNull);
+    expect(hiveHandler.getRequestModel('request-id'), isNull);
+    expect(hiveHandler.getEnvironmentIds(), [kGlobalEnvironmentId]);
+    expect(hiveHandler.getEnvironment(kGlobalEnvironmentId), isNotNull);
+    expect(hiveHandler.getHistoryIds(), ['history-id']);
+    expect(hiveHandler.getHistoryMeta('history-id'), isNotNull);
+    expect(await hiveHandler.getHistoryRequest('history-id'), isNotNull);
+    expect(await hiveHandler.getDashbotMessages(), 'saved messages');
+    expect(container.read(requestSequenceProvider), isEmpty);
+    expect(container.read(selectedIdStateProvider), isNull);
+    expect(container.read(collectionStateNotifierProvider), isEmpty);
+    expect(
+      container
+          .read(
+            availableEnvironmentVariablesStateProvider,
+          )[kGlobalEnvironmentId]
+          ?.single
+          .key,
+      'baseUrl',
+    );
+  });
+}


### PR DESCRIPTION
## PR Description

The Clear Data UI promises to delete request data, but the previous implementation cleared every Hive box and all shared preferences while resetting only the in-memory request collection. That removed persisted environments, history, Dashbot data, and settings even though those values remained active in memory until restart.

This change aligns the implementation with the existing UI contract by:

- clearing only the persisted request collection
- preserving environments (including Global variables), history, Dashbot data, and settings
- resetting the request selection and sequence after the asynchronous disk clear, avoiding an initialization race that could restore a stale selected request ID
- adding a regression test that seeds each Hive store and verifies only request data is removed while the active Global variable remains available

AI assistance disclosure: OpenAI Codex was used to help investigate, implement, and test this fix. The resulting diff and test behavior were reviewed before submission.

## Related Issues

- Fixes #1770

## Video Demo

- Not included. This is a persistence-scope fix covered by an automated regression test.

### Checklist

- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (Flutter 3.47.1, stable)
- [ ] I have run the tests (`flutter test`) and all tests are passing

Test results:

- `flutter test --no-pub test/providers/clear_data_test.dart` passes.
- `flutter analyze --no-pub` on all changed files reports no issues.
- The full suite reached 2,196 passing tests (plus 1 skipped) and hit one unrelated existing failure in `test/services/connection_manager_test.dart`: the closed-port WebSocket test expects `channel.ready` to reject, but this Flutter/macOS runtime throws `SocketException` during `connect()` instead. No connection-manager code is touched here.
- Repository-wide analysis reports existing warnings/information outside this diff; changed files are clean.

## Added/updated tests?

- [x] Yes
- [ ] No

## OS on which you have developed and tested the feature?

- [ ] Windows
- [x] macOS
- [ ] Linux