### PR TITLE
fix: log agent governor exceptions

### DIFF
--- a/packages/genai/lib/agentic_engine/agent_service.dart
+++ b/packages/genai/lib/agentic_engine/agent_service.dart
@@ -60,7 +60,7 @@ class AIAgentService {
           }
         }
       } catch (e) {
-        "AIAgentService::Governor: Exception Occurred: $e";
+        debugPrint("AIAgentService::Governor: Exception Occurred: $e");
       }
       // Exponential Backoff
       if (RETRY_COUNT < backoffDelays.length) {


### PR DESCRIPTION
## Summary

- Log exceptions caught by `AIAgentService._governor` using the existing `debugPrint` convention.
- Preserve the existing retry and return behavior.

## Problem

`AIAgentService._governor` was constructing an exception message as a discarded string, so agent failures were retried without any diagnostic output.

## Fix

Route the existing exception message through `debugPrint`.

## Testing

- `flutter test packages/genai/test/agentic_engine/agent_service_test.dart`
- All 3 tests passed.