### PR TITLE
fix(security): escape OAuth error parameters and enforce callback path

### DIFF
--- a/packages/better_networking/lib/services/oauth_callback_server.dart
+++ b/packages/better_networking/lib/services/oauth_callback_server.dart
@@ -1,6 +1,11 @@
 import 'dart:io';
 import 'dart:async';
+import 'dart:convert' show HtmlEscape;
 import 'dart:developer' show log;
+
+/// Escapes text that originates from the authorization server's query
+/// parameters before it is written into the response page.
+const _htmlEscape = HtmlEscape();
 
 /// A lightweight HTTP server for handling OAuth callbacks on desktop platforms.
 /// This provides a standard localhost callback URL that's compatible with most OAuth providers.
@@ -166,8 +171,20 @@ class OAuthCallbackServer {
         return;
       }
 
-      // Check if this is an authorization callback (has 'code' or 'error' parameters)
       final uri = request.uri;
+
+      // Only the registered callback path is served. Anything else is a stray
+      // request and must not be able to complete the OAuth flow.
+      if (_path != null && uri.path != _path) {
+        request.response
+          ..statusCode = HttpStatus.notFound
+          ..headers.contentType = ContentType.text
+          ..write('Not Found')
+          ..close();
+        return;
+      }
+
+      // Check if this is an authorization callback (has 'code' or 'error' parameters)
       final hasCode = uri.queryParameters.containsKey('code');
       final hasError = uri.queryParameters.containsKey('error');
 
@@ -318,8 +335,8 @@ class OAuthCallbackServer {
       Please try again from API Dash.
     </div>
     <div class="details">
-      <strong>Error:</strong> $error<br>
-      <strong>Description:</strong> $errorDescription
+      <strong>Error:</strong> ${_htmlEscape.convert(error)}<br>
+      <strong>Description:</strong> ${_htmlEscape.convert(errorDescription)}
     </div>
     <div class="countdown" id="countdown">This window will close automatically in <span id="timer">10</span> seconds...</div>
   </div>


### PR DESCRIPTION
## PR Description

This PR addresses two security and isolation improvements in `OAuthCallbackServer`:
1. **HTML-escapes error parameters:** In `_generateErrorHtml`, the `error` and `error_description` query parameters were interpolated raw into the HTML response. They are now sanitized using `HtmlEscape().convert()`.
2. **Validates callback path:** `_handleRequest` now checks that `request.uri.path == _path` and returns a 404 for any other path. This ensures random localhost requests on the port cannot interact with the OAuth callback flow.

## Related Issues

- Fixes unescaped query parameter reflection in OAuth error page and adds callback path enforcement

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [ ] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [ ] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Involves ephemeral desktop loopback server socket lifecycle; verified path routing and escaping directly.

## OS on which you have developed and tested the feature?

- [x] macOS
- [ ] Windows
- [ ] Linux
