### PR TITLE
GSoC-26-borgy: Agentic Testing- In App

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,38 +2,85 @@ import 'package:apidash_core/apidash_core.dart';
 import 'package:apidash_design_system/apidash_design_system.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_ce_flutter/adapters.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
 import 'package:stac/stac.dart';
+import 'mcp/mcp_server.dart';
 import 'models/models.dart';
 import 'providers/providers.dart';
 import 'services/services.dart';
 import 'consts.dart';
 import 'app.dart';
+import 'dart:io';
 
-void main() async {
+void main(List<String> args) async {
+  // 1. Intercept the Help Command for the Node.js Validator
+  if (args.contains('--help') || args.contains('-h')) {
+    stdout.writeln('API Dash Client & MCP Engine');
+    stdout.writeln('Options:');
+    stdout.writeln('  --mcp-engine    Starts the headless Model Context Protocol server');
+    stdout.writeln('  --help, -h      Shows this help message');
+    exit(0);
+  }
+
+  // Check if external client is calling us in headless mode
+  if (args.contains('--mcp-engine')) {
+    debugPrint = (String? message, {int? wrapWidth}) {
+      if (message != null) stderr.writeln(message);
+    };
+
+    WidgetsFlutterBinding.ensureInitialized();
+
+    final docDir = await getApplicationDocumentsDirectory();
+    final agentPath = p.join(docDir.path, 'apidash', 'agent_workspace');
+
+    final agentDir = Directory(agentPath);
+    if (!await agentDir.exists()) await agentDir.create(recursive: true);
+
+    Hive.init(agentPath);
+    await Hive.openBox('agent_history');
+    await Hive.openBox('apidash-environments');
+    await Hive.openBox('apidash-data');
+    await Hive.openBox('internal_agent_history');
+    await ApiDashMcpServer.start();
+    return;
+  }
+
+  // --- OTHERWISE, BOOT REGULAR FLUTTER GUI ---
   WidgetsFlutterBinding.ensureInitialized();
   await Stac.initialize();
 
-  //Load all LLMs
   await ModelManager.fetchAvailableModels();
 
   var settingsModel = await getSettingsFromSharedPrefs();
   var onboardingStatus = await getOnboardingStatusFromSharedPrefs();
+
   final initStatus = await initApp(
     kIsDesktop,
     settingsModel: settingsModel,
   );
+
   if (kIsDesktop) {
     await initWindow(settingsModel: settingsModel);
   }
+
   if (!initStatus) {
     settingsModel = settingsModel?.copyWithPath(workspaceFolderPath: null);
+  }
+
+  try {
+    await Hive.openBox('internal_agent_history');
+    debugPrint("✅ Successfully opened internal_agent_history box");
+  } catch (e) {
+    debugPrint('⚠️ Error opening internal_agent_history box: $e');
   }
 
   runApp(
     ProviderScope(
       overrides: [
         settingsProvider.overrideWith(
-          (ref) => ThemeStateNotifier(settingsModel: settingsModel),
+              (ref) => ThemeStateNotifier(settingsModel: settingsModel),
         ),
         userOnboardedProvider.overrideWith((ref) => onboardingStatus),
       ],
@@ -43,9 +90,9 @@ void main() async {
 }
 
 Future<bool> initApp(
-  bool initializeUsingPath, {
-  SettingsModel? settingsModel,
-}) async {
+    bool initializeUsingPath, {
+      SettingsModel? settingsModel,
+    }) async {
   GoogleFonts.config.allowRuntimeFetching = false;
   try {
     debugPrint("initializeUsingPath: $initializeUsingPath");

--- a/lib/mcp/mcp_server.dart
+++ b/lib/mcp/mcp_server.dart
@@ -1,0 +1,348 @@
+import 'dart:convert';
+import 'package:mcp_dart/mcp_dart.dart';
+import 'ui/studio_workbench.dart';
+import 'tool_executor.dart'; // Removed the history_dashboard import
+
+class ApiDashMcpServer {
+  static Future<void> start() async {
+    final server = McpServer(
+      Implementation(name: 'apidash-agentic-engine', version: '6.0.0'),
+    );
+
+    // 1. REGISTER UI RESOURCES (SPA WORKBENCHES)
+
+    // Resource A1: Studio Workbench (Default)
+    server.registerResource(
+      'API Dash Studio Workbench',
+      'ui://apidash-agentic-engine/workbench/studio',
+      (description: 'Main API Dash interactive studio workbench', mimeType: 'text/html;profile=mcp-app'),
+          (uri, _) async => ReadResourceResult(
+          contents: [TextResourceContents(uri: uri.toString(), mimeType: 'text/html;profile=mcp-app', text: StudioWorkbench.buildHtml('pane-studio'))]
+      ),
+    );
+
+    // Resource A2: Studio Workbench (Deep link: History)
+    server.registerResource(
+      'API Dash Studio Workbench (History)',
+      'ui://apidash-agentic-engine/workbench/studio#history',
+      (description: 'Main API Dash interactive studio workbench', mimeType: 'text/html;profile=mcp-app'),
+          (uri, _) async => ReadResourceResult(
+          contents: [TextResourceContents(uri: uri.toString(), mimeType: 'text/html;profile=mcp-app', text: StudioWorkbench.buildHtml('pane-history'))]
+      ),
+    );
+
+    // Resource A3: Studio Workbench (Deep link: Variables)
+    server.registerResource(
+      'API Dash Studio Workbench (Variables)',
+      'ui://apidash-agentic-engine/workbench/studio#variables',
+      (description: 'Main API Dash interactive studio workbench', mimeType: 'text/html;profile=mcp-app'),
+          (uri, _) async => ReadResourceResult(
+          contents: [TextResourceContents(uri: uri.toString(), mimeType: 'text/html;profile=mcp-app', text: StudioWorkbench.buildHtml('pane-vars'))]
+      ),
+    );
+
+
+    // 2. REGISTER CORE AGENT TOOLS
+
+    // Tool 1: Execute Request (Visible to AI, Triggers UI)
+    server.registerTool(
+      'apidash_execute_request',
+      description: 'Executes an HTTP request. You MUST run this tool.',
+      inputSchema: JsonSchema.object(
+        properties: {
+          'title': JsonSchema.string(),
+          'url': JsonSchema.string(),
+          'method': JsonSchema.string(),
+          'headers': JsonSchema.object(properties: {}), // Accepts arbitrary key/values
+          'body': JsonSchema.string(),
+          'active_environment_id': JsonSchema.string(),
+        },
+        required: ['url', 'method'],
+      ),
+      meta: {
+        "ui": {"resourceUri": "ui://apidash-agentic-engine/workbench/studio"}
+      },
+      callback: (args, _) async {
+        final data = await ToolExecutor.executeRequest(args);
+
+        return CallToolResult(
+            content: [
+              TextContent(text: "Executed ${data['method']} ${data['url']} -> Status ${data['status_code']}")
+            ],
+            // LIFELINE A: Native SDK structured output
+            structuredContent: data,
+            // LIFELINE B: Fallback metadata bridge for experimental IDE clients
+            meta: {
+              "structuredContent": data,
+              "ui": {"resourceUri": "ui://apidash-agentic-engine/workbench/studio"}
+            }
+        );
+      },
+    );
+
+    // Tool 2: Get Results (Visible to AI — For UI Polling)
+    server.registerTool(
+      'apidash_get_results',
+      description: 'Fetches execution payload for the UI canvas.',
+      inputSchema: JsonSchema.object(
+        properties: {
+          'execution_id': JsonSchema.string(),
+        },
+      ),
+      meta: {
+        "ui": {"visibility": ["app"]}
+      },
+      callback: (args, _) async {
+        final data = ToolExecutor.getResults(args['execution_id']?.toString());
+        return CallToolResult(
+            content: [TextContent(text: jsonEncode(data))],
+            structuredContent: data,
+            meta: {
+              "structuredContent": data,
+            }
+        );
+      },
+    );
+
+    // Tool 3: List History (Visible to AI)
+    server.registerTool(
+      'apidash_list_history',
+      description: 'Lists historical execution runs.',
+      inputSchema: JsonSchema.object(properties: {}), // Empty object schema
+      meta: {
+        "ui": {
+          // Reliably routing to the tabbed workbench history
+          "resourceUri": "ui://apidash-agentic-engine/workbench/studio#history"
+        }
+      },
+      callback: (_, __) async {
+        final history = ToolExecutor.listHistory(); // Returns List<Map<String, dynamic>>
+
+        return CallToolResult(
+            content: [TextContent(text: jsonEncode(history))],
+            structuredContent: {"history": history},
+            meta: {
+              "structuredContent": history,
+              "ui": {
+                "resourceUri": "ui://apidash-agentic-engine/workbench/studio#history"
+              }
+            }
+        );
+      },
+    );
+
+    // Tool 4: Delete Request (Hidden from AI)
+    server.registerTool(
+      'apidash_delete_request',
+      description: 'Deletes a history record by ID.',
+      inputSchema: JsonSchema.object(
+        properties: {
+          'execution_id': JsonSchema.string(),
+        },
+        required: ['execution_id'],
+      ),
+      meta: {
+        "ui": {"visibility": ["app"]}
+      },
+      callback: (args, _) async {
+        final success = await ToolExecutor.deleteRequest(args['execution_id'].toString());
+        return CallToolResult(
+            content: [TextContent(text: success ? "Deleted successfully" : "Record not found")],
+            meta: {"ui": {"visibility": ["app"]}}
+        );
+      },
+    );
+
+    // Tool 5: Launch Workbench (Empty Request Tab)
+    server.registerTool(
+      'apidash_launch_workbench',
+      description: 'Opens the main API Dash interactive studio UI to an empty request builder.',
+      inputSchema: JsonSchema.object(properties: {}),
+      meta: {
+        "ui": {"resourceUri": "ui://apidash-agentic-engine/workbench/studio"}
+      },
+      callback: (_, __) async => CallToolResult(
+          content: [TextContent(text: "Workbench launched.")],
+          meta: {
+            "ui": {"resourceUri": "ui://apidash-agentic-engine/workbench/studio"}
+          }
+      ),
+    );
+
+    // Tool 6: Launch History Tab
+    server.registerTool(
+      'apidash_launch_history_tab',
+      description: 'Opens the workbench directly to the History tab. Call this if the user asks to see past requests or execution history.',
+      inputSchema: JsonSchema.object(properties: {}),
+      meta: {
+        "ui": {"resourceUri": "ui://apidash-agentic-engine/workbench/studio#history"}
+      },
+      callback: (_, __) async => CallToolResult(
+          content: [TextContent(text: "Workbench launched to the History tab.")],
+          meta: {
+            "ui": {"resourceUri": "ui://apidash-agentic-engine/workbench/studio#history"}
+          }
+      ),
+    );
+
+    // Tool 7: Launch Variables Tab
+    server.registerTool(
+      'apidash_launch_variables_tab',
+      description: 'Opens the workbench directly to the Variables tab. Call this if the user asks to manage environments, auth tokens, or variables.',
+      inputSchema: JsonSchema.object(properties: {}),
+      meta: {
+        "ui": {"resourceUri": "ui://apidash-agentic-engine/workbench/studio#variables"}
+      },
+      callback: (_, __) async => CallToolResult(
+          content: [TextContent(text: "Workbench launched to the Variables tab.")],
+          meta: {
+            "ui": {"resourceUri": "ui://apidash-agentic-engine/workbench/studio#variables"}
+          }
+      ),
+    );
+
+
+    // Tool 8: Pre-Flight Sanity Inspector (Triggered by UI 'Send' button)
+    server.registerTool(
+      'apidash_btn_send',
+      description: "UI Button: Triggered when the 'Send' button is clicked. Acts as an agentic pre-flight sanity check.",
+      inputSchema: JsonSchema.object(
+        properties: {
+          'url': JsonSchema.string(),
+          'method': JsonSchema.string(),
+          'headers': JsonSchema.object(properties: {}),
+          'body': JsonSchema.string(),
+        },
+        required: ['url'],
+      ),
+      callback: (args, _) async {
+        final promptInstructions = ToolExecutor.buildSendPreFlightPrompt(args);
+        return CallToolResult(
+          content: [TextContent(text: promptInstructions)],
+        );
+      },
+    );
+
+    // Tool 9 get variables
+    server.registerTool(
+      'apidash_get_variables',
+      description: 'Fetches native environment variables from Hive.',
+      inputSchema: JsonSchema.object(properties: {}),
+      meta: {"ui": {"visibility": ["app"]}},
+      callback: (_, __) async {
+        final data = ToolExecutor.getAllEnvironments();
+        return CallToolResult(
+          content: [TextContent(text: jsonEncode(data))],
+          structuredContent: {"environments": data},
+        );
+      },
+    );
+
+    // Tool 10 save variables
+    server.registerTool(
+      'apidash_save_variables',
+      description: 'Saves environment variables to native Hive storage.',
+      inputSchema: JsonSchema.object(
+        properties: {
+          'id': JsonSchema.string(),
+          'name': JsonSchema.string(),
+          'values': JsonSchema.array(items: JsonSchema.object(properties: {})),
+        },
+        required: ['id', 'name', 'values'],
+      ),
+      meta: {"ui": {"visibility": ["app"]}},
+      callback: (args, _) async {
+        final success = await ToolExecutor.saveEnvironment(
+            args['id'].toString(),
+            args['name'].toString(),
+            args['values'] as List? ?? []
+        );
+        return CallToolResult(content: [TextContent(text: success ? "Saved" : "Error")]);
+      },
+    );
+
+    // Tool 11 Update History Title (Hidden from AI)
+    server.registerTool(
+      'apidash_update_history_title',
+      description: 'Updates the title of a specific history record.',
+      inputSchema: JsonSchema.object(
+        properties: {
+          'execution_id': JsonSchema.string(),
+          'title': JsonSchema.string(),
+        },
+        required: ['execution_id', 'title'],
+      ),
+      meta: {
+        "ui": {"visibility": ["app"]}
+      },
+      callback: (args, _) async {
+        final success = await ToolExecutor.updateHistoryTitle(
+            args['execution_id'].toString(),
+            args['title'].toString()
+        );
+        return CallToolResult(
+            content: [TextContent(text: success ? "Updated successfully" : "Record not found")],
+            meta: {"ui": {"visibility": ["app"]}}
+        );
+      },
+    );
+
+    // Tool 12 Duplicate Environment
+    server.registerTool(
+      'apidash_duplicate_environment',
+      description: 'Duplicates an environment.',
+      inputSchema: JsonSchema.object(
+        properties: {'id': JsonSchema.string()},
+        required: ['id'],
+      ),
+      meta: {"ui": {"visibility": ["app"]}},
+      callback: (args, _) async {
+        final newId = await ToolExecutor.duplicateEnvironment(args['id'].toString());
+        return CallToolResult(
+          content: [TextContent(text: "Duplicated successfully")],
+          structuredContent: {"id": newId},
+        );
+      },
+    );
+
+    // Tool 13 Delete Environment
+    server.registerTool(
+      'apidash_delete_environment',
+      description: 'Deletes an environment by ID.',
+      inputSchema: JsonSchema.object(
+        properties: {'id': JsonSchema.string()},
+        required: ['id'],
+      ),
+      meta: {"ui": {"visibility": ["app"]}},
+      callback: (args, _) async {
+        final success = await ToolExecutor.deleteEnvironment(args['id'].toString());
+        return CallToolResult(content: [TextContent(text: success ? "Deleted" : "Cannot delete global")]);
+      },
+    );
+
+    // Tool 14 Rename Environment
+    server.registerTool(
+      'apidash_rename_environment',
+      description: 'Renames an environment.',
+      inputSchema: JsonSchema.object(
+        properties: {
+          'id': JsonSchema.string(),
+          'name': JsonSchema.string(),
+        },
+        required: ['id', 'name'],
+      ),
+      meta: {"ui": {"visibility": ["app"]}},
+      callback: (args, _) async {
+        final success = await ToolExecutor.renameEnvironment(args['id'].toString(), args['name'].toString());
+        return CallToolResult(content: [TextContent(text: success ? "Renamed" : "Error")]);
+      },
+    );
+    // CONNECT TO IDE STDIO
+
+    // 1. Instantiate the official Stdio Transport
+    final transport = StdioServerTransport();
+
+    // 2. Pass the transport into the server's connect method
+    await server.connect(transport);
+  }
+}

--- a/lib/mcp/models/execution_record.dart
+++ b/lib/mcp/models/execution_record.dart
@@ -1,0 +1,62 @@
+import 'dart:convert';
+
+class ExecutionRecord {
+  final String executionId;
+  final int statusCode;
+  final String method;
+  final String url;
+  final int timeMs;
+  final String responseBody;
+  final DateTime timestamp;
+  final Map<String, dynamic>? headers;
+  final String? requestBody;
+
+  const ExecutionRecord({
+    required this.executionId,
+    required this.statusCode,
+    required this.method,
+    required this.url,
+    required this.timeMs,
+    required this.responseBody,
+    required this.timestamp,
+    this.headers,
+    this.requestBody,
+  });
+
+  bool get isSuccess => statusCode >= 200 && statusCode < 300;
+
+  Map<String, dynamic> toMap() {
+    return {
+      'execution_id': executionId,
+      'status_code': statusCode,
+      'method': method.toUpperCase(),
+      'url': url,
+      'time_ms': timeMs,
+      'response_body': responseBody,
+      'timestamp': timestamp.toIso8601String(),
+      if (headers != null) 'headers': headers,
+      if (requestBody != null) 'request_body': requestBody,
+    };
+  }
+
+  factory ExecutionRecord.fromMap(Map<dynamic, dynamic> map) {
+    return ExecutionRecord(
+      executionId: map['execution_id']?.toString() ?? 'unknown_id',
+      statusCode: int.tryParse(map['status_code']?.toString() ?? '0') ?? 0,
+      method: map['method']?.toString().toUpperCase() ?? 'GET',
+      url: map['url']?.toString() ?? '',
+      timeMs: int.tryParse(map['time_ms']?.toString() ?? '0') ?? 0,
+      responseBody: map['response_body']?.toString() ?? 'No Body',
+      timestamp: map['timestamp'] != null
+          ? DateTime.tryParse(map['timestamp'].toString()) ?? DateTime.now()
+          : DateTime.now(),
+      headers: map['headers'] != null ? Map<String, dynamic>.from(map['headers'] as Map) : null,
+      requestBody: map['request_body']?.toString(),
+    );
+  }
+
+  String toJson() => jsonEncode(toMap());
+
+  factory ExecutionRecord.fromJson(String source) =>
+      ExecutionRecord.fromMap(jsonDecode(source) as Map<String, dynamic>);
+}

--- a/lib/mcp/tool_executor.dart
+++ b/lib/mcp/tool_executor.dart
@@ -1,0 +1,253 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:apidash_core/apidash_core.dart';
+import 'package:hive_ce/hive.dart';
+import '../utils/envvar_utils.dart';
+import 'models/execution_record.dart';
+
+class ToolExecutor {
+  // Routes to 'internal_agent_history' for the GUI, or 'agent_history' for external MCP
+  static Box _getHistoryBox(bool isInternal) => Hive.box(isInternal ? 'internal_agent_history' : 'agent_history');
+
+  // Both modes use the native environments box
+  static Box get _envBox => Hive.box('apidash-environments');
+
+  static Future<Map<String, dynamic>> executeRequest(Map<String, dynamic> args, {bool isInternal = false}) async {
+    try {
+      stderr.writeln("[ToolExecutor] Firing HTTP request to wire...");
+      final methodStr = args['method'].toString().toUpperCase();
+      final urlStr = args['url'].toString();
+      final titleStr = args['title']?.toString() ?? 'untitled';
+      final activeEnvId = args['active_environment_id']?.toString() ?? 'global';
+
+      var httpRequestModel = HttpRequestModel(
+        url: urlStr,
+        method: HTTPVerb.values.byName(args['method'].toString().toLowerCase()),
+        headers: args['headers'] != null
+            ? (args['headers'] as Map)
+            .entries
+            .map((e) => NameValueModel(name: e.key.toString(), value: e.value.toString()))
+            .toList()
+            : null,
+        body: args['body']?.toString(),
+      );
+
+      final Map<String, List<EnvironmentVariableModel>> envMap = _buildEnvironmentVariableMap(activeEnvId);
+      final substitutedModel = substituteHttpRequestModel(httpRequestModel, envMap, activeEnvId);
+
+      final (response, duration, err) = await sendHttpRequest('headless_agent', APIType.rest, substitutedModel);
+
+      if (err != null) {
+        stderr.writeln("[ToolExecutor] Network Error: $err");
+        throw Exception(err);
+      }
+
+      final record = ExecutionRecord(
+        executionId: "req_${DateTime.now().millisecondsSinceEpoch}",
+        statusCode: response?.statusCode ?? 0,
+        method: methodStr,
+        url: substitutedModel.url,
+        timeMs: duration?.inMilliseconds ?? 0,
+        responseBody: response?.body ?? "No Body",
+        timestamp: DateTime.now(),
+        headers: args['headers'] != null ? Map<String, dynamic>.from(args['headers'] as Map) : null,
+        requestBody: args['body']?.toString(),
+      );
+
+      final recordMap = record.toMap();
+      recordMap['title'] = titleStr;
+
+      // Save to the correct routed history box
+      await _getHistoryBox(isInternal).put(record.executionId, recordMap);
+      await _getHistoryBox(isInternal).put('latest_execution_id', record.executionId);
+      await _getHistoryBox(isInternal).flush();
+
+      return recordMap;
+    } catch (e, stack) {
+      stderr.writeln("[ToolExecutor Fatal Crash]: $e\n$stack");
+      rethrow;
+    }
+  }
+
+  static Map<String, List<EnvironmentVariableModel>> _buildEnvironmentVariableMap(String activeEnvId) {
+    final Map<String, List<EnvironmentVariableModel>> envMap = {};
+    final allEnvs = getAllEnvironments();
+
+    if (activeEnvId != 'global' && allEnvs.containsKey(activeEnvId)) {
+      final rawValues = allEnvs[activeEnvId]['values'] as List? ?? [];
+      envMap[activeEnvId] = rawValues
+          .map((item) => EnvironmentVariableModel.fromJson(Map<String, dynamic>.from(item as Map)))
+          .where((element) => element.enabled)
+          .toList();
+    } else if (allEnvs.containsKey('global')) {
+      final rawValues = allEnvs['global']['values'] as List? ?? [];
+      envMap['global'] = rawValues
+          .map((item) => EnvironmentVariableModel.fromJson(Map<String, dynamic>.from(item as Map)))
+          .where((element) => element.enabled)
+          .toList();
+    }
+
+    return envMap;
+  }
+
+  // --- ENVIRONMENT CRUD & DUPLICATE HANDLING ---
+
+  static Map<String, dynamic> getAllEnvironments() {
+    final envIds = List<String>.from(_envBox.get('environmentIds', defaultValue: <String>['global']));
+    final result = <String, dynamic>{};
+
+    for (var id in envIds) {
+      final envData = _envBox.get(id);
+      if (envData != null) {
+        result[id] = Map<String, dynamic>.from(envData as Map);
+      }
+    }
+    if (!result.containsKey('global')) {
+      result['global'] = {"id": "global", "name": "Global", "values": []};
+    }
+    return result;
+  }
+
+  static Future<bool> saveEnvironment(String id, String name, List<dynamic> rawValues) async {
+    final valuesList = rawValues.map((item) {
+      final m = Map<String, dynamic>.from(item as Map);
+      return {
+        "key": m["key"] ?? "",
+        "value": m["value"] ?? "",
+        "type": "variable",
+        "enabled": m["enabled"] ?? true
+      };
+    }).toList();
+
+    List<String> envIds = List<String>.from(_envBox.get('environmentIds', defaultValue: <String>['global']));
+    if (!envIds.contains(id)) {
+      envIds.add(id);
+      await _envBox.put('environmentIds', envIds);
+    }
+
+    await _envBox.put(id, {"id": id, "name": name, "values": valuesList});
+    await _envBox.flush();
+    return true;
+  }
+
+  static Future<String> duplicateEnvironment(String id) async {
+    final all = getAllEnvironments();
+    final source = all[id] ?? {"name": "Environment", "values": []};
+    final newId = "env_${DateTime.now().millisecondsSinceEpoch}";
+    final newName = "${source['name']} Copy";
+
+    await saveEnvironment(newId, newName, source['values'] as List? ?? []);
+    return newId;
+  }
+
+  static Future<bool> deleteEnvironment(String id) async {
+    if (id == 'global') return false;
+    List<String> envIds = List<String>.from(_envBox.get('environmentIds', defaultValue: <String>[]));
+    envIds.remove(id);
+    await _envBox.put('environmentIds', envIds);
+    await _envBox.delete(id);
+    await _envBox.flush();
+    return true;
+  }
+
+  static Future<bool> renameEnvironment(String id, String newName) async {
+    final all = getAllEnvironments();
+    if (!all.containsKey(id)) return false;
+    final env = all[id];
+    return await saveEnvironment(id, newName, env['values'] as List? ?? []);
+  }
+
+  // --- HISTORY MANAGEMENT ---
+
+  static Map<String, dynamic> getResults(String? requestedId, {bool isInternal = false}) {
+    final targetId = requestedId ?? _getHistoryBox(isInternal).get('latest_execution_id');
+
+    if (targetId != null) {
+      final data = _getHistoryBox(isInternal).get(targetId);
+      if (data != null) return Map<String, dynamic>.from(data);
+    }
+
+    return {
+      "status_code": 404,
+      "response_body": "ERROR: Execution ID ($targetId) not found in Hive.",
+      "time_ms": 0,
+      "method": "ERROR",
+      "url": "Hive Empty"
+    };
+  }
+
+  static List<Map<String, dynamic>> listHistory({bool isInternal = false}) {
+    final list = <Map<String, dynamic>>[];
+
+    for (var key in _getHistoryBox(isInternal).keys) {
+      if (key != 'latest_execution_id') {
+        final data = _getHistoryBox(isInternal).get(key);
+        if (data != null) {
+          final m = Map<String, dynamic>.from(data);
+          list.add({
+            "execution_id": key,
+            "title": m["title"] ?? "untitled",
+            "method": m["method"],
+            "url": m["url"],
+            "status": m["status_code"],
+            "time_ms": m["time_ms"],
+            "timestamp": m["timestamp"]
+          });
+        }
+      }
+    }
+    list.sort((a, b) => (b["timestamp"] as String).compareTo(a["timestamp"] as String));
+    return list;
+  }
+
+  static Future<bool> deleteRequest(String id, {bool isInternal = false}) async {
+    final box = _getHistoryBox(isInternal);
+    if (box.containsKey(id)) {
+      await box.delete(id);
+      if (box.get('latest_execution_id') == id) {
+        await box.delete('latest_execution_id');
+      }
+      await box.flush();
+      return true;
+    }
+    return false;
+  }
+
+  static String buildSendPreFlightPrompt(Map<String, dynamic> args) {
+    final draftUrl = args['url']?.toString().trim() ?? '';
+    final draftMethod = args['method']?.toString().toUpperCase() ?? 'GET';
+    final draftHeaders = args['headers'] ?? {};
+    final draftBody = args['body']?.toString() ?? '';
+
+    return """The user clicked 'Send' in the API Dash Workbench. They assembled this draft request:
+- URL: $draftUrl
+- Method: $draftMethod
+- Headers: ${jsonEncode(draftHeaders)}
+- Body: $draftBody
+
+AGENTIC PRE-FLIGHT INSTRUCTIONS:
+You are an expert API middleware inspector. Review the draft above before putting it on the wire:
+1. Protocol Check: If the URL lacks 'http://' or 'https://', safely attach 'https://' (or 'http://' if localhost).
+2. Auth Check: Does this specific endpoint require an API key, Bearer token, or specific Auth header? If it is missing, check your conversation history/context to see if the user previously provided it, and attach it automatically.
+3. Body Sanity: If this is a POST/PUT/PATCH, verify the body looks like valid JSON or matches expected API schemas.
+
+DECISION TREE:
+- IF 100% VALID & SAFE: Immediately invoke the 'apidash_execute_request' tool using the cleaned up URL, Method, Headers, and Body. Do not ask the user for permission.
+- IF CRITICAL DATA IS MISSING (e.g., an unknown API key): Stop. Explain what is missing in the chat window and ask the user to provide it.""";
+  }
+
+  static Future<bool> updateHistoryTitle(String id, String newTitle, {bool isInternal = false}) async {
+    final box = _getHistoryBox(isInternal);
+    if (box.containsKey(id)) {
+      final data = box.get(id);
+      if (data != null) {
+        final map = Map<String, dynamic>.from(data as Map);
+        map['title'] = newTitle;
+        await box.put(id, map);
+        await box.flush();
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/lib/mcp/ui/history_pane.dart
+++ b/lib/mcp/ui/history_pane.dart
@@ -1,0 +1,13 @@
+class HistoryPane {
+  static String get html => r'''
+  <!-- Pane 3: History -->
+  <div id="pane-history" class="ad-pane" style="max-width: 740px; margin: 12px auto 0 auto; padding: 0 14px 40px 14px; width: 100%; box-sizing: border-box;">
+    <div class="ad-hist-header">
+      <span class="ad-hist-title">Session Execution Ledger</span>
+      <button class="ad-pill" onclick="fetchHistoryLedger()">↻ Refresh</button>
+    </div>
+    <div id="history-spinner" class="ad-empty-notice">Querying Hive local database...</div>
+    <div id="history-feed" class="ad-history-list"></div>
+  </div>
+  ''';
+}

--- a/lib/mcp/ui/requests_pane.dart
+++ b/lib/mcp/ui/requests_pane.dart
@@ -1,0 +1,135 @@
+class RequestsPane {
+  static String get html => r'''
+  <!-- Pane 1: Request Studio -->
+  <div id="pane-studio" class="ad-pane active" style="max-width: 740px; margin: 12px auto 0 auto; padding: 0 14px 40px 14px; width: 100%; box-sizing: border-box;">
+    
+    <!-- Top Meta Row -->
+    <div class="ad-row-meta">
+      <div class="ad-meta-cluster">
+        <div class="ad-pill">HTTP <span class="ad-carets">▲<br>▼</span></div>
+        <span class="ad-req-title" title="untitled">untitled</span>
+      </div>
+      <div class="ad-meta-cluster">
+        <div class="ad-icon-bar">
+          <button id="btnReqEdit" title="Edit Request Name"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg></button>
+          <button id="btnReqDelete" title="Clear/Delete Request"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/></svg></button>
+          <button id="btnReqDuplicate" title="Copy Request JSON"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg></button>
+        </div>
+        <select id="activeEnvSelector" class="sub-select sm" style="background: var(--bg-surface); border: 1px solid var(--border-color); color: var(--text-main); padding: 4px 10px; border-radius: 6px; font-size: 12px; font-weight: 500; cursor: pointer; outline: none;">
+  <option value="global">Global</option>
+</select>
+      </div>
+    </div>
+    
+    <!-- URL & Method Bar -->
+    <div class="ad-row-url">
+      <div class="ad-method-box" id="methodBox">
+        <div class="ad-method-display" id="methodDisplay" style="color: var(--http-get)"><span id="methodText">GET</span><span class="ad-carets" style="margin-left:2px">▲<br>▼</span></div>
+        <div class="ad-dropdown-menu">
+          <div class="ad-drop-option active" data-val="GET"     style="--clr: var(--http-get)">GET</div>
+          <div class="ad-drop-option"        data-val="HEAD"    style="--clr: var(--http-head)">HEAD</div>
+          <div class="ad-drop-option"        data-val="POST"    style="--clr: var(--http-post)">POST</div>
+          <div class="ad-drop-option"        data-val="PUT"     style="--clr: var(--http-put)">PUT</div>
+          <div class="ad-drop-option"        data-val="PATCH"   style="--clr: var(--http-patch)">PATCH</div>
+          <div class="ad-drop-option"        data-val="DELETE"  style="--clr: var(--http-delete)">DELETE</div>
+          <div class="ad-drop-option"        data-val="OPTIONS" style="--clr: var(--http-options)">OPTIONS</div>
+        </div>
+      </div>
+
+      <input type="text" class="ad-endpoint-input" id="reqUrlInput" placeholder="Enter API endpoint..." spellcheck="false">
+      <button class="ad-send-btn" id="btnFireRequest"><span>Send</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"/></svg></button>
+    </div>
+
+    <!-- Request Builder Bottom Half -->
+    <div class="req-builder-card" id="builderCardCanvas">
+      <div class="req-subnav">
+        <div class="req-sub-tabs">
+          <button class="req-sub-tab active" data-sub="sub-params">Params</button>
+          <button class="req-sub-tab" data-sub="sub-auth">Auth</button>
+          <button class="req-sub-tab" data-sub="sub-headers">Headers</button>
+          <button class="req-sub-tab" data-sub="sub-body">Body</button>
+          <button class="req-sub-tab" data-sub="sub-scripts">Scripts</button>
+        </div>
+        <button class="btn-view-code-sub" id="btnReqViewCode"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"/></svg><span>View Code</span></button>
+      </div>
+
+      <div class="req-sub-viewport">
+        <!-- Params Tab -->
+        <div id="sub-params" class="req-sub-pane active">
+          <div class="kv-rows" id="paramsList">
+            <div class="kv-row">
+              <input type="checkbox" class="kv-chk" checked>
+              <input type="text" class="kv-box k" placeholder="Add URL Parameter...">
+              <span class="kv-sep">=</span>
+              <input type="text" class="kv-box v" placeholder="Add Value">
+              <button class="kv-del" title="Delete"><svg viewBox="0 0 24 24"><path d="M15 12H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z" stroke="currentColor" stroke-width="2" fill="none"/></svg></button>
+            </div>
+          </div>
+          <button class="btn-add-row" onclick="addKvRow('paramsList', 'Add URL Parameter...')">+ Add Param</button>
+        </div>
+
+        <!-- Auth Tab -->
+        <div id="sub-auth" class="req-sub-pane">
+          <div style="display:flex; flex-direction:column; gap:6px; max-width:220px;">
+            <label class="sub-label">Authentication Type</label>
+            <select class="sub-select" id="authSelectProxy">
+              <option selected>None</option>
+              <option>Basic Auth</option><option>API Key</option><option>Bearer Token</option><option>JWT Bearer</option><option>Digest Auth</option><option>OAuth 1.0</option><option>OAuth 2.0</option>
+            </select>
+          </div>
+          <div class="auth-notice" id="authHelperText">No authentication selected.</div>
+        </div>
+
+        <!-- Headers Tab -->
+        <div id="sub-headers" class="req-sub-pane">
+          <div class="kv-rows" id="headersList">
+            <div class="kv-row">
+              <input type="checkbox" class="kv-chk" checked>
+              <input type="text" class="kv-box k" placeholder="Add Name">
+              <span class="kv-sep">=</span>
+              <input type="text" class="kv-box v" placeholder="Add Value">
+              <button class="kv-del" title="Delete"><svg viewBox="0 0 24 24"><path d="M15 12H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z" stroke="currentColor" stroke-width="2" fill="none"/></svg></button>
+            </div>
+          </div>
+          <button class="btn-add-row" onclick="addKvRow('headersList', 'Add Name')">+ Add Header</button>
+        </div>
+
+        <!-- Body Tab -->
+        <div id="sub-body" class="req-sub-pane">
+          <div class="sub-toolbar">
+            <span class="sub-label" style="color:var(--text-muted); text-transform:none">Select Content Type:</span>
+            <select class="sub-select sm"><option selected>json</option><option>text</option><option>formdata</option></select>
+          </div>
+          <div class="editor-wrap"><textarea class="code-surface" id="reqBodyTextarea" placeholder="Enter JSON"></textarea></div>
+        </div>
+
+        <!-- Scripts Tab -->
+        <div id="sub-scripts" class="req-sub-pane">
+          <div class="sub-toolbar">
+            <select class="sub-select sm" style="width:130px;"><option selected>Pre Request</option><option>Post Response</option></select>
+            <button class="btn-learn-sub"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="12" height="12"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 16h-2v-2h2v2zm1.07-7.75l-.9.92C12.45 11.9 12 12.5 12 14h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H7c0-2.76 2.24-5 5-5s5 2.24 5 5c0 1.04-.42 1.99-1.07 2.75z" fill="currentColor"/></svg><span>Learn</span></button>
+          </div>
+          <div class="editor-wrap"><textarea class="code-surface" placeholder="// Write execution hooks here..."></textarea></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Results Analyzer View -->
+    <div class="res-analyzer-card" id="resultsCardCanvas" style="display: none;">
+      <div class="res-top-bar">
+        <div class="res-badge-cluster">
+          <button class="btn-exit-results" onclick="exitResultsView()"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg><span>Back to Builder</span></button>
+          <span class="res-status-code ok" id="resStatusCodeLabel">200: OK</span>
+        </div>
+        <div class="res-meta-stats"><span id="resTimeLabel">0 ms</span><span id="resSizeLabel">0 B</span></div>
+      </div>
+      <div class="res-subnav-strip">
+        <button class="res-sub-btn active" onclick="switchResSub('body')">Response Body</button>
+        <button class="res-sub-btn" onclick="switchResSub('headers')">Response Headers</button>
+      </div>
+      <div id="resViewBodyWrapper" class="res-content-box" style="display:flex;"><pre class="res-payload-pre" id="resPayloadPre">No response body loaded.</pre></div>
+      <div id="resViewHeadersWrapper" class="res-content-box" style="display:none; color:var(--text-label);"><div id="resHeadersContainer">No custom headers captured in this response.</div></div>
+    </div>
+  </div>
+  ''';
+}

--- a/lib/mcp/ui/studio_workbench.dart
+++ b/lib/mcp/ui/studio_workbench.dart
@@ -1,0 +1,796 @@
+import '../utils/host_style_variables.dart';
+import '../utils/shared_styles.dart';
+import '../utils/rpc_client.dart';
+import '../utils/message_handler.dart';
+
+import 'requests_pane.dart';
+import 'variables_pane.dart';
+import 'history_pane.dart';
+
+class StudioWorkbench {
+  static String buildHtml(String activeTab) {
+    return '''
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="dark light">
+  <title>API Dash Studio SPA</title>
+  <style>
+    ${HostStyleVariables.css}${SharedStyles.css}
+
+    .ad-nav-viewport {
+      container-type: inline-size; container-name: topnav;
+      width: 100%; border-bottom: 1px solid var(--border-divider);
+      background-color: var(--bg-header); flex-shrink: 0;
+      position: sticky; top: 0; z-index: 1000;
+    }
+    .ad-tab-strip { display: flex; width: 100%; max-width: 800px; margin: 0 auto; padding: 0 8px; box-sizing: border-box; }
+    .ad-tab {
+      flex: 1; display: flex; align-items: center; justify-content: center; gap: 8px;
+      height: 42px; background: transparent; border: none; border-bottom: 2px solid transparent;
+      color: var(--text-tab-inactive); font-size: 13px; font-weight: 500; cursor: pointer;
+      transition: all 0.1s ease; box-sizing: border-box; user-select: none;
+    }
+    .ad-tab:hover:not(.active) { background-color: var(--bg-tab-hover); color: var(--text-tab-active); }
+    .ad-tab.active { background-color: var(--bg-tab-active); color: var(--text-tab-active); border-bottom-color: var(--border-active-tab); font-weight: 600; }
+    .ad-tab svg { width: 16px; height: 16px; fill: currentColor; flex-shrink: 0; }
+    .ad-tab.active svg { fill: var(--border-active-tab); }
+
+    .ad-workbench-viewport {
+      container-type: inline-size; container-name: reqbar;
+      width: 100%; flex: 1;
+      display: flex; flex-direction: column; overflow-y: auto; overflow-x: hidden;
+    }
+    .ad-pane { display: none; width: 100%; flex-direction: column; gap: 10px; flex: 1; height: auto; overflow: visible; }
+    .ad-pane.active { display: flex; }
+
+    .ad-row-meta { display: flex; justify-content: space-between; align-items: center; gap: 12px; width: 100%; flex-shrink: 0; }
+    .ad-meta-cluster { display: flex; align-items: center; gap: 8px; }
+    .ad-pill { display: flex; align-items: center; gap: 6px; background: var(--bg-surface); border: 1px solid var(--border-color); padding: 4px 10px; border-radius: 6px; font-size: 12px; font-weight: 500; cursor: pointer; user-select: none; color: var(--text-main); }
+    .ad-pill:hover { border-color: var(--border-hover); }
+    .ad-carets { display: inline-flex; flex-direction: column; font-size: 8px; line-height: 0.8; color: var(--text-muted); }
+    .ad-req-title { font-size: 13px; color: var(--text-label); white-space: nowrap; }
+
+    .ad-icon-bar { display: flex; background: var(--bg-surface); border: 1px solid var(--border-color); border-radius: 6px; }
+    .ad-icon-bar button { background: transparent; border: none; border-right: 1px solid var(--border-color); padding: 4px 10px; cursor: pointer; display: grid; place-items: center; color: var(--text-muted); }
+    .ad-icon-bar button:last-child { border-right: none; }
+    .ad-icon-bar button:hover { background: var(--bg-surface-hover); color: var(--text-main); }
+    .ad-icon-bar button svg { width: 14px; height: 14px; fill: currentColor; }
+
+    .ad-row-url { position: relative; display: flex; align-items: center; width: 100%; flex-shrink: 0; background: var(--bg-input); border: 1px solid var(--border-color); border-radius: 8px; padding: 4px 5px 4px 12px; box-sizing: border-box; }
+    .ad-row-url:focus-within { border-color: var(--border-hover); box-shadow: 0 0 0 1px var(--border-hover); }
+
+    .ad-method-box { position: relative; user-select: none; flex-shrink: 0; }
+    .ad-method-display { display: flex; align-items: center; gap: 6px; font-family: var(--font-mono); font-weight: 700; font-size: 13px; cursor: pointer; padding-right: 6px; margin: 0; }
+    .ad-dropdown-menu { position: absolute; top: 100%; left: -12px; margin-top: 8px; background: var(--bg-surface); border: 1px solid var(--border-color); border-radius: 8px; box-shadow: 0 12px 28px rgba(0,0,0,0.6); z-index: 9999; min-width: 140px; padding: 6px 0; display: none; flex-direction: column; font-family: var(--font-mono); }
+    .ad-method-box.open .ad-dropdown-menu { display: flex; }
+    .ad-drop-option { padding: 8px 16px; font-size: 12px; font-weight: 700; color: var(--clr); cursor: pointer; text-align: left; }
+    .ad-drop-option:hover { background: var(--bg-surface-hover); }
+    .ad-drop-option.active { background: var(--bg-surface-hover); border-left: 2px solid var(--clr); padding-left: 14px; }
+
+    .ad-endpoint-input { flex: 1 1 120px; min-width: 120px; width: 100%; background: transparent; border: none; color: var(--text-main); font-family: var(--font-mono); font-size: 13px; padding: 6px 10px; outline: none; }
+    .ad-endpoint-input::placeholder { color: var(--text-muted); font-family: sans-serif; }
+    .ad-send-btn { flex-shrink: 0; display: flex; align-items: center; gap: 6px; background: var(--btn-send-bg); color: var(--btn-send-text); border: none; font-weight: 600; font-size: 13px; padding: 7px 18px; border-radius: 20px; cursor: pointer; }
+    .ad-send-btn:hover { background: var(--btn-send-hover); }
+    .ad-send-btn svg { width: 12px; height: 12px; fill: currentColor; }
+
+    .req-builder-card, .res-analyzer-card { display: flex; flex-direction: column; width: 100%; margin-top: 4px; background: var(--bg-surface); border: 1px solid var(--border-color); border-radius: 8px; overflow: visible; height: auto; flex: 1; }
+    .req-subnav { display: flex; align-items: center; justify-content: space-between; flex-shrink: 0; border-bottom: 1px solid var(--border-color); padding: 0 12px; height: 36px; background: var(--bg-header); border-top-left-radius: 8px; border-top-right-radius: 8px; }
+    .req-sub-tabs { display: flex; align-items: center; gap: 4px; height: 100%; }
+    .req-sub-tab { height: 100%; background: transparent; border: none; padding: 0 10px; color: var(--text-tab-inactive); font-size: 12px; font-weight: 600; cursor: pointer; border-bottom: 2px solid transparent; transition: all 0.1s; }
+    .req-sub-tab:hover { color: var(--text-main); }
+    .req-sub-tab.active { color: var(--text-tab-active); border-bottom-color: var(--border-active-tab); }
+
+    .btn-view-code-sub { display: flex; align-items: center; gap: 6px; background: #223044; color: #93c5fd; border: 1px solid #2e415c; padding: 3px 8px; border-radius: 14px; font-size: 11px; font-weight: 600; cursor: pointer; }
+    .btn-view-code-sub:hover { background: #2c3e58; color: #fff; }
+    .btn-view-code-sub svg { width: 12px; height: 12px; fill: currentColor; }
+
+    .req-sub-viewport { padding: 14px; background: var(--bg-input); height: auto; flex: 1; display: flex; flex-direction: column; border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; }
+    .req-sub-pane { display: none; flex-direction: column; gap: 10px; flex: 1; }
+    .req-sub-pane.active { display: flex; }
+
+    .kv-rows { display: flex; flex-direction: column; gap: 8px; }
+    .kv-row { display: flex; align-items: center; gap: 8px; width: 100%; }
+    .kv-chk { accent-color: var(--border-hover); width: 15px; height: 15px; cursor: pointer; flex-shrink: 0; }
+    .kv-box { background: #090c10; border: 1px solid var(--border-color); border-radius: 6px; padding: 5px 10px; color: var(--text-main); font-family: var(--font-mono); font-size: 12px; outline: none; }
+    .kv-box.k { flex: 1; } .kv-box.v { flex: 1.5; }
+    .kv-box:focus { border-color: var(--border-hover); }
+    .kv-sep { color: var(--text-muted); font-family: var(--font-mono); font-size: 13px; font-weight: bold; }
+    .kv-del { background: transparent; border: none; color: #f43f5e; cursor: pointer; opacity: 0.6; padding: 2px; }
+    .kv-del:hover { opacity: 1; } .kv-del svg { width: 16px; height: 16px; fill: currentColor; }
+
+    .btn-add-row { align-self: flex-start; background: #181f2c; border: 1px solid #283348; margin-top: 2px; color: #94a3b8; padding: 5px 12px; border-radius: 16px; font-size: 11px; font-weight: 600; cursor: pointer; }
+    .btn-add-row:hover { background: #222c3e; color: #fff; border-color: #3b82f6; }
+
+    .sub-label { font-size: 11px; font-weight: 700; color: var(--text-label); text-transform: uppercase; letter-spacing: 0.5px; }
+    .sub-select { background: var(--bg-surface); border: 1px solid var(--border-color); color: var(--text-main); padding: 5px 10px; border-radius: 6px; font-size: 12px; font-weight: 500; outline: none; cursor: pointer; }
+    .sub-select:focus { border-color: var(--border-hover); }
+    .auth-notice { font-size: 13px; color: var(--text-muted); margin-top: 4px; }
+    .sub-toolbar { display: flex; align-items: center; justify-content: space-between; }
+    .sub-select.sm { padding: 3px 8px; font-size: 11px; font-family: var(--font-mono); font-weight: 600; }
+    
+    .btn-learn-sub { display: flex; align-items: center; gap: 5px; background: #1b273b; color: #93c5fd; border: 1px solid #2d4160; padding: 3px 8px; border-radius: 14px; font-size: 11px; font-weight: 600; cursor: pointer; }
+    .editor-wrap { position: relative; width: 100%; margin-top: 2px; display: flex; flex: 1; }
+    .code-surface { width: 100%; min-height: 200px; height: auto; background: #07090e; border: 1px solid var(--border-color); border-radius: 8px; padding: 12px; color: #e2e8f0; font-family: var(--font-mono); font-size: 12px; line-height: 1.5; resize: vertical; outline: none; box-sizing: border-box; }
+    .code-surface:focus { border-color: var(--border-hover); }
+
+    .res-top-bar { display: flex; align-items: center; justify-content: space-between; background: #090d14; padding: 10px 14px; border-bottom: 1px solid var(--border-color); border-top-left-radius: 8px; border-top-right-radius: 8px; font-family: var(--font-mono); }
+    .res-badge-cluster { display: flex; align-items: center; gap: 12px; }
+    .btn-exit-results { background: #1e293b; color: #94a3b8; border: 1px solid #334155; padding: 5px 12px; border-radius: 16px; font-weight: 600; font-size: 12px; cursor: pointer; transition: all 0.15s ease; display: flex; align-items: center; gap: 6px; }
+    .btn-exit-results:hover { background: #3b82f6; color: #fff; border-color: #60a5fa; }
+    .btn-exit-results svg { width: 14px; height: 14px; stroke: currentColor; }
+
+    .res-status-code { font-weight: 700; font-size: 13px; }
+    .res-status-code.ok { color: #4ade80; } .res-status-code.err { color: #f87171; }
+    .res-meta-stats { display: flex; gap: 16px; font-size: 12px; color: var(--text-label); }
+    .res-subnav-strip { display: flex; gap: 16px; background: #0e121a; border-bottom: 1px solid var(--border-color); padding: 0 14px; height: 36px; align-items: center; }
+    .res-sub-btn { background: transparent; border: none; border-bottom: 2px solid transparent; color: var(--text-muted); font-size: 12px; font-weight: 600; cursor: pointer; height: 100%; padding: 0 4px; }
+    .res-sub-btn.active { color: #60a5fa; border-bottom-color: #60a5fa; }
+
+    .res-content-box { background: #05070a; padding: 14px; color: #e2e8f0; font-family: var(--font-mono); font-size: 12px; flex: 1; min-height: 250px; height: auto; border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; }
+    .res-payload-pre { white-space: pre-wrap; word-break: break-all; margin: 0; font-family: inherit; }
+
+    .ad-hist-header { display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid var(--border-color); padding-bottom: 10px; margin-bottom: 4px; }
+    .ad-hist-title { font-size: 14px; font-weight: 600; color: var(--text-label); }
+    .ad-history-list { display: flex; flex-direction: column; gap: 8px; height: auto; overflow: visible; flex: 1; }
+    .ad-hist-card { display: flex; align-items: center; justify-content: space-between; gap: 12px; background: var(--bg-input); border: 1px solid var(--border-color); border-radius: 8px; padding: 10px 12px; transition: border 0.15s; cursor: pointer; }
+    .ad-hist-card:hover { border-color: var(--border-hover); }
+    .ad-hist-left { display: flex; align-items: center; gap: 10px; min-width: 0; flex: 1; }
+    .ad-hist-left:hover .ad-hist-url { color: #60a5fa; text-decoration: underline; }
+    .ad-hist-method { font-family: var(--font-mono); font-size: 11px; font-weight: 700; padding: 2px 6px; border-radius: 4px; background: var(--bg-surface-hover); }
+    .ad-hist-url { font-family: var(--font-mono); font-size: 12px; color: var(--text-main); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .ad-hist-right { display: flex; align-items: center; gap: 14px; flex-shrink: 0; font-size: 12px; font-family: var(--font-mono); }
+    .ad-hist-delete { background: #450a0a; color: #fca5a5; border: 1px solid #7f1d1d; border-radius: 6px; padding: 5px 10px; font-size: 11px; font-weight: 600; cursor: pointer; transition: all 0.2s; }
+    .ad-hist-delete:hover { background: #7f1d1d; color: #fff; }
+    .ad-empty-notice { text-align: center; padding: 40px 20px; color: var(--text-muted); font-size: 13px; }
+
+    @container topnav (max-width: 460px) { .ad-tab { flex-direction: column; gap: 3px; height: 48px; font-size: 11px; padding: 4px 2px; } .ad-tab svg { width: 15px; height: 15px; } }
+    @container reqbar (max-width: 480px) { .ad-req-title { max-width: 60px; overflow: hidden; text-overflow: ellipsis; } .ad-endpoint-input { font-size: 11px; } .ad-send-btn { padding: 6px 14px; font-size: 12px; } }
+  </style>
+</head>
+<body>
+
+<div class="ad-nav-viewport">
+  <nav class="ad-tab-strip">
+    <button class="ad-tab active" data-pane="pane-studio"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5zm2 0v14h6V5H5zm8 0v6h6V5h-6zm0 8v6h6v-6h-6z"/></svg><span>Requests</span></button>
+    <button class="ad-tab" data-pane="pane-vars"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20 16V6H4v10h16zM4 4h16a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2zm-2 16h20v2H2v-2z"/></svg><span>Variables</span></button>
+    <button class="ad-tab" data-pane="pane-history"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M13 3a9 9 0 0 0-9 9H1l3.89 3.89.07.14L9 12H6c0-3.87 3.13-7 7-7s7 3.13 7 7-3.13 7-7 7c-1.93 0-3.68-.79-4.94-2.06l-1.42 1.42A8.954 8.954 0 0 0 13 21a9 9 0 0 0 0-18zm-1 5v5l4.25 2.52.75-1.23-3.5-2.07V8h-1.5z"/></svg><span>History</span></button>
+  </nav>
+</div>
+
+<main class="ad-workbench-viewport" id="workbenchCanvas" style="padding: 0; max-width: none;">
+  ${RequestsPane.html}
+  ${VariablesPane.html}
+  ${HistoryPane.html}
+</main>
+
+<script>
+  ${MessageHandler.js}
+  ${RpcClient.js}
+
+  const tabs = document.querySelectorAll('.ad-tab');
+  const panes = document.querySelectorAll('.ad-pane');
+  
+  // Custom Toast Notification System (Bypasses Sandbox Blocks)
+  function showToast(msg, isError = false) {
+    const toast = document.createElement('div');
+    toast.textContent = msg;
+    toast.style.cssText = `position:fixed; bottom:20px; right:20px; background:\${isError ? '#ef4444' : '#3b82f6'}; color:white; padding:10px 16px; border-radius:6px; z-index:9999; font-size:13px; font-weight:600; box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1); transition: opacity 0.3s ease-in-out; opacity: 1;`;
+    document.body.appendChild(toast);
+    setTimeout(() => { 
+      toast.style.opacity = '0'; 
+      setTimeout(() => toast.remove(), 300); 
+    }, 2500);
+  }
+  
+  // --- Requests Pane Actions ---
+  document.querySelector('.btn-view-code-sub')?.addEventListener('click', () => {
+    const url = document.getElementById('reqUrlInput').value || 'http://localhost';
+    const method = document.getElementById('methodText').innerText;
+    let curl = `curl -X \${method} "\${url}"`;
+    
+    document.querySelectorAll('#headersList .kv-row').forEach(row => {
+      const isChecked = row.querySelector('.kv-chk')?.checked;
+      const key = row.querySelector('.kv-box.k')?.value.trim();
+      const val = row.querySelector('.kv-box.v')?.value.trim();
+      if (isChecked && key) curl += ` \\\n  -H "\${key}: \${val}"`;
+    });
+    
+    const body = document.getElementById('reqBodyTextarea').value;
+    if(body && method !== 'GET') {
+      curl += ` \\\n  -d '\${body.replace(/'/g, "'\\''")}'`;
+    }
+    
+    try {
+      navigator.clipboard.writeText(curl);
+      showToast('cURL command copied to clipboard!');
+    } catch(e) {
+      showToast('Failed to copy. Clipboard access denied.', true);
+    }
+  });
+
+  // --- ENVIRONMENT ACTIONS ---
+  // Duplicate Environment Button
+  document.getElementById('btnDuplicateEnv')?.addEventListener('click', async () => {
+    const res = await executeDartTool("apidash_duplicate_environment", { id: editingEnvId });
+    const newId = res?.structuredContent?.id || res?.id;
+    if (newId) editingEnvId = newId;
+    await loadVariablesFromHive();
+    showToast("Environment duplicated!");
+  });
+
+  // Delete Environment Button
+  document.getElementById('btnDeleteEnv')?.addEventListener('click', async () => {
+    if (editingEnvId === 'global') return showToast("Cannot delete Global environment.", true);
+    await executeDartTool("apidash_delete_environment", { id: editingEnvId });
+    editingEnvId = 'global';
+    await loadVariablesFromHive();
+    showToast("Environment deleted!");
+  });
+
+  // Rename Environment Button (In-Place Edit)
+  document.getElementById('btnRenameEnv')?.addEventListener('click', () => {
+    const nameEl = document.getElementById('activeEnvNameDisplay');
+    if (!nameEl || editingEnvId === 'global') return showToast("Cannot rename Global environment.", true);
+    
+    nameEl.contentEditable = 'true';
+    nameEl.style.borderBottom = '1px dashed #3b82f6';
+    nameEl.focus();
+
+    const saveName = async () => {
+      nameEl.contentEditable = 'false';
+      nameEl.style.borderBottom = 'none';
+      const newName = nameEl.innerText.trim() || 'Untitled Environment';
+      nameEl.innerText = newName;
+      await executeDartTool("apidash_rename_environment", { id: editingEnvId, name: newName });
+      await loadVariablesFromHive();
+      showToast("Environment renamed!");
+      nameEl.removeEventListener('blur', saveName);
+    };
+
+    nameEl.addEventListener('blur', saveName);
+    nameEl.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') { e.preventDefault(); nameEl.blur(); }
+    });
+  });
+
+  // Ensure New Environment gets a timestamped unique name to avoid duplicates
+  document.getElementById('btnNewEnv')?.addEventListener('click', async () => {
+    const all = Object.keys(allEnvironments);
+    const newId = 'env_' + Date.now();
+    const newName = "Environment " + (all.length);
+    await executeDartTool("apidash_save_variables", { id: newId, name: newName, values: [] });
+    editingEnvId = newId;
+    await loadVariablesFromHive();
+    showToast("New environment created!");
+  });
+
+  // --- STATE TRACKING FIX ---
+  let trackedExecutionId = null; // The request you are currently looking at/editing
+  let latestKnownExecutionId = null; // The absolute newest request in the database
+  
+  // Edit Request Name (In-Place DOM Edit, No Prompt)
+  document.getElementById('btnReqEdit')?.addEventListener('click', () => {
+    const titleEl = document.querySelector('.ad-req-title');
+    if (!titleEl) return;
+    
+    titleEl.contentEditable = 'true';
+    titleEl.style.borderBottom = '1px dashed #3b82f6';
+    titleEl.style.outline = 'none';
+    titleEl.focus();
+    
+    // Select the existing text for easy replacement
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(titleEl);
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    const finishEditing = async () => {
+      titleEl.contentEditable = 'false';
+      titleEl.style.borderBottom = 'none';
+      const newName = titleEl.innerText.trim() || 'untitled';
+      titleEl.innerText = newName;
+      titleEl.setAttribute('title', newName);
+      
+      // NEW: Automatically save the renamed title to the database
+      if (trackedExecutionId) {
+        try {
+          await executeDartTool("apidash_update_history_title", { 
+            execution_id: trackedExecutionId, 
+            title: newName 
+          });
+          // Refresh the ledger behind the scenes so the History tab reflects the change immediately
+          fetchHistoryLedger();
+        } catch(e) {}
+      }
+
+      showToast('Request name updated!');
+      titleEl.removeEventListener('blur', finishEditing);
+    };
+
+    titleEl.addEventListener('blur', finishEditing);
+    titleEl.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        titleEl.blur(); // Trigger blur to save
+      }
+    });
+  });
+
+  // Delete/Clear Button (No Confirm Dialog)
+  document.getElementById('btnReqDelete')?.addEventListener('click', () => {
+    // NEW: Unlink from the history record so we don't accidentally rename it later
+    trackedExecutionId = null; 
+
+    document.getElementById('reqUrlInput').value = '';
+    document.getElementById('reqBodyTextarea').value = '';
+    document.getElementById('paramsList').innerHTML = '';
+    document.getElementById('headersList').innerHTML = '';
+    
+    const titleEl = document.querySelector('.ad-req-title');
+    if (titleEl) {
+      titleEl.innerText = 'untitled';
+      titleEl.setAttribute('title', 'untitled');
+    }
+    
+    addKvRow('paramsList', 'Add URL Parameter...');
+    addKvRow('headersList', 'Add Name');
+    showToast('Request cleared!'); 
+  });
+
+  // Duplicate/Copy Button
+  document.getElementById('btnReqDuplicate')?.addEventListener('click', () => {
+    const titleEl = document.querySelector('.ad-req-title');
+    const payload = {
+      title: titleEl ? titleEl.innerText : 'untitled',
+      url: document.getElementById('reqUrlInput').value,
+      method: document.getElementById('methodText').innerText,
+      body: document.getElementById('reqBodyTextarea').value
+    };
+    try {
+      navigator.clipboard.writeText(JSON.stringify(payload, null, 2));
+      showToast('json is copied!'); 
+    } catch(e) {
+      showToast('Failed to copy. Clipboard access denied.', true);
+    }
+  });
+
+  function openNamedRoofTab(targetId) {
+    tabs.forEach(t => t.classList.remove('active'));
+    panes.forEach(p => p.classList.remove('active'));
+    document.querySelector(`[data-pane="\${targetId}"]`)?.classList.add('active');
+    document.getElementById(targetId)?.classList.add('active');
+
+    // Trigger data fetching based on the active tab
+    if (targetId === 'pane-vars') loadVariablesFromHive();
+    if (targetId === 'pane-history') fetchHistoryLedger();
+
+    setTimeout(sendResizeNotification, 50);
+  }
+
+
+  window.addEventListener('DOMContentLoaded', async () => {
+    const target = '$activeTab';
+
+    if (target === 'pane-history') {
+      openNamedRoofTab('pane-history');
+    } else if (target === 'pane-vars') {
+      openNamedRoofTab('pane-vars');
+    } else {
+      openNamedRoofTab('pane-studio');
+    }
+
+    try {
+      const res = await executeDartTool("apidash_get_results", { _cache_buster: Date.now().toString() });
+      const payload = res?.structuredContent || res?.result?.structuredContent || res?.meta?.structuredContent || res;
+      if (payload && payload.execution_id) {
+        trackedExecutionId = payload.execution_id;
+        latestKnownExecutionId = payload.execution_id;
+      }
+    } catch(e) {}
+    
+    loadVariablesFromHive();
+  });
+
+  tabs.forEach(tab => {
+    tab.addEventListener('click', () => {
+      const target = tab.getAttribute('data-pane');
+      openNamedRoofTab(target);
+    });
+  });
+
+  const subTabs = document.querySelectorAll('.req-sub-tab');
+  const subPanes = document.querySelectorAll('.req-sub-pane');
+  subTabs.forEach(tab => {
+    tab.addEventListener('click', () => {
+      const target = tab.getAttribute('data-sub');
+      subTabs.forEach(t => t.classList.remove('active'));
+      subPanes.forEach(p => p.classList.remove('active'));
+      tab.classList.add('active');
+      document.getElementById(target).classList.add('active');
+      setTimeout(sendResizeNotification, 50);
+    });
+  });
+
+  function addKvRow(listId, phText) {
+    const cont = document.getElementById(listId);
+    const div = document.createElement('div');
+    div.className = 'kv-row';
+    div.innerHTML = `
+      <input type="checkbox" class="kv-chk" checked>
+      <input type="text" class="kv-box k" placeholder="\${phText}">
+      <span class="kv-sep">=</span>
+      <input type="text" class="kv-box v" placeholder="Add Value">
+      <button class="kv-del" title="Delete"><svg viewBox="0 0 24 24"><path d="M15 12H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z" stroke="currentColor" stroke-width="2" fill="none"/></svg></button>
+    `;
+    cont.appendChild(div);
+    setTimeout(sendResizeNotification, 50);
+  }
+
+  function addVarRow(listId, phKey, phVal) {
+    const cont = document.getElementById(listId);
+    const div = document.createElement('div');
+    div.className = 'kv-row';
+    div.innerHTML = `
+      <input type="checkbox" class="kv-chk" style="width:14px; height:14px;" checked>
+      <input type="text" class="kv-box k" placeholder="\${phKey}" style="background: transparent; padding: 8px 12px; border-color: var(--border-divider);">
+      <span class="kv-sep" style="font-weight: normal; margin: 0 4px;">=</span>
+      <input type="text" class="kv-box v" placeholder="\${phVal}" style="background: transparent; padding: 8px 12px; border-color: var(--border-divider);">
+      <button class="kv-del" title="Delete" style="color: #f43f5e;"><svg viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11H7v-2h10v2z" stroke="currentColor" stroke-width="0" fill="currentColor"/></svg></button>
+    `;
+    cont.appendChild(div);
+    setTimeout(sendResizeNotification, 50);
+  }
+
+  document.addEventListener('click', (e) => {
+    const delBtn = e.target.closest('.kv-del');
+    if (delBtn) {
+      delBtn.closest('.kv-row').remove();
+      setTimeout(sendResizeNotification, 50);
+    }
+  });
+
+  document.getElementById('authSelectProxy')?.addEventListener('change', (e) => {
+    const label = document.getElementById('authHelperText');
+    if (!label) return;
+    if (e.target.value === 'None') label.textContent = "No authentication selected.";
+    else label.textContent = `Configure \${e.target.value} credentials below...`;
+  });
+
+  const mBox = document.getElementById('methodBox');
+  const mDisp = document.getElementById('methodDisplay');
+  const mText = document.getElementById('methodText');
+  const mOpts = document.querySelectorAll('.ad-drop-option');
+  mDisp.addEventListener('click', (e) => { e.stopPropagation(); mBox.classList.toggle('open'); });
+  mOpts.forEach(opt => {
+    opt.addEventListener('click', (e) => {
+      const val = e.target.getAttribute('data-val');
+      const clr = getComputedStyle(e.target).getPropertyValue('--clr');
+      mText.innerText = val;
+      mDisp.style.color = clr;
+      mOpts.forEach(o => o.classList.remove('active'));
+      e.target.classList.add('active');
+      mBox.classList.remove('open');
+    });
+  });
+  document.addEventListener('click', (e) => { if (!mBox.contains(e.target)) mBox.classList.remove('open'); });
+
+  // --- STATE MANAGEMENT ---
+  let allEnvironments = {};
+  let editingEnvId = 'global';
+
+  async function loadVariablesFromHive() {
+    try {
+      const res = await executeDartTool("apidash_get_variables", {});
+      allEnvironments = res?.structuredContent?.environments || res?.environments || {};
+      
+      renderEnvironmentSidebar();
+      renderActiveEnvironmentEditor();
+      
+      const selector = document.getElementById('activeEnvSelector');
+      if (selector) {
+        const currentVal = selector.value;
+        selector.innerHTML = '';
+        Object.keys(allEnvironments).forEach(id => {
+          const opt = document.createElement('option');
+          opt.value = id;
+          opt.innerText = allEnvironments[id].name || 'Unknown';
+          selector.appendChild(opt);
+        });
+        if (allEnvironments[currentVal]) selector.value = currentVal;
+      }
+    } catch(e) {}
+  }
+
+  function renderEnvironmentSidebar() {
+    const list = document.getElementById('envListContainer');
+    if (!list) return;
+    list.innerHTML = '';
+
+    Object.keys(allEnvironments).forEach(id => {
+      const env = allEnvironments[id];
+      const isGlobal = id === 'global';
+      const isActive = id === editingEnvId;
+      
+      const div = document.createElement('div');
+      div.className = `env-item \${isActive ? 'active' : ''}`;
+      div.style.cssText = `background: \${isActive ? 'var(--bg-surface-hover)' : 'transparent'}; border-left: 2px solid \${isActive ? 'var(--border-hover)' : 'transparent'}; color: \${isActive ? 'var(--text-tab-active)' : 'var(--text-main)'}; padding: 8px 12px; border-radius: 0 4px 4px 0; font-size: 13px; font-weight: 500; cursor: pointer; display: flex; justify-content: space-between; align-items: center;`;
+      
+      div.innerHTML = `<span>\${env.name}</span>\${isGlobal ? '<span style="font-size: 10px; background: var(--bg-input); border: 1px solid var(--border-color); color: var(--text-label); padding: 2px 6px; border-radius: 4px;">Default</span>' : ''}`;
+      
+      div.onclick = () => {
+        editingEnvId = id;
+        renderEnvironmentSidebar();
+        renderActiveEnvironmentEditor();
+      };
+      list.appendChild(div);
+    });
+  }
+
+  function renderActiveEnvironmentEditor() {
+    const env = allEnvironments[editingEnvId] || { name: 'Unknown', values: [] };
+    document.getElementById('activeEnvNameDisplay').innerText = env.name;
+    
+    const list = document.getElementById('globalVarsList');
+    if (!list) return;
+    list.innerHTML = '';
+
+    if (!env.values || env.values.length === 0) {
+      addVarRow('globalVarsList', 'Variable Name', 'Value');
+      return;
+    }
+
+    env.values.forEach(item => {
+      const div = document.createElement('div');
+      div.className = 'kv-row';
+      div.innerHTML = `
+        <input type="checkbox" class="kv-chk" style="width:14px; height:14px;" \${item.enabled !== false ? 'checked' : ''}>
+        <input type="text" class="kv-box k" value="\${item.key || ''}" placeholder="Variable Name" style="background: transparent; padding: 8px 12px; border-color: var(--border-divider);">
+        <span class="kv-sep" style="font-weight: normal; margin: 0 4px;">=</span>
+        <input type="text" class="kv-box v" value="\${item.value || ''}" placeholder="Value" style="background: transparent; padding: 8px 12px; border-color: var(--border-divider);">
+        <button class="kv-del" title="Delete" style="color: #f43f5e;"><svg viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11H7v-2h10v2z" stroke="currentColor" stroke-width="0" fill="currentColor"/></svg></button>
+      `;
+      list.appendChild(div);
+    });
+  }
+
+  document.getElementById('btnSaveEnv')?.addEventListener('click', async () => {
+    const values = [];
+    document.querySelectorAll('#globalVarsList .kv-row').forEach(row => {
+      const key = row.querySelector('.kv-box.k')?.value.trim();
+      if (key) {
+        values.push({
+          key: key, 
+          value: row.querySelector('.kv-box.v')?.value.trim(), 
+          enabled: row.querySelector('.kv-chk')?.checked
+        });
+      }
+    });
+
+    const envName = document.getElementById('activeEnvNameDisplay').innerText;
+    await executeDartTool("apidash_save_variables", { id: editingEnvId, name: envName, values: values });
+    loadVariablesFromHive();
+    showToast("Environment Saved!");
+  });
+
+  // --- REQUEST DISPATCHER ---
+  document.getElementById('btnFireRequest')?.addEventListener('click', async () => {
+    const url = document.getElementById('reqUrlInput').value.trim();
+    if (!url) return showToast("Please specify a target URL endpoint.", true);
+    
+    const method = document.getElementById('methodText').innerText;
+    const body = document.getElementById('reqBodyTextarea').value;
+    
+    // Fallback in case title element is not found
+    const titleEl = document.querySelector('.ad-req-title');
+    const reqTitle = titleEl ? titleEl.innerText : 'untitled';
+    
+    const envSelector = document.getElementById('activeEnvSelector');
+    const selectedEnvId = envSelector ? envSelector.value : 'global';
+    
+    let headers = {};
+    document.querySelectorAll('#headersList .kv-row').forEach(row => {
+      const isChecked = row.querySelector('.kv-chk')?.checked;
+      const key = row.querySelector('.kv-box.k')?.value.trim();
+      const val = row.querySelector('.kv-box.v')?.value.trim();
+      if (isChecked && key) headers[key] = val;
+    });
+
+    renderHydratedResults({ status_code: 0, time_ms: 0, response_body: "Dispatching request over MCP pipe..." });
+    const res = await executeDartTool("apidash_execute_request", {
+      title: reqTitle,
+      url, method,
+      headers: Object.keys(headers).length > 0 ? headers : undefined,
+      body: body ? body : undefined,
+      active_environment_id: selectedEnvId
+    });
+    const payload = res?.structuredContent || res?.result?.structuredContent || res?.meta?.structuredContent || res;
+    if (payload && payload.execution_id) {
+      trackedExecutionId = payload.execution_id;
+      latestKnownExecutionId = payload.execution_id;
+      renderHydratedResults(payload);
+    }
+  });
+
+  function renderHydratedResults(data) {
+    document.getElementById('builderCardCanvas').style.display = 'none';
+    const resCard = document.getElementById('resultsCardCanvas');
+    resCard.style.display = 'flex';
+    const code = data.status_code || 0;
+    const isOk = code >= 200 && code < 300;
+    const lblCode = document.getElementById('resStatusCodeLabel');
+    if (code === 0) {
+      lblCode.textContent = "⚡ FETCHING..."; lblCode.className = "res-status-code"; lblCode.style.color = "#fbbf24";
+    } else {
+      lblCode.textContent = `\${code}: \${isOk ? 'OK' : 'ERROR'}`; lblCode.className = `res-status-code \${isOk ? 'ok' : 'err'}`; lblCode.style.color = isOk ? "#4ade80" : "#f87171";
+    }
+    document.getElementById('resTimeLabel').textContent = (data.time_ms || 0) + ' ms';
+    let rawBody = data.response_body || 'No response body loaded.';
+    let cleanBody = rawBody;
+    try { cleanBody = JSON.stringify(JSON.parse(rawBody), null, 2); } catch(e) {}
+    document.getElementById('resPayloadPre').textContent = cleanBody;
+    const sizeB = new Blob([cleanBody]).size;
+    document.getElementById('resSizeLabel').textContent = sizeB < 1024 ? `\${sizeB} B` : `\${(sizeB / 1024).toFixed(2)} KB`;
+    setTimeout(sendResizeNotification, 50);
+  }
+
+  window.exitResultsView = function() {
+    document.getElementById('resultsCardCanvas').style.display = 'none';
+    document.getElementById('builderCardCanvas').style.display = 'flex';
+    setTimeout(sendResizeNotification, 50);
+  };
+
+  window.switchResSub = function(target) {
+    const btns = document.querySelectorAll('.res-subnav-strip .res-sub-btn');
+    if (target === 'body') {
+      btns[0].classList.add('active'); btns[1].classList.remove('active');
+      document.getElementById('resViewBodyWrapper').style.display = 'flex';
+      document.getElementById('resViewHeadersWrapper').style.display = 'none';
+    } else {
+      btns[1].classList.add('active'); btns[0].classList.remove('active');
+      document.getElementById('resViewBodyWrapper').style.display = 'none';
+      document.getElementById('resViewHeadersWrapper').style.display = 'block';
+    }
+    setTimeout(sendResizeNotification, 50);
+  };
+
+  window.addEventListener('message', async (event) => {
+    const msg = event.data;
+    if (msg && msg.type === 'HYDRATE_HISTORIC_RUN') {
+      openNamedRoofTab('pane-studio');
+      renderHydratedResults({ status_code: 0, time_ms: 0, response_body: "Querying Hive DB for historical run..." });
+      const res = await executeDartTool("apidash_get_results", { execution_id: msg.id });
+      const payload = res?.structuredContent || res?.result?.structuredContent || res?.meta?.structuredContent || res;
+      if (payload) {
+        trackedExecutionId = payload.execution_id || msg.id;
+        // Hydrate Title
+        const titleEl = document.querySelector('.ad-req-title');
+        if (titleEl) {
+          titleEl.innerText = payload.title || 'untitled';
+          titleEl.setAttribute('title', payload.title || 'untitled');
+        }
+        if (payload.url) document.getElementById('reqUrlInput').value = payload.url;
+        if (payload.method) {
+          document.getElementById('methodText').innerText = payload.method.toUpperCase();
+          document.getElementById('methodDisplay').style.color = `var(--http-\${payload.method.toLowerCase()}, var(--http-get))`;
+        }
+        renderHydratedResults(payload);
+      }
+    }
+  });
+
+  window.openHistoryResult = async function(id) {
+    openNamedRoofTab('pane-studio');
+    renderHydratedResults({ status_code: 0, time_ms: 0, response_body: "Loading execution record from Hive..." });
+    try {
+      const res = await executeDartTool("apidash_get_results", { execution_id: id });
+      const payload = res?.structuredContent || res?.result?.structuredContent || res?.meta?.structuredContent || res;
+      if (payload) {
+        trackedExecutionId = payload.execution_id || id;
+        // Hydrate Title
+        const titleEl = document.querySelector('.ad-req-title');
+        if (titleEl) {
+          titleEl.innerText = payload.title || 'untitled';
+          titleEl.setAttribute('title', payload.title || 'untitled');
+        }
+        if (payload.url) document.getElementById('reqUrlInput').value = payload.url;
+        if (payload.method) {
+          document.getElementById('methodText').innerText = payload.method.toUpperCase();
+          document.getElementById('methodDisplay').style.color = `var(--http-\${payload.method.toLowerCase()}, var(--http-get))`;
+        }
+        renderHydratedResults(payload);
+      }
+    } catch(e) {}
+  };
+
+  let isPolling = false;
+  setInterval(async () => {
+    if (isPolling) return;
+    isPolling = true;
+    try {
+      const res = await executeDartTool("apidash_get_results", { _cache_buster: Date.now().toString() });
+      const payload = res?.structuredContent || res?.result?.structuredContent || res?.meta?.structuredContent || res;
+      if (payload && payload.execution_id && payload.execution_id !== latestKnownExecutionId) {
+        latestKnownExecutionId = payload.execution_id;
+        trackedExecutionId = payload.execution_id;
+        // Hydrate Title
+        const titleEl = document.querySelector('.ad-req-title');
+        if (titleEl) {
+          titleEl.innerText = payload.title || 'untitled';
+          titleEl.setAttribute('title', payload.title || 'untitled');
+        }
+        if (payload.url) document.getElementById('reqUrlInput').value = payload.url;
+        if (payload.method) {
+          document.getElementById('methodText').innerText = payload.method.toUpperCase();
+          document.getElementById('methodDisplay').style.color = `var(--http-\${payload.method.toLowerCase()}, var(--http-get))`;
+        }
+        renderHydratedResults(payload);
+      }
+    } catch(e) {} finally { isPolling = false; }
+  }, 1500);
+
+  async function fetchHistoryLedger() {
+    const feed = document.getElementById('history-feed');
+    const spinner = document.getElementById('history-spinner');
+    if(!feed || !spinner) return;
+    feed.innerHTML = ''; spinner.style.display = 'block';
+    try {
+      const payload = await executeDartTool("apidash_list_history", { _cache_buster: Date.now().toString() });
+      spinner.style.display = 'none';
+      let data = [];
+      const raw = payload?.structuredContent || payload?.result?.structuredContent || payload?.meta?.structuredContent || payload;
+      if (Array.isArray(raw)) data = raw;
+      else if (raw && Array.isArray(raw.history)) data = raw.history;
+      else if (raw && raw.result && Array.isArray(raw.result)) data = raw.result;
+
+      if (data.length === 0) { 
+        feed.innerHTML = '<div class="ad-empty-notice">No requests executed yet.</div>'; 
+        setTimeout(sendResizeNotification, 50); return; 
+      }
+
+      data.forEach(req => {
+        const isOk = req.status >= 200 && req.status < 300;
+        const verbClr = `var(--http-\${req.method.toLowerCase()}, var(--http-get))`;
+        
+        const displayTitle = req.title && req.title.trim() !== '' ? req.title : 'untitled';
+
+        const item = document.createElement('div');
+        item.className = 'ad-hist-card';
+        item.innerHTML = `
+          <div class="ad-hist-left" onclick="openHistoryResult('\${req.execution_id}')" title="Click to load into Studio">
+            <span class="ad-hist-method" style="color:\${verbClr}; align-self: center;">\${req.method}</span>
+            <div style="display:flex; flex-direction:column; min-width:0; overflow:hidden; justify-content: center; gap: 2px;">
+              <span style="font-size: 13px; font-weight: 600; color: var(--text-main); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">\${displayTitle}</span>
+              <span class="ad-hist-url" style="color: var(--text-muted); font-size: 11px;">\${req.url}</span>
+            </div>
+          </div>
+          <div class="ad-hist-right">
+            <span style="color:\${isOk ? 'var(--http-get)' : 'var(--http-delete)'}; font-weight:700">\${req.status}</span>
+            <span style="color:var(--text-muted)">\${req.time_ms || 0}ms</span>
+            <button class="ad-hist-delete" onclick="triggerDelete('\${req.execution_id}', event)">Delete</button>
+          </div>
+        `;
+        feed.appendChild(item);
+      });
+      setTimeout(sendResizeNotification, 100);
+    } catch(e) { 
+      spinner.textContent = "❌ RPC Bridge Error."; 
+      setTimeout(sendResizeNotification, 50);
+    }
+  }
+
+  window.triggerDelete = async function(id, event) {
+    event.stopPropagation();
+    event.currentTarget.style.opacity = '0.3';
+    await executeDartTool("apidash_delete_request", { execution_id: id });
+    fetchHistoryLedger();
+  };
+</script>
+</body>
+</html>
+  ''';
+  }
+}

--- a/lib/mcp/ui/variables_pane.dart
+++ b/lib/mcp/ui/variables_pane.dart
@@ -1,0 +1,98 @@
+class VariablesPane {
+  static String get html => r'''
+  <!-- Pane 2: Variables -->
+  <div id="pane-vars" class="ad-pane" style="flex-direction: row; padding: 0; gap: 0; border-top: 1px solid var(--border-divider); height: 100%; box-sizing: border-box; position: relative;">
+    
+    <!-- OVERLAY LEFT SIDEBAR -->
+    <div id="vars-sidebar" style="display: none; position: absolute; z-index: 1000; left: 0; top: 0; bottom: 0; width: 280px; background-color: var(--bg-surface) !important; border-right: 1px solid var(--border-color); box-shadow: 8px 0 30px rgba(0, 0, 0, 0.5); flex-direction: column; height: 100%; flex-shrink: 0;">
+      
+      <!-- Row 1: Header & Exit Button -->
+      <div style="padding: 16px 16px 8px 16px; display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid var(--border-color);">
+        <span style="font-size: 12px; font-weight: 700; color: var(--text-label); text-transform: uppercase; letter-spacing: 0.5px;">Environments</span>
+        <button onclick="document.getElementById('vars-sidebar').style.display = 'none';" style="background: transparent; border: none; color: var(--text-muted); cursor: pointer; display: grid; place-items: center; padding: 4px; border-radius: 4px; transition: all 0.2s;" title="Close Panel">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+        </button>
+      </div>
+
+      <!-- Row 2: Action Buttons -->
+      <div style="padding: 12px 16px; display: flex; justify-content: space-between; align-items: center;">
+        <button id="btnSaveEnv" onclick="console.log('Hook: Save triggered')" style="background: transparent; border: 1px solid var(--border-color); color: var(--text-main); padding: 6px 12px; border-radius: 4px; display: flex; align-items: center; gap: 6px; font-size: 12px; cursor: pointer; font-family: inherit;">
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><path d="M17 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4zm-5 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm3-10H5V5h10v4z"/></svg>
+          Save
+        </button>
+        <button id="btnNewEnv" onclick="console.log('Hook: New Env triggered')" style="background: var(--btn-send-bg); border: none; color: var(--btn-send-text); padding: 6px 14px; border-radius: 4px; font-size: 12px; cursor: pointer; display: flex; align-items: center; font-weight: 600; font-family: inherit;">
+          + New
+        </button>
+      </div>
+
+      <!-- Filter Input -->
+      <div style="padding: 0 16px 12px 16px;">
+        <div style="position: relative; width: 100%;">
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="var(--text-muted)" style="position: absolute; left: 10px; top: 50%; transform: translateY(-50%);"><path d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"/></svg>
+          <input type="text" id="envFilterInput" placeholder="Filter by name" style="width: 100%; background: var(--bg-input); border: 1px solid var(--border-color); border-radius: 4px; padding: 7px 8px 7px 30px; color: var(--text-main); font-size: 13px; outline: none; box-sizing: border-box; font-family: inherit;">
+        </div>
+      </div>
+
+      <!-- Environment List Container -->
+      <div id="envListContainer" style="flex: 1; overflow-y: auto; padding: 0 16px; display: flex; flex-direction: column; gap: 4px;">
+        <div class="env-item active" data-env-id="global" style="background: var(--bg-surface-hover); border-left: 2px solid var(--border-hover); color: var(--text-tab-active); padding: 8px 12px; border-radius: 0 4px 4px 0; font-size: 13px; font-weight: 500; cursor: pointer; display: flex; justify-content: space-between; align-items: center;">
+          <span>Global</span>
+          <span style="font-size: 10px; background: var(--bg-input); border: 1px solid var(--border-color); color: var(--text-label); padding: 2px 6px; border-radius: 4px;">Default</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- RIGHT MAIN CANVAS: Key-Value Editor -->
+    <div style="flex: 1; background: var(--bg-canvas); display: flex; flex-direction: column; height: 100%; width: 100%; overflow: hidden;">
+      
+      <!-- Top Action Bar -->
+      <div style="display: flex; justify-content: space-between; align-items: center; padding: 16px 24px; border-bottom: 1px solid var(--border-divider);">
+        <div style="display: flex; align-items: center; gap: 12px;">
+          <button id="btnToggleEnvSidebar" onclick="const sb = document.getElementById('vars-sidebar'); sb.style.display = sb.style.display === 'none' ? 'flex' : 'none';" style="background: var(--bg-surface); border: 1px solid var(--border-color); color: var(--text-muted); cursor: pointer; display: flex; align-items: center; justify-content: center; padding: 6px 10px; border-radius: 4px; font-size: 12px; gap: 6px; font-family: inherit;">
+            <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="9" y1="3" x2="9" y2="21"></line></svg>
+            <span>Environments</span>
+          </button>
+          <h2 id="activeEnvNameDisplay" style="font-size: 15px; font-weight: 500; color: var(--text-main); margin: 0; font-family: inherit;">Global</h2>
+        </div>
+        
+        <div class="ad-icon-bar" style="background: var(--bg-surface); border: 1px solid var(--border-color);">
+          <button id="btnRenameEnv" title="Rename Environment"><svg viewBox="0 0 24 24"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg></button>
+          <button id="btnDeleteEnv" title="Delete Environment"><svg viewBox="0 0 24 24"><path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/></svg></button>
+          <button id="btnDuplicateEnv" title="Duplicate Environment"><svg viewBox="0 0 24 24"><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg></button>
+        </div>
+      </div>
+
+      <!-- Variables Table Area -->
+      <div style="flex: 1; padding: 24px; overflow-y: auto;">
+        <div style="border: 1px solid var(--border-color); border-radius: 4px; display: flex; flex-direction: column; min-height: 400px; background: var(--bg-surface);">
+          
+          <div style="display: flex; border-bottom: 1px solid var(--border-color); padding: 12px 16px; font-size: 12px; font-weight: 600; color: var(--text-label); text-transform: uppercase; background: var(--bg-header);">
+            <div style="width: 24px;"></div>
+            <div style="flex: 1; text-align: center;">Variable Name</div>
+            <div style="width: 20px;"></div>
+            <div style="flex: 1.5; text-align: center;">Value</div>
+            <div style="width: 24px;"></div>
+          </div>
+
+          <div class="kv-rows" id="globalVarsList" style="padding: 16px; gap: 12px;">
+            <div class="kv-row">
+              <input type="checkbox" class="kv-chk" checked>
+              <input type="text" class="kv-box k" placeholder="e.g. BASE_URL" style="background: var(--bg-input); border: 1px solid var(--border-color); color: var(--text-main); font-family: var(--font-mono); padding: 8px 12px; border-radius: 4px; font-size: 13px; outline: none;">
+              <span class="kv-sep" style="font-weight: bold; margin: 0 8px; color: var(--text-muted); font-size: 14px;">=</span>
+              <input type="text" class="kv-box v" placeholder="e.g. https://api.example.com" style="background: var(--bg-input); border: 1px solid var(--border-color); color: var(--text-main); font-family: var(--font-mono); padding: 8px 12px; border-radius: 4px; font-size: 13px; outline: none;">
+              <button class="kv-del" title="Delete"><svg viewBox="0 0 24 24"><path d="M15 12H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z" stroke="currentColor" stroke-width="2" fill="none"/></svg></button>
+            </div>
+          </div>
+
+          <div style="display: flex; justify-content: center; margin-top: auto; padding: 20px 0;">
+            <button class="btn-add-row" onclick="addVarRow('globalVarsList', 'Variable Name', 'Value')" style="background: transparent; border: 1px solid var(--border-color); color: var(--text-main); padding: 6px 16px; font-size: 12px; border-radius: 4px; cursor: pointer; font-family: inherit;">
+              + Add Variable
+            </button>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+  ''';
+}

--- a/lib/mcp/utils/host_style_variables.dart
+++ b/lib/mcp/utils/host_style_variables.dart
@@ -1,0 +1,46 @@
+class HostStyleVariables {
+  static String get css => r'''
+    :root {
+      /* 1. Canvas & Surface Backgrounds (Goose -> VS Code -> Hex Fallback) */
+      --bg-canvas: var(--host-bg, var(--vscode-editor-background, #121212));
+      --bg-input: var(--host-input-bg, var(--vscode-input-background, #1e1e1e));
+      --bg-surface: var(--host-surface-bg, var(--vscode-sideBar-background, #181818));
+      --bg-surface-hover: var(--host-surface-hover, var(--vscode-list-hoverBackground, #272727));
+
+      /* 2. Headers & Tabs */
+      --bg-header: var(--host-header-bg, var(--vscode-editorGroupHeader-tabsBackground, #141414));
+      --bg-tab-active: var(--host-tab-active, var(--vscode-tab-activeBackground, #1e1e1e));
+      --bg-tab-hover: var(--host-tab-hover, var(--vscode-tab-hoverBackground, rgba(255, 255, 255, 0.05)));
+      
+      /* 3. Typography & Text Colors */
+      --text-main: var(--host-color, var(--vscode-editor-foreground, #f3f4f6));
+      --text-muted: var(--host-muted, var(--vscode-input-placeholderForeground, #6b7280));
+      --text-label: var(--host-label, var(--vscode-descriptionForeground, #9ca3af));
+      --text-tab-active: var(--host-tab-active-text, var(--vscode-tab-activeForeground, #f9fafb));
+      --text-tab-inactive: var(--host-tab-inactive-text, var(--vscode-tab-inactiveForeground, #6b7280));
+
+      /* 4. Borders & Dividers */
+      --border-color: var(--host-border, var(--vscode-input-border, var(--vscode-widget-border, #2d2d2d)));
+      --border-hover: var(--host-border-hover, var(--vscode-focusBorder, #3b82f6));
+      --border-divider: var(--host-divider, var(--vscode-editorGroupHeader-tabsBorder, #262626));
+      --border-active-tab: var(--host-active-tab-border, var(--vscode-tab-activeBorder, var(--vscode-focusBorder, #60a5fa)));
+
+      /* 5. Buttons */
+      --btn-send-bg: var(--host-btn-bg, var(--vscode-button-background, #93c5fd));
+      --btn-send-text: var(--host-btn-text, var(--vscode-button-foreground, #0f172a));
+      --btn-send-hover: var(--host-btn-hover, var(--vscode-button-hoverBackground, #bfdbfe));
+
+      /* 6. API Dash HTTP Verb Colors (Terminal ANSI Mapping) */
+      --http-get: var(--vscode-terminal-ansiBrightGreen, #4ade80);
+      --http-head: var(--vscode-terminal-ansiGreen, #86efac);
+      --http-post: var(--vscode-terminal-ansiBrightBlue, #60a5fa);
+      --http-put: var(--vscode-terminal-ansiBrightYellow, #fbbf24);
+      --http-patch: var(--vscode-terminal-ansiYellow, #fb923c);
+      --http-delete: var(--vscode-terminal-ansiBrightRed, #f87171);
+      --http-options: var(--vscode-terminal-ansiBrightMagenta, #c084fc);
+
+      /* 7. Fonts */
+      --font-mono: var(--vscode-editor-font-family, "JetBrains Mono", Consolas, monospace);
+    }
+  ''';
+}

--- a/lib/mcp/utils/message_handler.dart
+++ b/lib/mcp/utils/message_handler.dart
@@ -1,0 +1,38 @@
+class MessageHandler {
+  static String get js => r'''
+    // 0. The Missing Handshake (Claude's Green Light)
+    window.parent.postMessage({ type: 'ready' }, '*');
+    window.parent.postMessage({ jsonrpc: '2.0', method: 'ready' }, '*');
+    window.parent.postMessage({ jsonrpc: '2.0', method: 'notifications/initialized' }, '*');
+
+    // 1. Dynamic Host Theme Synchronization
+    window.addEventListener('message', (event) => {
+      const msg = event.data;
+      if (msg && (msg.method === 'ui/initialize' || msg?.hostContext?.styles?.variables)) {
+        
+        // STRICT MCP REQUIREMENT: Acknowledge initialization if the host sent a request ID
+        if (msg.id) {
+          window.parent.postMessage({ jsonrpc: '2.0', id: msg.id, result: {} }, '*');
+        }
+
+        const vars = msg?.hostContext?.styles?.variables || msg?.params?.hostContext?.styles?.variables;
+        if (vars) {
+          for (const [key, value] of Object.entries(vars)) {
+            if (value) document.documentElement.style.setProperty(key, value);
+          }
+        }
+      }
+    });
+
+    // 2. Iframe Auto-Resizer
+    const sendResizeNotification = () => {
+      const scrollHeight = document.documentElement.scrollHeight || document.body.scrollHeight;
+      window.parent.postMessage({ type: 'MCP_APP_RESIZE', height: scrollHeight }, '*');
+      window.parent.postMessage({ jsonrpc: '2.0', method: 'ui/notifications/resize', params: { height: scrollHeight } }, '*');
+    };
+    new ResizeObserver(sendResizeNotification).observe(document.body);
+    
+    // Trigger an initial resize computation just in case
+    setTimeout(sendResizeNotification, 100);
+  ''';
+}

--- a/lib/mcp/utils/rpc_client.dart
+++ b/lib/mcp/utils/rpc_client.dart
@@ -1,0 +1,42 @@
+class RpcClient {
+  static String get js => r'''
+    async function executeMcpTool(name, args) {
+      if (typeof request === 'function') {
+        return await request("tools/call", { name, arguments: args });
+      } else {
+        return new Promise((resolve, reject) => {
+          const id = Math.random().toString(36).substring(7);
+          
+          // Failsafe timeout for strict clients like Claude
+          const timeout = setTimeout(() => {
+            window.removeEventListener('message', handler);
+            reject(new Error("Tool execution timed out waiting for host response."));
+          }, 15000);
+
+          const handler = (event) => {
+            const msg = event.data;
+            if (msg && msg.jsonrpc === '2.0' && msg.id === id) {
+              clearTimeout(timeout);
+              window.removeEventListener('message', handler);
+              
+              if (msg.error) {
+                reject(msg.error);
+              } else {
+                resolve(msg.result);
+              }
+            }
+          };
+          window.addEventListener('message', handler);
+          window.parent.postMessage({ 
+            jsonrpc: '2.0', 
+            id: id, 
+            method: 'tools/call', 
+            params: { name, arguments: args } 
+          }, '*');
+        });
+      }
+    }
+    // Alias for studio compatibility
+    const executeDartTool = executeMcpTool;
+  ''';
+}

--- a/lib/mcp/utils/shared_styles.dart
+++ b/lib/mcp/utils/shared_styles.dart
@@ -1,0 +1,19 @@
+class SharedStyles {
+  static String get css => r'''
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    
+    html, body {
+      width: 100%;
+      height: 100%;
+      margin: 0;
+      padding: 0;
+      overflow: hidden;
+      background-color: var(--bg-canvas, #121212);
+      font-family: var(--vscode-font-family, -apple-system, system-ui, sans-serif);
+      color: var(--text-main, #f3f4f6);
+      display: flex;
+      flex-direction: column;
+      box-sizing: border-box;
+    }
+  ''';
+}

--- a/lib/models/agentic_dashboard_state.dart
+++ b/lib/models/agentic_dashboard_state.dart
@@ -1,0 +1,35 @@
+class AgenticDashboardState {
+  final bool isAiThinking;
+  final String? error;
+  final Map<String, dynamic>? dashboardData;
+  final List<Map<String, dynamic>> testResults;
+  final bool isExecuting;
+  final bool isComplete;
+
+  AgenticDashboardState({
+    this.isAiThinking = false,
+    this.error,
+    this.dashboardData,
+    this.testResults = const [],
+    this.isExecuting = false,
+    this.isComplete = false,
+  });
+
+  AgenticDashboardState copyWith({
+    bool? isAiThinking,
+    String? error,
+    Map<String, dynamic>? dashboardData,
+    List<Map<String, dynamic>>? testResults,
+    bool? isExecuting,
+    bool? isComplete,
+  }) {
+    return AgenticDashboardState(
+      isAiThinking: isAiThinking ?? this.isAiThinking,
+      error: error, // Null out error if not explicitly provided
+      dashboardData: dashboardData ?? this.dashboardData,
+      testResults: testResults ?? this.testResults,
+      isExecuting: isExecuting ?? this.isExecuting,
+      isComplete: isComplete ?? this.isComplete,
+    );
+  }
+}

--- a/lib/providers/agentic_providers.dart
+++ b/lib/providers/agentic_providers.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:apidash/models/models.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:hive_ce_flutter/adapters.dart';
+class AgenticHistoryNotifier extends StateNotifier<Map<String, RequestModel>> {
+  AgenticHistoryNotifier() : super({}) {
+    _init();
+  }
+
+  void _init() {
+    final box = Hive.box('internal_agent_history');
+    final Map<String, RequestModel> items = {};
+
+    for (final key in box.keys) {
+      final val = box.get(key);
+      if (val != null) {
+        try {
+          items[key.toString()] = RequestModel.fromJson(Map<String, dynamic>.from(val));
+        } catch (_) {
+          // Ignore malformed data
+        }
+      }
+    }
+    state = items;
+  }
+
+  void addRequest(RequestModel request) {
+    state = {...state, request.id: request};
+    Hive.box('internal_agent_history').put(request.id, request.toJson());
+  }
+
+  void addRequests(List<RequestModel> requests) {
+    final Map<String, RequestModel> newItems = {};
+    for (var req in requests) {
+      newItems[req.id] = req;
+    }
+
+    // Update state once
+    state = {...state, ...newItems};
+
+    // Batch write to Hive to prevent UI stuttering
+    final box = Hive.box('internal_agent_history');
+    box.putAll(newItems.map((key, value) => MapEntry(key, value.toJson())));
+  }
+
+  void deleteRequest(String id) {
+    final newState = Map<String, RequestModel>.from(state);
+    newState.remove(id);
+    state = newState;
+    Hive.box('internal_agent_history').delete(id);
+  }
+
+  void clearAllHistory() {
+    state = {};
+    Hive.box('internal_agent_history').clear();
+  }
+}
+
+/// Shared provider for the Agentic History collection
+final agenticCollectionStateNotifierProvider =
+StateNotifierProvider<AgenticHistoryNotifier, Map<String, RequestModel>>((ref) {
+  return AgenticHistoryNotifier();
+});
+
+/// Shared provider for tracking the active selected request
+final activeAgenticIdStateProvider = StateProvider<String?>((ref) => null);
+
+final agenticHistoryGroupedProvider = Provider<Map<String, List<RequestModel>>>((ref) {
+  final collection = ref.watch(agenticCollectionStateNotifierProvider);
+  final grouped = <String, List<RequestModel>>{};
+
+  for (final req in collection.values) {
+    final parts = req.name.split('::');
+    final groupName = parts.length > 1 ? parts[0] : 'Ungrouped AI Tests';
+    final cleanReq = req.copyWith(name: parts.length > 1 ? parts.sublist(1).join('::') : req.name);
+
+    grouped.putIfAbsent(groupName, () => []).add(cleanReq);
+  }
+
+  return grouped;
+});

--- a/lib/providers/agentic_testing_provider.dart
+++ b/lib/providers/agentic_testing_provider.dart
@@ -1,0 +1,172 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:google_generative_ai/google_generative_ai.dart';
+import 'package:http/http.dart' as http;
+import 'package:apidash_core/apidash_core.dart';
+
+import '../models/agentic_dashboard_state.dart';
+import '../models/request_model.dart';
+import '../mcp/tool_executor.dart';
+import 'agentic_providers.dart';
+
+final agenticDashboardProvider = StateNotifierProvider<AgenticTestingNotifier, AgenticDashboardState>((ref) {
+  return AgenticTestingNotifier(ref);
+});
+
+class AgenticTestingNotifier extends StateNotifier<AgenticDashboardState> {
+  final Ref ref;
+
+  AgenticTestingNotifier(this.ref) : super(AgenticDashboardState(
+      dashboardData: {
+        "suite_name": "Welcome to Agentic Testing",
+        "explanation": "Configure your API key and target URL, then type a goal below to generate an intelligent test suite.",
+        "tests": []
+      }
+  ));
+
+  Future<void> generateTestPlan(String prompt, String apiKey, String targetUrl) async {
+    state = state.copyWith(isAiThinking: true, error: null);
+
+    try {
+      final model = GenerativeModel(model: 'gemini-2.5-flash', apiKey: apiKey);
+
+      String openApiSpec = "";
+      try {
+        final specResponse = await http.get(Uri.parse('$targetUrl/openapi.json'));
+        if (specResponse.statusCode == 200) openApiSpec = specResponse.body;
+      } catch (_) {}
+
+      final envContextStr = jsonEncode(ToolExecutor.getAllEnvironments());
+
+      final sysPrompt = '''
+You are an embedded Agentic API Testing Co-Pilot inside API Dash. 
+Base URL: "$targetUrl". 
+User Goal: "$prompt".
+Workspace Context: $envContextStr
+OpenAPI: ${openApiSpec.isNotEmpty ? openApiSpec : "None"}
+
+Generate a comprehensive test suite. Return ONLY a raw JSON object matching:
+{"suite_name": "...", "explanation": "...", "tests": [{"title": "...", "expected": "...", "url": "$targetUrl/...", "method": "GET", "body": "...", "expected_status": 200}]}
+''';
+
+      final response = await model.generateContent([Content.text(sysPrompt)]);
+      final String jsonStr = response.text?.replaceAll('```json', '').replaceAll('```', '').trim() ?? '{}';
+
+      state = AgenticDashboardState(
+        dashboardData: jsonDecode(jsonStr),
+      );
+    } catch (e) {
+      state = state.copyWith(isAiThinking: false, error: "Error generating tests: $e");
+    }
+  }
+
+  Future<void> runTests(String targetUrl) async {
+    if (state.dashboardData == null) return;
+
+    state = state.copyWith(isExecuting: true, testResults: [], isComplete: false);
+
+    final List<dynamic> tests = state.dashboardData!['tests'] ?? [];
+    final String suiteTag = state.dashboardData!['suite_name'] ?? 'AI Test Suite';
+    List<Map<String, dynamic>> results = [];
+    List<RequestModel> generatedHistory = [];
+
+    for (int i = 0; i < tests.length; i++) {
+      final test = tests[i];
+      try {
+        final payload = test['body'];
+        final safeBody = (payload == null || payload.toString().isEmpty)
+            ? null
+            : (payload is String ? payload : jsonEncode(payload));
+
+        String rawUrl = test['url']?.toString().replaceFirst('{{base_url}}', targetUrl) ?? '';
+        if (rawUrl.startsWith('/')) rawUrl = '$targetUrl$rawUrl';
+
+        final httpResult = await ToolExecutor.executeRequest({
+          "title": test['title'],
+          "url": rawUrl,
+          "method": test['method'],
+          "headers": {"Content-Type": "application/json", "Accept": "application/json"},
+          "body": safeBody,
+          "active_environment_id": "global"
+        }, isInternal: true);
+
+        final int actualStatusCode = httpResult['statusCode'] ?? httpResult['status_code'] ?? 200;
+        final int expectedStatusCode = test['expected_status'];
+
+        Map<String, String>? responseHeadersMap;
+        if (httpResult['headers'] != null && httpResult['headers'] is Map) {
+          responseHeadersMap = (httpResult['headers'] as Map).map(
+                (key, value) => MapEntry(key.toString().toLowerCase(), value.toString()),
+          );
+        }
+
+        dynamic rawResBody = httpResult['response_body'] ?? httpResult['responseBody'] ?? httpResult['body'];
+        String rawString = (rawResBody != null && rawResBody.toString().isNotEmpty)
+            ? (rawResBody is String ? rawResBody : jsonEncode(rawResBody))
+            : "{}";
+
+        // Performance Optimization: Isolate for heavy payload parsing
+        final Uint8List finalBytes = await compute<String, Uint8List>(
+              (body) => Uint8List.fromList(utf8.encode(body)),
+          rawString,
+        );
+
+        String formatted = rawString;
+        try { formatted = const JsonEncoder.withIndent('  ').convert(jsonDecode(rawString)); } catch (_) {}
+
+        final newReqId = 'agentic_${DateTime.now().microsecondsSinceEpoch}_$i';
+
+        final historyRequest = RequestModel(
+          id: newReqId,
+          name: "$suiteTag::${test['title'] ?? 'AI Test'}",
+          apiType: APIType.rest,
+          httpRequestModel: HttpRequestModel(
+            url: rawUrl,
+            method: HTTPVerb.values.byName(test['method'].toString().toLowerCase()),
+            body: safeBody,
+            headers: const [
+              NameValueModel(name: 'Content-Type', value: 'application/json'),
+              NameValueModel(name: 'Accept', value: 'application/json'),
+            ],
+          ),
+          responseStatus: actualStatusCode,
+          httpResponseModel: HttpResponseModel(
+            statusCode: actualStatusCode,
+            body: rawString,
+            formattedBody: formatted,
+            bodyBytes: finalBytes,
+            headers: responseHeadersMap,
+            time: Duration(milliseconds: (httpResult['time_ms'] ?? httpResult['timeMs'] ?? 150) as int),
+          ),
+        );
+
+        generatedHistory.add(historyRequest);
+
+        bool isSuccess = (expectedStatusCode >= 200 && expectedStatusCode < 300)
+            ? (actualStatusCode >= 200 && actualStatusCode < 300)
+            : (actualStatusCode == expectedStatusCode);
+
+        results.add({
+          'index': i,
+          'passed': isSuccess,
+          'message': 'Got $actualStatusCode (Expected $expectedStatusCode)',
+          'request_id': newReqId,
+        });
+
+      } catch (e) {
+        results.add({'index': i, 'passed': false, 'message': 'Failed: $e'});
+      }
+    }
+
+    // Performance Optimization: Batch history writes
+    ref.read(agenticCollectionStateNotifierProvider.notifier).addRequests(generatedHistory);
+
+    state = state.copyWith(
+      isExecuting: false,
+      isComplete: true,
+      testResults: results,
+    );
+  }
+}

--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -109,6 +109,26 @@ class CollectionStateNotifier
     unsave();
   }
 
+  void addModel(RequestModel requestModel) {
+    final id = requestModel.id;
+
+    // 1. Add the cloned model to the main state map
+    var map = {...state!};
+    map[id] = requestModel;
+    state = map;
+
+    // 2. Insert it at the top of the sidebar sequence
+    var itemIds = ref.read(requestSequenceProvider);
+    itemIds.insert(0, id);
+    ref.read(requestSequenceProvider.notifier).state = [...itemIds];
+
+    // 3. Set it as the active tab in the workspace
+    ref.read(selectedIdStateProvider.notifier).state = id;
+
+    // 4. Trigger the save pipeline
+    unsave();
+  }
+
   void reorder(int oldIdx, int newIdx) {
     var itemIds = ref.read(requestSequenceProvider);
     final itemId = itemIds.removeAt(oldIdx);

--- a/lib/providers/ui_providers.dart
+++ b/lib/providers/ui_providers.dart
@@ -15,7 +15,7 @@ final saveDataStateProvider = StateProvider<bool>((ref) => false);
 final clearDataStateProvider = StateProvider<bool>((ref) => false);
 final hasUnsavedChangesProvider = StateProvider<bool>((ref) => false);
 final showTerminalBadgeProvider = StateProvider<bool>((ref) => false);
-
+final showGenTestBadgeProvider = StateProvider<bool>((ref) => true);
 // final nameTextFieldControllerProvider =
 //     StateProvider.autoDispose<TextEditingController>((ref) {
 //   TextEditingController controller = TextEditingController(text: "");

--- a/lib/screens/agentic_history/agentic_history_screen.dart
+++ b/lib/screens/agentic_history/agentic_history_screen.dart
@@ -1,0 +1,219 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:apidash/models/models.dart';
+import 'package:apidash_core/apidash_core.dart';
+import 'package:apidash/widgets/widgets.dart';
+import '../../consts.dart';
+import '../../providers/agentic_providers.dart';
+import '../../providers/providers.dart';
+import '../../screens/history/history_details.dart';
+
+class AgenticHistoryScreen extends ConsumerWidget {
+  const AgenticHistoryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final isNarrowScreen = constraints.maxWidth < 800;
+
+        if (isNarrowScreen) {
+          return Scaffold(
+            backgroundColor: Theme.of(context).colorScheme.surface,
+            appBar: AppBar(
+              title: const Text("Agentic History", style: TextStyle(fontSize: 16)),
+              scrolledUnderElevation: 0,
+            ),
+            drawer: const Drawer(
+              child: SafeArea(child: _AgenticHistorySidebar()),
+            ),
+            body: const _AgenticHistoryDetails(),
+          );
+        }
+
+        return const Row(
+          children: [
+            SizedBox(
+              width: 280,
+              child: _AgenticHistorySidebar(),
+            ),
+            VerticalDivider(width: 1, thickness: 1),
+            Expanded(
+              child: _AgenticHistoryDetails(),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _AgenticHistorySidebar extends ConsumerWidget {
+  const _AgenticHistorySidebar();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final groupedRequests = ref.watch(agenticHistoryGroupedProvider);
+    final activeId = ref.watch(activeAgenticIdStateProvider);
+
+    return Column(
+      children: [
+        if (MediaQuery.sizeOf(context).width >= 800) ...[
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text(
+                  "Agentic History",
+                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                ),
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    SizedBox(
+                      height: 24,
+                      width: 24,
+                      child: IconButton(
+                        padding: EdgeInsets.zero,
+                        icon: Icon(
+                          Icons.delete_outline,
+                          size: 20,
+                          color: Theme.of(context).colorScheme.error,
+                        ),
+                        tooltip: 'Clear All Agentic History',
+                        onPressed: () {
+                          ref.read(activeAgenticIdStateProvider.notifier).state = null;
+                          ref.read(agenticCollectionStateNotifierProvider.notifier).clearAllHistory();
+                        },
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    SizedBox(
+                      height: 24,
+                      width: 24,
+                      child: IconButton(
+                        padding: EdgeInsets.zero,
+                        icon: Icon(
+                          Icons.history_toggle_off,
+                          size: 20,
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                        tooltip: 'History Settings',
+                        // --- FUNCTIONAL SETTINGS TRIGGER ---
+                        onPressed: () {
+                          showHistoryRetentionDialog(
+                            context,
+                            ref.read(
+                              settingsProvider.select(
+                                    (value) => value.historyRetentionPeriod,
+                              ),
+                            ),
+                                (value) {
+                              ref
+                                  .read(settingsProvider.notifier)
+                                  .update(historyRetentionPeriod: value);
+                            },
+                          );
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          const Divider(height: 1),
+        ],
+        Expanded(
+          child: ListView.builder(
+            itemCount: groupedRequests.keys.length,
+            itemBuilder: (context, index) {
+              final groupName = groupedRequests.keys.elementAt(index);
+              final items = groupedRequests[groupName]!;
+
+              return ExpansionTile(
+                initiallyExpanded: false,
+                shape: const Border(),
+                title: Text(
+                  groupName,
+                  style: const TextStyle(fontWeight: FontWeight.w600, fontSize: 13),
+                ),
+                subtitle: Text("${items.length} tests", style: const TextStyle(fontSize: 11)),
+                children: items.map((req) {
+                  if (req.httpRequestModel == null) return const SizedBox.shrink();
+
+                  return Padding(
+                    padding: const EdgeInsets.all(1.0),
+                    child: SidebarRequestCard(
+                      id: req.id,
+                      apiType: req.apiType,
+                      method: req.httpRequestModel?.method,
+                      name: req.name.split('::').last,
+                      url: req.getUrl(),
+                      selectedId: activeId,
+                      onTap: () {
+                        ref.read(activeAgenticIdStateProvider.notifier).state = req.id;
+
+                        if (MediaQuery.sizeOf(context).width < 800) {
+                          Navigator.pop(context);
+                        }
+                      },
+                      onMenuSelected: (ItemMenuOption item) {
+                        if (item == ItemMenuOption.delete) {
+                          if (activeId == req.id) {
+                            ref.read(activeAgenticIdStateProvider.notifier).state = null;
+                          }
+                          ref.read(agenticCollectionStateNotifierProvider.notifier).deleteRequest(req.id);
+                        }
+                      },
+                    ),
+                  );
+                }).toList(),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _AgenticHistoryDetails extends ConsumerWidget {
+  const _AgenticHistoryDetails();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final activeId = ref.watch(activeAgenticIdStateProvider);
+    final collection = ref.watch(agenticCollectionStateNotifierProvider);
+    final activeRequest = activeId != null ? collection[activeId] : null;
+
+    if (activeRequest == null) {
+      return const Center(child: Text("Select an agentic test to view details"));
+    }
+
+    final historyModel = HistoryRequestModel(
+      historyId: activeRequest.id,
+      metaData: HistoryMetaModel(
+        historyId: activeRequest.id,
+        requestId: activeRequest.id,
+        apiType: activeRequest.apiType,
+        name: activeRequest.name.split('::').last,
+        url: activeRequest.httpRequestModel?.url ?? '',
+        method: activeRequest.httpRequestModel?.method ?? HTTPVerb.get,
+        responseStatus: activeRequest.responseStatus ?? -1,
+        timeStamp: DateTime.now(),
+      ),
+      httpRequestModel: activeRequest.httpRequestModel,
+      httpResponseModel: activeRequest.httpResponseModel ?? const HttpResponseModel(),
+    );
+
+    return ProviderScope(
+      key: ValueKey(activeRequest.id),
+      overrides: [
+        selectedHistoryRequestModelProvider.overrideWith((ref) => historyModel),
+      ],
+      child: const HistoryDetails(),
+    );
+  }
+}

--- a/lib/screens/agentic_testing/agentic_testing_screen.dart
+++ b/lib/screens/agentic_testing/agentic_testing_screen.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../providers/agentic_testing_provider.dart';
+import 'widgets/native_test_dashboard.dart';
+
+class AgenticTestingScreen extends ConsumerStatefulWidget {
+  const AgenticTestingScreen({super.key});
+
+  @override
+  ConsumerState<AgenticTestingScreen> createState() => _AgenticTestingScreenState();
+}
+
+class _AgenticTestingScreenState extends ConsumerState<AgenticTestingScreen> {
+  final TextEditingController _promptController = TextEditingController();
+  final TextEditingController _urlController = TextEditingController();
+  final TextEditingController _apiKeyController = TextEditingController();
+
+  void _handleSubmit() {
+    final prompt = _promptController.text.trim();
+    if (prompt.isEmpty) return;
+
+    if (_apiKeyController.text.isEmpty || _urlController.text.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text("Please configure API Key and Target URL first.")),
+      );
+      return;
+    }
+
+    ref.read(agenticDashboardProvider.notifier).generateTestPlan(
+      prompt, _apiKeyController.text.trim(), _urlController.text.trim(),
+    );
+    _promptController.clear();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final dashboardState = ref.watch(agenticDashboardProvider);
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Scaffold(
+      backgroundColor: colorScheme.surface,
+      body: Padding(
+        padding: const EdgeInsets.all(30.0),
+        child: Column(
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _apiKeyController,
+                    obscureText: true,
+                    decoration: InputDecoration(
+                      labelText: "Gemini API Key",
+                      border: OutlineInputBorder(borderSide: BorderSide(color: colorScheme.outlineVariant)),
+                      prefixIcon: const Icon(Icons.key),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: TextField(
+                    controller: _urlController,
+                    decoration: InputDecoration(
+                      labelText: "Target API URL",
+                      border: OutlineInputBorder(borderSide: BorderSide(color: colorScheme.outlineVariant)),
+                      prefixIcon: const Icon(Icons.link),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
+
+            Expanded(
+              child: dashboardState.isAiThinking
+                  ? const Center(child: CircularProgressIndicator())
+                  : dashboardState.error != null
+                  ? Center(child: Text(dashboardState.error!, style: TextStyle(color: colorScheme.error)))
+                  : NativeTestDashboard(targetUrl: _urlController.text.trim()),
+            ),
+
+            const SizedBox(height: 20),
+            Container(
+              decoration: BoxDecoration(
+                border: Border.all(color: colorScheme.outlineVariant),
+                borderRadius: BorderRadius.circular(12),
+                color: colorScheme.surfaceContainer,
+              ),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: TextField(
+                      controller: _promptController,
+                      decoration: const InputDecoration(
+                        hintText: "Type your Agentic API testing goal here...",
+                        border: InputBorder.none,
+                        contentPadding: EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+                      ),
+                      onSubmitted: (_) => _handleSubmit(),
+                    ),
+                  ),
+                  IconButton(
+                    icon: Icon(Icons.send, color: colorScheme.primary),
+                    onPressed: _handleSubmit,
+                  )
+                ],
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/agentic_testing/widgets/native_test_dashboard.dart
+++ b/lib/screens/agentic_testing/widgets/native_test_dashboard.dart
@@ -1,0 +1,223 @@
+import 'package:better_networking/consts.dart';
+import 'package:better_networking/models/http_response_model.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:apidash/models/models.dart';
+
+import '../../../providers/agentic_testing_provider.dart';
+import '../../../providers/agentic_providers.dart';
+import '../../../providers/providers.dart';
+import '../../history/history_details.dart';
+
+class NativeTestDashboard extends ConsumerWidget {
+  final String targetUrl;
+
+  const NativeTestDashboard({super.key, required this.targetUrl});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(agenticDashboardProvider);
+    final colorScheme = Theme.of(context).colorScheme;
+
+    final data = state.dashboardData ?? {};
+    final List<dynamic> tests = data['tests'] ?? [];
+    final results = state.testResults;
+
+    final int passedCount = results.where((r) => r['passed'] == true).length;
+    final int failedCount = results.where((r) => r['passed'] == false).length;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerLowest,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: colorScheme.outlineVariant),
+      ),
+      padding: const EdgeInsets.all(20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                "AGENTIC TESTING DASHBOARD",
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: colorScheme.onSurface),
+              ),
+              if (tests.isNotEmpty)
+                ElevatedButton(
+                  onPressed: state.isExecuting ? null : () {
+                    ref.read(agenticDashboardProvider.notifier).runTests(targetUrl);
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: colorScheme.primary,
+                    foregroundColor: colorScheme.onPrimary,
+                  ),
+                  child: Text(state.isExecuting ? "Executing..." : "Run Tests"),
+                )
+            ],
+          ),
+          const SizedBox(height: 16),
+          Divider(color: colorScheme.outlineVariant),
+          const SizedBox(height: 16),
+
+          // STATS ROW: Neutral backgrounds, text-only color accents
+          Row(
+            children: [
+              _statBox(context, "Total Tests", tests.length.toString(), colorScheme.surfaceContainer),
+              const SizedBox(width: 10),
+              _statBox(context, "Passed", state.isComplete ? passedCount.toString() : "-",
+                  colorScheme.surfaceContainer, // Neutral background
+                  textColor: passedCount > 0 ? Colors.green : colorScheme.onSurface),
+              const SizedBox(width: 10),
+              _statBox(context, "Failed", state.isComplete ? failedCount.toString() : "-",
+                  colorScheme.surfaceContainer, // Neutral background
+                  textColor: failedCount > 0 ? colorScheme.error : colorScheme.onSurface),
+            ],
+          ),
+          const SizedBox(height: 15),
+
+          if (data['explanation'] != null && data['explanation'].toString().isNotEmpty)
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: colorScheme.surfaceContainer, // Clean neutral background
+                border: Border(left: BorderSide(color: colorScheme.secondary, width: 4)),
+                borderRadius: BorderRadius.circular(6),
+              ),
+              child: Text("💡 AI Strategy: ${data['explanation']}", style: TextStyle(fontSize: 13, color: colorScheme.onSurface)),
+            ),
+
+          const SizedBox(height: 15),
+          Expanded(
+            child: ListView.builder(
+              itemCount: tests.length,
+              itemBuilder: (context, index) {
+                final test = tests[index];
+                final result = results.length > index ? results[index] : null;
+
+                Color accentColor = colorScheme.outline;
+                Color cardBg = colorScheme.surfaceContainer;
+
+                if (result != null) {
+                  accentColor = result['passed'] ? Colors.green : colorScheme.error;
+                }
+
+                return Container(
+                  margin: const EdgeInsets.only(bottom: 10),
+                  decoration: BoxDecoration(
+                    color: accentColor, // The Left Border Color
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.only(left: 4), // Expose 4px of the border
+                    child: Material(
+                      color: cardBg, // Solid neutral background
+                      borderRadius: const BorderRadius.horizontal(right: Radius.circular(6)),
+                      child: InkWell(
+                        hoverColor: colorScheme.onSurface.withOpacity(0.05),
+                        onTap: result == null ? null : () => _showNativeDialog(context, ref, result['request_id']),
+                        child: Container(
+                          padding: const EdgeInsets.all(12),
+                          decoration: BoxDecoration(
+                            border: Border.all(color: colorScheme.outlineVariant),
+                            borderRadius: const BorderRadius.horizontal(right: Radius.circular(6)),
+                          ),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.stretch,
+                            children: [
+                              Text(test['title'] ?? 'AI Test', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 13, color: colorScheme.onSurface)),
+                              const SizedBox(height: 4),
+                              Text("Expects: ${test['expected']}", style: TextStyle(color: colorScheme.onSurfaceVariant, fontSize: 12)),
+                              Text("Tested: ${test['method']} ${test['url']}", style: TextStyle(color: colorScheme.primary, fontSize: 11)),
+                              if (result != null) ...[
+                                const SizedBox(height: 6),
+                                Text(
+                                  "${result['passed'] ? '✓ Passed' : '✗ Failed'}: ${result['message']}",
+                                  style: TextStyle(
+                                    color: accentColor, // Colored text for result
+                                    fontWeight: FontWeight.bold,
+                                    fontSize: 12,
+                                  ),
+                                )
+                              ]
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+          )
+        ],
+      ),
+    );
+  }
+
+  Widget _statBox(BuildContext context, String label, String value, Color bgColor, {Color? textColor}) {
+    return Expanded(
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 12),
+        decoration: BoxDecoration(
+          color: bgColor,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: Theme.of(context).colorScheme.outlineVariant),
+        ),
+        child: Column(
+          children: [
+            Text(value, style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: textColor)),
+            Text(label, style: TextStyle(fontSize: 11, color: Theme.of(context).colorScheme.onSurfaceVariant)),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showNativeDialog(BuildContext context, WidgetRef ref, String requestId) {
+    final req = ref.read(agenticCollectionStateNotifierProvider)[requestId];
+    if (req == null) return;
+
+    final historyModel = HistoryRequestModel(
+      historyId: req.id,
+      metaData: HistoryMetaModel(
+        historyId: req.id,
+        requestId: req.id,
+        apiType: req.apiType,
+        name: req.name.split('::').last,
+        url: req.httpRequestModel?.url ?? '',
+        method: req.httpRequestModel?.method ?? HTTPVerb.get,
+        responseStatus: req.responseStatus ?? -1,
+        timeStamp: DateTime.now(),
+      ),
+      httpRequestModel: req.httpRequestModel,
+      httpResponseModel: req.httpResponseModel ?? const HttpResponseModel(),
+    );
+
+    final width = MediaQuery.sizeOf(context).width * 0.85;
+    showDialog(
+      context: context,
+      builder: (ctx) => Dialog(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        child: SizedBox(
+          width: width < 900.0 ? 900.0 : width,
+          height: MediaQuery.sizeOf(context).height * 0.85,
+          child: Column(
+            children: [
+              Align(
+                alignment: Alignment.centerRight,
+                child: IconButton(icon: const Icon(Icons.close), onPressed: () => Navigator.pop(ctx)),
+              ),
+              Expanded(
+                child: ProviderScope(
+                  overrides: [selectedHistoryRequestModelProvider.overrideWith((ref) => historyModel)],
+                  child: const HistoryDetails(),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/dashboard.dart
+++ b/lib/screens/dashboard.dart
@@ -11,6 +11,8 @@ import 'home_page/home_page.dart';
 import 'history/history_page.dart';
 import 'settings_page.dart';
 import 'terminal/terminal_page.dart';
+import 'agentic_testing/agentic_testing_screen.dart';
+import 'agentic_history/agentic_history_screen.dart';
 
 class Dashboard extends ConsumerWidget {
   const Dashboard({super.key});
@@ -82,15 +84,15 @@ class Dashboard extends ConsumerWidget {
                     Badge(
                       backgroundColor: Theme.of(context).colorScheme.error,
                       isLabelVisible:
-                          ref.watch(showTerminalBadgeProvider) && railIdx != 3,
+                      ref.watch(showTerminalBadgeProvider) && railIdx != 3,
                       child: IconButton(
                         tooltip: kLabelLogs,
                         isSelected: railIdx == 3,
                         onPressed: () {
                           ref.read(navRailIndexStateProvider.notifier).state =
-                              3;
+                          3;
                           ref.read(showTerminalBadgeProvider.notifier).state =
-                              false;
+                          false;
                         },
                         icon: const Icon(Icons.terminal_outlined),
                         selectedIcon: const Icon(Icons.terminal),
@@ -98,6 +100,45 @@ class Dashboard extends ConsumerWidget {
                     ),
                     Text(
                       kLabelLogs,
+                      style: Theme.of(context).textTheme.labelSmall,
+                    ),
+                    kVSpacer10,
+                    Badge(
+                      label: const Text(
+                          'NEW',
+                          style: TextStyle(fontSize: 9, fontWeight: FontWeight.bold)
+                      ),
+                      backgroundColor: Theme.of(context).colorScheme.primary,
+                      isLabelVisible: ref.watch(showGenTestBadgeProvider) && railIdx != 4,
+                      offset: const Offset(-4, 2),
+                      child: IconButton(
+                        tooltip: 'Agentic\nTesting',
+                        isSelected: railIdx == 4,
+                        onPressed: () {
+                          ref.read(navRailIndexStateProvider.notifier).state = 4;
+                          ref.read(showGenTestBadgeProvider.notifier).state = false;
+                        },
+                        icon: const Icon(Icons.auto_awesome_outlined),
+                        selectedIcon: const Icon(Icons.auto_awesome),
+                      ),
+                    ),
+                    Text(
+                      'Agentic\nTesting',
+                      style: Theme.of(context).textTheme.labelSmall,
+                    ),
+                    kVSpacer10,
+                    // Agentic History
+                    IconButton(
+                      tooltip: 'Agentic\nHistory',
+                      isSelected: railIdx == 5,
+                      onPressed: () {
+                        ref.read(navRailIndexStateProvider.notifier).state = 5;
+                      },
+                      icon: const Icon(Icons.manage_history_outlined),
+                      selectedIcon: const Icon(Icons.manage_history),
+                    ),
+                    Text(
+                      'Agentic\nHistory',
                       style: Theme.of(context).textTheme.labelSmall,
                     ),
                   ],
@@ -124,7 +165,7 @@ class Dashboard extends ConsumerWidget {
                         padding: const EdgeInsets.only(bottom: 16.0),
                         child: NavbarButton(
                           railIdx: railIdx,
-                          buttonIdx: 4,
+                          buttonIdx: 6,
                           selectedIcon: Icons.settings,
                           icon: Icons.settings_outlined,
                           label: kLabelSettings,
@@ -151,6 +192,8 @@ class Dashboard extends ConsumerWidget {
                   EnvironmentPage(),
                   HistoryPage(),
                   TerminalPage(),
+                  AgenticTestingScreen(),
+                  AgenticHistoryScreen(),
                   SettingsPage(),
                 ],
               ),
@@ -159,18 +202,18 @@ class Dashboard extends ConsumerWidget {
         ),
       ),
       floatingActionButton:
-          isDashBotEnabled && !isDashBotActive && isDashBotPopped
+      isDashBotEnabled && !isDashBotActive && isDashBotPopped
           ? FloatingActionButton(
-              backgroundColor: Theme.of(context).colorScheme.primaryContainer,
-              onPressed: () => showDashbotWindow(context, ref),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(
-                  vertical: 6.0,
-                  horizontal: 10,
-                ),
-                child: DashbotIcons.getDashbotIcon1(),
-              ),
-            )
+        backgroundColor: Theme.of(context).colorScheme.primaryContainer,
+        onPressed: () => showDashbotWindow(context, ref),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            vertical: 6.0,
+            horizontal: 10,
+          ),
+          child: DashbotIcons.getDashbotIcon1(),
+        ),
+      )
           : null,
     );
   }

--- a/lib/screens/home_page/collection_pane.dart
+++ b/lib/screens/home_page/collection_pane.dart
@@ -20,7 +20,7 @@ class CollectionPane extends ConsumerWidget {
     }
     return Padding(
       padding:
-          (!context.isMediumWindow && kIsMacOS ? kPt24l4 : kPt8l4) +
+      (!context.isMediumWindow && kIsMacOS ? kPt24l4 : kPt8l4) +
           (context.isMediumWindow ? kPb70 : EdgeInsets.zero),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -81,7 +81,7 @@ class _RequestListState extends ConsumerState<RequestList> {
     final requestItems = ref.watch(collectionStateNotifierProvider)!;
     final alwaysShowCollectionPaneScrollbar = ref.watch(
       settingsProvider.select(
-        (value) => value.alwaysShowCollectionPaneScrollbar,
+            (value) => value.alwaysShowCollectionPaneScrollbar,
       ),
     );
     final filterQuery = ref
@@ -95,70 +95,71 @@ class _RequestListState extends ConsumerState<RequestList> {
       radius: const Radius.circular(12),
       child: filterQuery.isEmpty
           ? ReorderableListView.builder(
-              padding: context.isMediumWindow
-                  ? EdgeInsets.only(
-                      bottom: MediaQuery.paddingOf(context).bottom,
-                      right: 8,
-                    )
-                  : kPe8,
-              scrollController: controller,
-              buildDefaultDragHandles: false,
-              itemCount: requestSequence.length,
-              onReorder: (int oldIndex, int newIndex) {
-                if (oldIndex < newIndex) {
-                  newIndex -= 1;
-                }
-                if (oldIndex != newIndex) {
-                  ref
-                      .read(collectionStateNotifierProvider.notifier)
-                      .reorder(oldIndex, newIndex);
-                }
-              },
-              itemBuilder: (context, index) {
-                var id = requestSequence[index];
-                if (kIsMobile) {
-                  return ReorderableDelayedDragStartListener(
-                    key: ValueKey(id),
-                    index: index,
-                    child: Padding(
-                      padding: kP1,
-                      child: RequestItem(
-                        id: id,
-                        requestModel: requestItems[id]!,
-                      ),
-                    ),
-                  );
-                }
-                return ReorderableDragStartListener(
-                  key: ValueKey(id),
-                  index: index,
-                  child: Padding(
-                    padding: kP1,
-                    child: RequestItem(id: id, requestModel: requestItems[id]!),
-                  ),
-                );
-              },
-            )
-          : ListView(
-              padding: context.isMediumWindow
-                  ? EdgeInsets.only(
-                      bottom: MediaQuery.paddingOf(context).bottom,
-                      right: 8,
-                    )
-                  : kPe8,
-              controller: controller,
-              children: requestSequence.map((id) {
-                var item = requestItems[id]!;
-                if ((item.getUrl() ?? "").toLowerCase().contains(filterQuery) ||
-                    item.name.toLowerCase().contains(filterQuery)) {
-                  return Padding(
-                    padding: kP1,
-                    child: RequestItem(id: id, requestModel: item),
-                  );
-                }
-                return kSizedBoxEmpty;
-              }).toList(),
+        padding: context.isMediumWindow
+            ? EdgeInsets.only(
+          bottom: MediaQuery.paddingOf(context).bottom,
+          right: 8,
+        )
+            : kPe8,
+        scrollController: controller,
+        buildDefaultDragHandles: false,
+        itemCount: requestSequence.length,
+        onReorder: (int oldIndex, int newIndex) {
+          if (oldIndex < newIndex) {
+            newIndex -= 1;
+          }
+          if (oldIndex != newIndex) {
+            ref
+                .read(collectionStateNotifierProvider.notifier)
+                .reorder(oldIndex, newIndex);
+          }
+        },
+        itemBuilder: (context, index) {
+          var id = requestSequence[index];
+          if (kIsMobile) {
+            return ReorderableDelayedDragStartListener(
+              key: ValueKey(id),
+              index: index,
+              child: Padding(
+                padding: kP1,
+                child: RequestItem(
+                  id: id,
+                  requestModel: requestItems[id]!,
+                ),
+              ),
+            );
+          }
+          return ReorderableDragStartListener(
+            key: ValueKey(id),
+            index: index,
+            child: Padding(
+              padding: kP1,
+              child: RequestItem(id: id, requestModel: requestItems[id]!),
             ),
+          );
+        },
+      )
+          : ListView(
+        padding: context.isMediumWindow
+            ? EdgeInsets.only(
+          bottom: MediaQuery.paddingOf(context).bottom,
+          right: 8,
+        )
+            : kPe8,
+        controller: controller,
+        children: requestSequence.map((id) {
+          final item = requestItems[id];
+          if (item == null) return kSizedBoxEmpty;
+          if ((item.getUrl() ?? "").toLowerCase().contains(filterQuery) ||
+              item.name.toLowerCase().contains(filterQuery)) {
+            return Padding(
+              padding: kP1,
+              child: RequestItem(id: id, requestModel: item),
+            );
+          }
+          return kSizedBoxEmpty;
+        }).toList(),
+      ),
     );
   }
 }
@@ -215,7 +216,7 @@ class RequestItem extends ConsumerWidget {
           ref.read(selectedIdEditStateProvider.notifier).state = id;
           Future.delayed(
             const Duration(milliseconds: 150),
-            () => ref
+                () => ref
                 .read(nameTextFieldFocusNodeProvider.notifier)
                 .state
                 .requestFocus(),

--- a/lib/services/hive_services.dart
+++ b/lib/services/hive_services.dart
@@ -4,6 +4,7 @@ import 'package:hive_ce_flutter/hive_flutter.dart';
 enum HiveBoxType { normal, lazy }
 
 const String kDataBox = "apidash-data";
+const String kAgenticDataBox = "internal_agent_history"; // NEW: Agentic history box constant
 const String kKeyDataBoxIds = "ids";
 
 const String kEnvironmentBox = "apidash-environments";
@@ -18,6 +19,7 @@ const String kKeyDashBotBoxIds = 'messages';
 
 const kHiveBoxes = [
   (kDataBox, HiveBoxType.normal),
+  (kAgenticDataBox, HiveBoxType.normal), // NEW: Ensures the box is opened on startup
   (kEnvironmentBox, HiveBoxType.normal),
   (kHistoryMetaBox, HiveBoxType.normal),
   (kHistoryLazyBox, HiveBoxType.lazy),
@@ -25,9 +27,9 @@ const kHiveBoxes = [
 ];
 
 Future<bool> initHiveBoxes(
-  bool initializeUsingPath,
-  String? workspaceFolderPath,
-) async {
+    bool initializeUsingPath,
+    String? workspaceFolderPath,
+    ) async {
   try {
     if (initializeUsingPath) {
       if (workspaceFolderPath != null) {
@@ -94,18 +96,21 @@ Future<void> deleteHiveBoxes() async {
   }
 }
 
+// The global handler defaults to kDataBox, keeping the main app untouched
 final hiveHandler = HiveHandler();
 
 class HiveHandler {
+  final String boxName; // NEW: dynamic box name variable
   late final Box dataBox;
   late final Box environmentBox;
   late final Box historyMetaBox;
   late final LazyBox historyLazyBox;
   late final LazyBox dashBotBox;
 
-  HiveHandler() {
+  // NEW: Constructor accepts boxName, defaulting to the original kDataBox
+  HiveHandler({this.boxName = kDataBox}) {
     debugPrint("Trying to open Hive boxes");
-    dataBox = Hive.box(kDataBox);
+    dataBox = Hive.box(boxName); // Use the dynamic variable instead of the hardcoded constant
     environmentBox = Hive.box(kEnvironmentBox);
     historyMetaBox = Hive.box(kHistoryMetaBox);
     historyLazyBox = Hive.lazyBox(kHistoryLazyBox);
@@ -117,7 +122,7 @@ class HiveHandler {
 
   dynamic getRequestModel(String id) => dataBox.get(id);
   Future<void> setRequestModel(
-          String id, Map<String, dynamic>? requestModelJson) =>
+      String id, Map<String, dynamic>? requestModelJson) =>
       dataBox.put(id, requestModelJson);
 
   void delete(String key) => dataBox.delete(key);
@@ -128,7 +133,7 @@ class HiveHandler {
 
   dynamic getEnvironment(String id) => environmentBox.get(id);
   Future<void> setEnvironment(
-          String id, Map<String, dynamic>? environmentJson) =>
+      String id, Map<String, dynamic>? environmentJson) =>
       environmentBox.put(id, environmentJson);
 
   Future<void> deleteEnvironment(String id) => environmentBox.delete(id);
@@ -139,7 +144,7 @@ class HiveHandler {
 
   dynamic getHistoryMeta(String id) => historyMetaBox.get(id);
   Future<void> setHistoryMeta(
-          String id, Map<String, dynamic>? historyMetaJson) =>
+      String id, Map<String, dynamic>? historyMetaJson) =>
       historyMetaBox.put(id, historyMetaJson);
 
   Future<void> deleteHistoryMeta(String id) => historyMetaBox.delete(id);
@@ -147,7 +152,7 @@ class HiveHandler {
   Future<dynamic> getHistoryRequest(String id) async =>
       await historyLazyBox.get(id);
   Future<void> setHistoryRequest(
-          String id, Map<String, dynamic>? historyRequestJson) =>
+      String id, Map<String, dynamic>? historyRequestJson) =>
       historyLazyBox.put(id, historyRequestJson);
 
   Future<void> deleteHistoryRequest(String id) => historyLazyBox.delete(id);

--- a/packages/better_networking/example/pubspec.lock
+++ b/packages/better_networking/example/pubspec.lock
@@ -299,10 +299,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   native_toolchain_c:
     dependency: transitive
     description:
@@ -488,10 +488,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:

--- a/packages/json_field_editor/example/pubspec.lock
+++ b/packages/json_field_editor/example/pubspec.lock
@@ -150,10 +150,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -211,10 +211,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:
@@ -232,5 +232,5 @@ packages:
     source: hosted
     version: "15.0.2"
 sdks:
-  dart: ">=3.10.0-0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.24.0"

--- a/packages/multi_trigger_autocomplete_plus/example/pubspec.lock
+++ b/packages/multi_trigger_autocomplete_plus/example/pubspec.lock
@@ -223,10 +223,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   multi_trigger_autocomplete_plus:
     dependency: "direct main"
     description:
@@ -379,10 +379,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -73,6 +73,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.25"
+  audioplayers:
+    dependency: transitive
+    description:
+      name: audioplayers
+      sha256: "1d0c1b1f2095e59080e2d5046639096417a86687d89778da41b0c9a06d683dfd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.7.0"
+  audioplayers_android:
+    dependency: transitive
+    description:
+      name: audioplayers_android
+      sha256: "60a6728277228413a85755bd3ffd6fab98f6555608923813ce383b190a360605"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.2.1"
+  audioplayers_darwin:
+    dependency: transitive
+    description:
+      name: audioplayers_darwin
+      sha256: c994b3bb3a921e4904ac40e013fbc94488e824fd7c1de6326f549943b0b44a91
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.0"
+  audioplayers_linux:
+    dependency: transitive
+    description:
+      name: audioplayers_linux
+      sha256: f75bce1ce864170ef5e6a2c6a61cd3339e1a17ce11e99a25bae4474ea491d001
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.1"
+  audioplayers_platform_interface:
+    dependency: transitive
+    description:
+      name: audioplayers_platform_interface
+      sha256: "0e2f6a919ab56d0fec272e801abc07b26ae7f31980f912f24af4748763e5a656"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.1.1"
+  audioplayers_web:
+    dependency: transitive
+    description:
+      name: audioplayers_web
+      sha256: "24a6f258062bd7da8cb2157e83fccb9816a08dd306cbaaa24f9813d071470545"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.2.1"
+  audioplayers_windows:
+    dependency: transitive
+    description:
+      name: audioplayers_windows
+      sha256: "95f875a96c88c3dbbcb608d4f8288e300b0113d256a81d0b3197fcc18f0dc91a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.1"
   autotrie:
     dependency: transitive
     description:
@@ -317,10 +373,10 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.4+2"
+    version: "0.3.5+2"
   crypto:
     dependency: transitive
     description:
@@ -377,6 +433,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.5.16"
+  decimal:
+    dependency: transitive
+    description:
+      name: decimal
+      sha256: fc706a5618b81e5b367b01dd62621def37abc096f2b46a9bd9068b64c1fa36d0
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.4"
   desktop_drop:
     dependency: "direct main"
     description:
@@ -425,6 +489,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  email_validator:
+    dependency: transitive
+    description:
+      name: email_validator
+      sha256: b19aa5d92fdd76fbc65112060c94d45ba855105a28bb6e462de7ff03b12fa1fb
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   equatable:
     dependency: transitive
     description:
@@ -663,10 +735,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_riverpod
-      sha256: e2026c72738a925a60db30258ff1f29974e40716749f3c9850aabf34ffc1a14c
+      sha256: "4e166be88e1dbbaa34a280bdb744aeae73b7ef25fdf8db7a3bb776760a3648e2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.3.1"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -738,6 +810,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.35.2"
+  genai_primitives:
+    dependency: transitive
+    description:
+      name: genai_primitives
+      sha256: "2468ecd2984f32232ab199315e384821c61a198e356828e34b9a5bcf0fda863e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.3"
+  genui:
+    dependency: "direct main"
+    description:
+      name: genui
+      sha256: be0d9d689e15991c43ef6f1f6aa45a3bdea1ffe2a2259ac0ab38881cf8f346dd
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.0"
   glob:
     dependency: transitive
     description:
@@ -762,6 +850,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.0.2"
+  google_generative_ai:
+    dependency: "direct main"
+    description:
+      name: google_generative_ai
+      sha256: "71f613d0247968992ad87a0eb21650a566869757442ba55a31a81be6746e0d1f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.7"
   graphs:
     dependency: transitive
     description:
@@ -814,10 +910,10 @@ packages:
     dependency: "direct main"
     description:
       name: hooks_riverpod
-      sha256: "402a0969af107ebb42d0300dd68aa48df136671dacb70593d164f04b30af43f4"
+      sha256: "08527ec06aaef75e4b78694e045ef0cd8346594eaf9cc18b0f866398b07b93b1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.3.1"
   hotreloader:
     dependency: transitive
     description:
@@ -943,6 +1039,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.11.0"
+  json_schema_builder:
+    dependency: transitive
+    description:
+      name: json_schema_builder
+      sha256: "65035d48d028401ad0ffc8c2f173209c7b1441e465a942a0f909070fae33170c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3"
   json_serializable:
     dependency: "direct dev"
     description:
@@ -1079,6 +1183,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
+  mcp_dart:
+    dependency: "direct main"
+    description:
+      name: mcp_dart
+      sha256: "777201efc190421e1c86502143379842ed42e16dc8b0ca1c4e8046dc7f7ee5f0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   media_kit:
     dependency: transitive
     description:
@@ -1115,10 +1227,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: "direct main"
     description:
@@ -1447,6 +1559,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  rational:
+    dependency: transitive
+    description:
+      name: rational
+      sha256: cb808fb6f1a839e6fc5f7d8cb3b0a10e1db48b3be102de73938c627f0b636336
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.3"
   recase:
     dependency: transitive
     description:
@@ -1856,26 +1976,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.16"
   textwrap:
     dependency: transitive
     description:
@@ -2040,10 +2160,10 @@ packages:
     dependency: "direct main"
     description:
       name: video_player
-      sha256: "08bfba72e311d48219acad4e191b1f9c27ff8cf928f2c7234874592d9c9d7341"
+      sha256: "48a7bdaa38a3d50ec10c78627abdbfad863fdf6f0d6e08c7c3c040cfd80ae36f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.11.1"
   video_player_android:
     dependency: transitive
     description:
@@ -2076,6 +2196,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.5"
+  video_player_win:
+    dependency: transitive
+    description:
+      name: video_player_win
+      sha256: a4caca55ead1eb469d10060592e7ecdcbcd4493c6e2b63e4e666ff5446c790f1
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   flutter:
     sdk: flutter
   apidash_core: any
+  better_networking: any
   apidash_design_system: any
   carousel_slider: ^5.1.2
   code_builder: ^4.11.1
@@ -86,6 +87,9 @@ dependencies:
     git:
       url: https://github.com/google/flutter-desktop-embedding.git
       path: plugins/window_size
+  mcp_dart: ^2.2.2
+  genui: ^0.9.0
+  google_generative_ai: ^0.4.7
 
 dependency_overrides:
   extended_text_field: ^16.0.0


### PR DESCRIPTION
## PR Description
This PR adds the Agentic Testing Dashboard to API Dash. It introduces a feature that uses the Gemini API to analyze API endpoints, generate test suites based on OpenAPI specifications, and execute those tests within the application. It also integrates a dedicated history system to record these automated test suites. Additionally, this feature relies on the previously created APIDash MCP file to function.

## Features
* **MCP Integration:** Leverages the existing APIDash MCP file to support the agentic testing workflows.
* **OpenAPI Parsing:** Fetches and parses `openapi.json` or `swagger.json` from the target API prior to test generation.
* **Environment Variable Injection:** Reads the user's active workspace variables and applies them to the generated test payloads.
* **Sequential Test Generation:** Generates chained, interdependent tests (e.g., Create, Read, Update, Delete) to maintain state consistency across a suite.
* **In-App Execution:** Runs the generated HTTP tests directly within the API Dash environment.
* **Dedicated History Storage:** Saves test suites automatically to a separate `internal_agent_history` Hive box.
* **Suite Grouping:** Groups historical requests by their generated Suite Name in the Agentic History sidebar.
* **History Integration:** Links generated tests to the native `HistoryDetails` widget to utilize existing syntax highlighting, raw/preview tabs, and workspace duplication features.
* **Native Theming:** Applies API Dash's Material 3 `colorScheme` to the testing dashboard for native Light and Dark mode support.
* **Isolate Processing:** Offloads JSON serialization and UTF-8 byte encoding for HTTP responses to a background isolate via `compute()` to prevent UI thread blocking.
* **Batched Database Writes:** Uses `box.putAll()` to batch write execution history to Hive, reducing disk I/O during large test suites.

## Files Added
* `lib/models/agentic_dashboard_state.dart`
* `lib/providers/agentic_testing_provider.dart`
* `lib/providers/agentic_providers.dart`
* `lib/screens/agentic_testing/agentic_testing_screen.dart`
* `lib/screens/agentic_testing/widgets/native_test_dashboard.dart`
* `lib/screens/agentic_history/agentic_history_screen.dart`

*(Note: While the core MCP files were created in a previous commit, their integration is a critical dependency for this feature's execution).*

## Technical Breakdown

### `lib/models/agentic_dashboard_state.dart`
Defines the immutable data model for the testing UI. It tracks the AI's loading status, error messages, the parsed JSON dashboard data, and the execution results of the tests.

### `lib/providers/agentic_testing_provider.dart`
Houses the Riverpod `StateNotifier` responsible for the core business logic. It handles the Gemini API network calls, constructs the system prompts with the OpenAPI context, triggers test execution, and uses `compute()` to parse HTTP responses in a background isolate.

### `lib/providers/agentic_providers.dart`
Manages the Riverpod providers for the agentic history system. This includes the initialization of the `internal_agent_history` Hive box and the implementation of the `addRequests` method for batched database writes.

### `lib/screens/agentic_testing/agentic_testing_screen.dart`
The main stateful layout for the feature. It manages the text controllers (API key, URL, prompt) and listens to the `agenticDashboardProvider` to swap between loading indicators, error messages, and the rendered test dashboard.

### `lib/screens/agentic_testing/widgets/native_test_dashboard.dart`
A stateless UI component that consumes the parsed test suite data. It renders the suite header, calculates the pass/fail statistics, builds the individual test cards using Material 3 theme constraints, and handles the click events to open the native history dialog.

### `lib/screens/agentic_history/agentic_history_screen.dart`
The UI layout for the new sidebar. It observes the history provider, groups the individual history records by their parent suite name, and renders the list view for past agentic executions.