### PR TITLE
fix: WebSocket Recently Sent dedupe, count, scroll, full-text view, hide heartbeats (#1750, #1751, #1752)

### DIFF
--- a/lib/models/ws_request_model.dart
+++ b/lib/models/ws_request_model.dart
@@ -10,13 +10,16 @@ enum WebSocketMessageType { connected, sent, received, error, disconnected }
 ///
 /// Each message carries a [payload] (the raw text), a [timestamp], whether it
 /// was [outgoing] (sent by the client) or incoming (received from the server),
-/// and a [messageType] that categorises the event for display in the UI log.
+/// whether it [isAutomatic] (sent by the app, e.g. a repeating heartbeat
+/// message, rather than by the user), and a [messageType] that categorises the
+/// event for display in the UI log.
 @freezed
 abstract class WebSocketMessage with _$WebSocketMessage {
   const factory WebSocketMessage({
     required String payload,
     DateTime? timestamp,
     @Default(true) bool outgoing,
+    @Default(false) bool isAutomatic,
     @Default(WebSocketMessageType.received) WebSocketMessageType messageType,
   }) = _WebSocketMessage;
 

--- a/lib/models/ws_request_model.freezed.dart
+++ b/lib/models/ws_request_model.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$WebSocketMessage {
 
- String get payload; DateTime? get timestamp; bool get outgoing; WebSocketMessageType get messageType;
+ String get payload; DateTime? get timestamp; bool get outgoing; bool get isAutomatic; WebSocketMessageType get messageType;
 /// Create a copy of WebSocketMessage
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $WebSocketMessageCopyWith<WebSocketMessage> get copyWith => _$WebSocketMessageCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is WebSocketMessage&&(identical(other.payload, payload) || other.payload == payload)&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.outgoing, outgoing) || other.outgoing == outgoing)&&(identical(other.messageType, messageType) || other.messageType == messageType));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is WebSocketMessage&&(identical(other.payload, payload) || other.payload == payload)&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.outgoing, outgoing) || other.outgoing == outgoing)&&(identical(other.isAutomatic, isAutomatic) || other.isAutomatic == isAutomatic)&&(identical(other.messageType, messageType) || other.messageType == messageType));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,payload,timestamp,outgoing,messageType);
+int get hashCode => Object.hash(runtimeType,payload,timestamp,outgoing,isAutomatic,messageType);
 
 @override
 String toString() {
-  return 'WebSocketMessage(payload: $payload, timestamp: $timestamp, outgoing: $outgoing, messageType: $messageType)';
+  return 'WebSocketMessage(payload: $payload, timestamp: $timestamp, outgoing: $outgoing, isAutomatic: $isAutomatic, messageType: $messageType)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $WebSocketMessageCopyWith<$Res>  {
   factory $WebSocketMessageCopyWith(WebSocketMessage value, $Res Function(WebSocketMessage) _then) = _$WebSocketMessageCopyWithImpl;
 @useResult
 $Res call({
- String payload, DateTime? timestamp, bool outgoing, WebSocketMessageType messageType
+ String payload, DateTime? timestamp, bool outgoing, bool isAutomatic, WebSocketMessageType messageType
 });
 
 
@@ -65,11 +65,12 @@ class _$WebSocketMessageCopyWithImpl<$Res>
 
 /// Create a copy of WebSocketMessage
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? payload = null,Object? timestamp = freezed,Object? outgoing = null,Object? messageType = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? payload = null,Object? timestamp = freezed,Object? outgoing = null,Object? isAutomatic = null,Object? messageType = null,}) {
   return _then(_self.copyWith(
 payload: null == payload ? _self.payload : payload // ignore: cast_nullable_to_non_nullable
 as String,timestamp: freezed == timestamp ? _self.timestamp : timestamp // ignore: cast_nullable_to_non_nullable
 as DateTime?,outgoing: null == outgoing ? _self.outgoing : outgoing // ignore: cast_nullable_to_non_nullable
+as bool,isAutomatic: null == isAutomatic ? _self.isAutomatic : isAutomatic // ignore: cast_nullable_to_non_nullable
 as bool,messageType: null == messageType ? _self.messageType : messageType // ignore: cast_nullable_to_non_nullable
 as WebSocketMessageType,
   ));
@@ -156,10 +157,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String payload,  DateTime? timestamp,  bool outgoing,  WebSocketMessageType messageType)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String payload,  DateTime? timestamp,  bool outgoing,  bool isAutomatic,  WebSocketMessageType messageType)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _WebSocketMessage() when $default != null:
-return $default(_that.payload,_that.timestamp,_that.outgoing,_that.messageType);case _:
+return $default(_that.payload,_that.timestamp,_that.outgoing,_that.isAutomatic,_that.messageType);case _:
   return orElse();
 
 }
@@ -177,10 +178,10 @@ return $default(_that.payload,_that.timestamp,_that.outgoing,_that.messageType);
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String payload,  DateTime? timestamp,  bool outgoing,  WebSocketMessageType messageType)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String payload,  DateTime? timestamp,  bool outgoing,  bool isAutomatic,  WebSocketMessageType messageType)  $default,) {final _that = this;
 switch (_that) {
 case _WebSocketMessage():
-return $default(_that.payload,_that.timestamp,_that.outgoing,_that.messageType);case _:
+return $default(_that.payload,_that.timestamp,_that.outgoing,_that.isAutomatic,_that.messageType);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -197,10 +198,10 @@ return $default(_that.payload,_that.timestamp,_that.outgoing,_that.messageType);
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String payload,  DateTime? timestamp,  bool outgoing,  WebSocketMessageType messageType)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String payload,  DateTime? timestamp,  bool outgoing,  bool isAutomatic,  WebSocketMessageType messageType)?  $default,) {final _that = this;
 switch (_that) {
 case _WebSocketMessage() when $default != null:
-return $default(_that.payload,_that.timestamp,_that.outgoing,_that.messageType);case _:
+return $default(_that.payload,_that.timestamp,_that.outgoing,_that.isAutomatic,_that.messageType);case _:
   return null;
 
 }
@@ -212,12 +213,13 @@ return $default(_that.payload,_that.timestamp,_that.outgoing,_that.messageType);
 @JsonSerializable()
 
 class _WebSocketMessage implements WebSocketMessage {
-  const _WebSocketMessage({required this.payload, this.timestamp, this.outgoing = true, this.messageType = WebSocketMessageType.received});
+  const _WebSocketMessage({required this.payload, this.timestamp, this.outgoing = true, this.isAutomatic = false, this.messageType = WebSocketMessageType.received});
   factory _WebSocketMessage.fromJson(Map<String, dynamic> json) => _$WebSocketMessageFromJson(json);
 
 @override final  String payload;
 @override final  DateTime? timestamp;
 @override@JsonKey() final  bool outgoing;
+@override@JsonKey() final  bool isAutomatic;
 @override@JsonKey() final  WebSocketMessageType messageType;
 
 /// Create a copy of WebSocketMessage
@@ -233,16 +235,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _WebSocketMessage&&(identical(other.payload, payload) || other.payload == payload)&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.outgoing, outgoing) || other.outgoing == outgoing)&&(identical(other.messageType, messageType) || other.messageType == messageType));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _WebSocketMessage&&(identical(other.payload, payload) || other.payload == payload)&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.outgoing, outgoing) || other.outgoing == outgoing)&&(identical(other.isAutomatic, isAutomatic) || other.isAutomatic == isAutomatic)&&(identical(other.messageType, messageType) || other.messageType == messageType));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,payload,timestamp,outgoing,messageType);
+int get hashCode => Object.hash(runtimeType,payload,timestamp,outgoing,isAutomatic,messageType);
 
 @override
 String toString() {
-  return 'WebSocketMessage(payload: $payload, timestamp: $timestamp, outgoing: $outgoing, messageType: $messageType)';
+  return 'WebSocketMessage(payload: $payload, timestamp: $timestamp, outgoing: $outgoing, isAutomatic: $isAutomatic, messageType: $messageType)';
 }
 
 
@@ -253,7 +255,7 @@ abstract mixin class _$WebSocketMessageCopyWith<$Res> implements $WebSocketMessa
   factory _$WebSocketMessageCopyWith(_WebSocketMessage value, $Res Function(_WebSocketMessage) _then) = __$WebSocketMessageCopyWithImpl;
 @override @useResult
 $Res call({
- String payload, DateTime? timestamp, bool outgoing, WebSocketMessageType messageType
+ String payload, DateTime? timestamp, bool outgoing, bool isAutomatic, WebSocketMessageType messageType
 });
 
 
@@ -270,11 +272,12 @@ class __$WebSocketMessageCopyWithImpl<$Res>
 
 /// Create a copy of WebSocketMessage
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? payload = null,Object? timestamp = freezed,Object? outgoing = null,Object? messageType = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? payload = null,Object? timestamp = freezed,Object? outgoing = null,Object? isAutomatic = null,Object? messageType = null,}) {
   return _then(_WebSocketMessage(
 payload: null == payload ? _self.payload : payload // ignore: cast_nullable_to_non_nullable
 as String,timestamp: freezed == timestamp ? _self.timestamp : timestamp // ignore: cast_nullable_to_non_nullable
 as DateTime?,outgoing: null == outgoing ? _self.outgoing : outgoing // ignore: cast_nullable_to_non_nullable
+as bool,isAutomatic: null == isAutomatic ? _self.isAutomatic : isAutomatic // ignore: cast_nullable_to_non_nullable
 as bool,messageType: null == messageType ? _self.messageType : messageType // ignore: cast_nullable_to_non_nullable
 as WebSocketMessageType,
   ));

--- a/lib/models/ws_request_model.g.dart
+++ b/lib/models/ws_request_model.g.dart
@@ -13,6 +13,7 @@ _WebSocketMessage _$WebSocketMessageFromJson(Map<String, dynamic> json) =>
           ? null
           : DateTime.parse(json['timestamp'] as String),
       outgoing: json['outgoing'] as bool? ?? true,
+      isAutomatic: json['isAutomatic'] as bool? ?? false,
       messageType:
           $enumDecodeNullable(
             _$WebSocketMessageTypeEnumMap,
@@ -26,6 +27,7 @@ Map<String, dynamic> _$WebSocketMessageToJson(_WebSocketMessage instance) =>
       'payload': instance.payload,
       'timestamp': instance.timestamp?.toIso8601String(),
       'outgoing': instance.outgoing,
+      'isAutomatic': instance.isAutomatic,
       'messageType': _$WebSocketMessageTypeEnumMap[instance.messageType]!,
     };
 

--- a/lib/providers/collection_providers.dart
+++ b/lib/providers/collection_providers.dart
@@ -448,14 +448,18 @@ class CollectionStateNotifier
           final substituted =
               substituteVariables(ws.messageHeartbeatPayload, combined) ??
                   ws.messageHeartbeatPayload;
-          sendWebSocketMessage(requestId, substituted);
+          sendWebSocketMessage(requestId, substituted, isAutomatic: true);
         },
       );
     }
   }
 
   /// Send a text message over an active WebSocket connection.
-  void sendWebSocketMessage(String requestId, String message) {
+  ///
+  /// [isAutomatic] marks messages sent by the app (repeating heartbeat) rather
+  /// than by the user, so the UI can keep them out of "Recently Sent".
+  void sendWebSocketMessage(String requestId, String message,
+      {bool isAutomatic = false}) {
     final currentRequest = state?[requestId];
     if (currentRequest == null || currentRequest.apiType != APIType.websocket) {
       return;
@@ -476,6 +480,7 @@ class CollectionStateNotifier
         payload: message,
         timestamp: DateTime.now(),
         outgoing: true,
+        isAutomatic: isAutomatic,
         messageType: WebSocketMessageType.sent,
       );
 

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/ws/ws_recently_sent.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/ws/ws_recently_sent.dart
@@ -30,7 +30,7 @@ class WsRecentlySent extends ConsumerWidget {
         const <WebSocketMessage>[];
 
     final sentHistory = messageHistory
-        .where((m) => m.outgoing && m.messageType == WebSocketMessageType.sent && m.payload != "Heartbeat ping")
+        .where((m) => m.outgoing && m.messageType == WebSocketMessageType.sent && !m.isAutomatic)
         .map((m) => m.payload)
         .toList()
         .reversed

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/ws/ws_recently_sent.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/ws/ws_recently_sent.dart
@@ -1,8 +1,10 @@
 import 'package:apidash_design_system/apidash_design_system.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:apidash/consts.dart';
 import 'package:apidash/models/models.dart';
 import 'package:apidash/providers/providers.dart';
+import 'package:apidash/widgets/widgets.dart';
 
 /// "Recently Sent" strip below the message composer. Extracted into its own
 /// widget so the `messageHistory` watch (which changes on every incoming WS
@@ -67,11 +69,7 @@ class WsRecentlySent extends ConsumerWidget {
 
                 final title = matchingTemplate?["name"];
 
-                return Tooltip(
-                  message: payload,
-                  waitDuration: const Duration(milliseconds: 600),
-                  textStyle: kCodeStyle.copyWith(fontSize: 11),
-                  child: Material(
+                return Material(
                     type: MaterialType.transparency,
                     clipBehavior: Clip.antiAlias,
                     borderRadius: BorderRadius.circular(8),
@@ -134,6 +132,15 @@ class WsRecentlySent extends ConsumerWidget {
                                       ),
                                     ),
                               ),
+                              // Long payloads are truncated by the card, so a
+                              // "View" button opens the full text in a dialog.
+                              ADIconButton(
+                                icon: Icons.open_in_full,
+                                iconSize: 14,
+                                tooltip: "View full message",
+                                visualDensity: VisualDensity.compact,
+                                onPressed: () => _showFullMessage(context, payload),
+                              ),
                             ],
                           ),
                           const SizedBox(height: 8),
@@ -148,12 +155,33 @@ class WsRecentlySent extends ConsumerWidget {
                       ),
                     ),
                   ),
-                  ),
                 );
               },
             ),
           ),
       ],
+    );
+  }
+
+  void _showFullMessage(BuildContext context, String payload) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text("Sent message"),
+        content: SizedBox(
+          width: 600,
+          child: SingleChildScrollView(
+            child: SelectableText(payload, style: kCodeStyle.copyWith(fontSize: 12)),
+          ),
+        ),
+        actions: [
+          CopyButton(toCopy: payload),
+          ADTextButton(
+            label: kLabelClose,
+            onPressed: () => Navigator.of(context).pop(),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/screens/home_page/editor_pane/details_card/request_pane/ws/ws_recently_sent.dart
+++ b/lib/screens/home_page/editor_pane/details_card/request_pane/ws/ws_recently_sent.dart
@@ -1,6 +1,8 @@
 import 'package:apidash_design_system/apidash_design_system.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:apidash/models/models.dart';
 import 'package:apidash/providers/providers.dart';
 
@@ -8,7 +10,7 @@ import 'package:apidash/providers/providers.dart';
 /// widget so the `messageHistory` watch (which changes on every incoming WS
 /// frame) lives here instead of in the composer — keeping the composer from
 /// rebuilding (and reseeding `TextFieldEditor`) while the user is typing.
-class WsRecentlySent extends ConsumerWidget {
+class WsRecentlySent extends HookConsumerWidget {
   final List<Map<String, String>> templates;
   final void Function(String payload) onReuse;
   final void Function(String name, String payload) onSaveTemplate;
@@ -29,13 +31,20 @@ class WsRecentlySent extends ConsumerWidget {
             .select((value) => value?.wsRequestModel?.messageHistory)) ??
         const <WebSocketMessage>[];
 
-    final sentHistory = messageHistory
+    // Newest-first, deduped by payload (map keeps insertion order, so a
+    // repeat keeps its latest slot) and counted so the card can show "×N".
+    final sentCounts = <String, int>{};
+    for (final payload in messageHistory
         .where((m) => m.outgoing && m.messageType == WebSocketMessageType.sent && m.payload != "Heartbeat ping")
         .map((m) => m.payload)
         .toList()
-        .reversed
-        .take(10)
-        .toList();
+        .reversed) {
+      sentCounts.update(payload, (n) => n + 1, ifAbsent: () => 1);
+    }
+    final sentHistory = sentCounts.keys.take(10).toList();
+    // Horizontal strip on desktop: visible draggable bar, mouse drag, and a
+    // plain wheel (no Shift) scrolls sideways.
+    final scrollController = useScrollController();
 
     return Column(
       mainAxisSize: MainAxisSize.min,
@@ -53,7 +62,23 @@ class WsRecentlySent extends ConsumerWidget {
         else
           SizedBox(
             height: 100,
-            child: ListView.separated(
+            child: Listener(
+              onPointerSignal: (e) {
+                if (e is PointerScrollEvent && e.scrollDelta.dy != 0 && scrollController.hasClients) {
+                  scrollController.jumpTo((scrollController.offset + e.scrollDelta.dy)
+                      .clamp(0.0, scrollController.position.maxScrollExtent));
+                }
+              },
+              child: Scrollbar(
+                controller: scrollController,
+                thumbVisibility: true,
+                child: ScrollConfiguration(
+                  behavior: ScrollConfiguration.of(context).copyWith(
+                    dragDevices: {PointerDeviceKind.mouse, PointerDeviceKind.touch, PointerDeviceKind.trackpad},
+                  ),
+                  child: ListView.separated(
+              controller: scrollController,
+              padding: const EdgeInsets.only(bottom: 8),
               scrollDirection: Axis.horizontal,
               itemCount: sentHistory.length,
               separatorBuilder: (_, __) => kHSpacer10,
@@ -134,6 +159,16 @@ class WsRecentlySent extends ConsumerWidget {
                                       ),
                                     ),
                               ),
+                              if (sentCounts[payload]! > 1)
+                                Padding(
+                                  padding: const EdgeInsets.only(left: 6, top: 2),
+                                  child: Text(
+                                    "×${sentCounts[payload]}",
+                                    style: kTextStyleButtonSmall.copyWith(
+                                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                                    ),
+                                  ),
+                                ),
                             ],
                           ),
                           const SizedBox(height: 8),
@@ -151,6 +186,9 @@ class WsRecentlySent extends ConsumerWidget {
                   ),
                 );
               },
+            ),
+                ),
+              ),
             ),
           ),
       ],

--- a/test/models/ws_request_models.dart
+++ b/test/models/ws_request_models.dart
@@ -12,6 +12,7 @@ const wsMessage1Json = {
   'payload': 'Hello',
   'timestamp': '2023-01-01T00:00:00.000',
   'outgoing': true,
+  'isAutomatic': false,
   'messageType': 'sent',
 };
 
@@ -26,6 +27,7 @@ const wsMessage2Json = {
   'payload': 'Hi',
   'timestamp': '2023-01-01T00:00:00.000',
   'outgoing': false,
+  'isAutomatic': false,
   'messageType': 'received',
 };
 
@@ -57,6 +59,7 @@ const wsRequestModel1Json = {
       'payload': 'Ping',
       'timestamp': '2023-01-01T00:00:00.000',
       'outgoing': true,
+      'isAutomatic': false,
       'messageType': 'sent',
     },
   ],
@@ -109,6 +112,7 @@ const wsMessageNullTimestampJson = {
   'payload': 'NoTime',
   'timestamp': null,
   'outgoing': false,
+  'isAutomatic': false,
   'messageType': 'error',
 };
 
@@ -121,6 +125,7 @@ const wsMessageConnectedJson = {
   'payload': 'conn',
   'timestamp': null,
   'outgoing': true,
+  'isAutomatic': false,
   'messageType': 'connected',
 };
 
@@ -132,6 +137,7 @@ const wsMessageSentJson = {
   'payload': 'snt',
   'timestamp': null,
   'outgoing': true,
+  'isAutomatic': false,
   'messageType': 'sent',
 };
 
@@ -143,6 +149,7 @@ const wsMessageReceivedJson = {
   'payload': 'rcv',
   'timestamp': null,
   'outgoing': true,
+  'isAutomatic': false,
   'messageType': 'received',
 };
 
@@ -154,6 +161,7 @@ const wsMessageErrorJson = {
   'payload': 'err',
   'timestamp': null,
   'outgoing': true,
+  'isAutomatic': false,
   'messageType': 'error',
 };
 
@@ -165,6 +173,7 @@ const wsMessageDisconnectedJson = {
   'payload': 'disc',
   'timestamp': null,
   'outgoing': true,
+  'isAutomatic': false,
   'messageType': 'disconnected',
 };
 
@@ -198,18 +207,21 @@ const wsRequestModelMultiHistoryJson = {
       'payload': 'first',
       'timestamp': '2023-01-01T00:00:00.000',
       'outgoing': true,
+      'isAutomatic': false,
       'messageType': 'sent',
     },
     {
       'payload': 'second',
       'timestamp': '2023-01-02T00:00:00.000',
       'outgoing': false,
+      'isAutomatic': false,
       'messageType': 'received',
     },
     {
       'payload': 'third',
       'timestamp': null,
       'outgoing': true,
+      'isAutomatic': false,
       'messageType': 'error',
     },
   ],

--- a/test/screens/home_page/editor_pane/details_card/request_pane/ws/ws_recently_sent_test.dart
+++ b/test/screens/home_page/editor_pane/details_card/request_pane/ws/ws_recently_sent_test.dart
@@ -1,0 +1,58 @@
+import 'package:apidash/models/models.dart';
+import 'package:apidash/providers/providers.dart';
+import 'package:apidash/screens/home_page/editor_pane/details_card/request_pane/ws/ws_recently_sent.dart';
+import 'package:apidash_core/apidash_core.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+      'Recently Sent hides automatic (heartbeat) messages with any payload',
+      (tester) async {
+    const keepalive = '{"type":"keepalive"}';
+    final history = [
+      WebSocketMessage(
+        payload: 'hi',
+        timestamp: DateTime(2026, 1, 1),
+        messageType: WebSocketMessageType.sent,
+      ),
+      WebSocketMessage(
+        payload: keepalive,
+        timestamp: DateTime(2026, 1, 1, 0, 0, 2),
+        isAutomatic: true,
+        messageType: WebSocketMessageType.sent,
+      ),
+    ];
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          selectedRequestModelProvider.overrideWith(
+            (ref) => RequestModel(
+              id: 'ws',
+              apiType: APIType.websocket,
+              wsRequestModel: WebSocketRequestModel(
+                enableMessageHeartbeat: true,
+                messageHeartbeatPayload: keepalive,
+                messageHistory: history,
+              ),
+            ),
+          ),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: WsRecentlySent(
+              templates: const [],
+              onReuse: (_) {},
+              onSaveTemplate: (_, __) {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('hi'), findsOneWidget);
+    expect(find.text(keepalive), findsNothing);
+  });
+}

--- a/test/screens/home_page/editor_pane/details_card/request_pane/ws/ws_recently_sent_test.dart
+++ b/test/screens/home_page/editor_pane/details_card/request_pane/ws/ws_recently_sent_test.dart
@@ -1,0 +1,57 @@
+import 'package:apidash/models/request_model.dart';
+import 'package:apidash/models/ws_request_model.dart';
+import 'package:apidash/providers/collection_providers.dart';
+import 'package:apidash/screens/home_page/editor_pane/details_card/request_pane/ws/ws_recently_sent.dart';
+import 'package:apidash_core/apidash_core.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Recently Sent dedupes repeated payloads, most recent first',
+      (tester) async {
+    const sent = WebSocketMessageType.sent;
+    final requestModel = RequestModel(
+      id: 'ws-1',
+      apiType: APIType.websocket,
+      wsRequestModel: const WebSocketRequestModel(
+        messageHistory: [
+          WebSocketMessage(payload: 'hi', messageType: sent),
+          WebSocketMessage(payload: 'hello', messageType: sent),
+          WebSocketMessage(payload: 'hi', messageType: sent),
+          WebSocketMessage(payload: 'hi', messageType: sent),
+        ],
+      ),
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          selectedRequestModelProvider.overrideWith((ref) => requestModel),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: WsRecentlySent(
+              templates: const [],
+              onReuse: (_) {},
+              onSaveTemplate: (_, __) {},
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('hi'), findsOneWidget);
+    expect(find.text('hello'), findsOneWidget);
+    // Send count shown only on the repeated card.
+    expect(find.text('\u00d73'), findsOneWidget);
+    expect(find.textContaining('\u00d7'), findsOneWidget);
+    expect(find.byType(Scrollbar), findsOneWidget);
+    // Most recent send comes first.
+    expect(
+      tester.getTopLeft(find.text('hi')).dx,
+      lessThan(tester.getTopLeft(find.text('hello')).dx),
+    );
+  });
+}

--- a/test/screens/home_page/editor_pane/details_card/request_pane/ws_recently_sent_test.dart
+++ b/test/screens/home_page/editor_pane/details_card/request_pane/ws_recently_sent_test.dart
@@ -1,0 +1,60 @@
+import 'package:apidash/models/models.dart';
+import 'package:apidash/providers/providers.dart';
+import 'package:apidash/screens/home_page/editor_pane/details_card/request_pane/ws/ws_recently_sent.dart';
+import 'package:apidash_core/apidash_core.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Recently Sent card opens the full long message in a dialog',
+      (tester) async {
+    final longPayload =
+        '{\n${List.generate(40, (i) => '  "key$i": "value$i"').join(',\n')}\n}';
+    String? reused;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          selectedRequestModelProvider.overrideWith(
+            (ref) => RequestModel(
+              id: 'ws',
+              apiType: APIType.websocket,
+              wsRequestModel: WebSocketRequestModel(
+                url: 'wss://example.com',
+                messageHistory: [
+                  WebSocketMessage(
+                    payload: longPayload,
+                    outgoing: true,
+                    messageType: WebSocketMessageType.sent,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: WsRecentlySent(
+              templates: const [],
+              onReuse: (p) => reused = p,
+              onSaveTemplate: (_, __) {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Tapping the card still loads the message into the editor.
+    await tester.tap(find.byType(InkWell).first);
+    expect(reused, longPayload);
+    expect(find.byType(AlertDialog), findsNothing);
+
+    // The "View" button opens the whole payload, selectable, with Copy.
+    await tester.tap(find.byTooltip('View full message'));
+    await tester.pumpAndSettle();
+    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(find.widgetWithText(SelectableText, longPayload), findsOneWidget);
+    expect(find.text('Copy'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## PR Description

WebSocket "Recently Sent" strip fixes.

- Duplicate payloads collapse into one card that shows a "×N" send count.
- Strip scrolls with the mouse wheel, click-drag, and a visible scrollbar.
- Each card has an expand button that opens the full message with Copy; the hover tooltip is gone.
- Automatic heartbeat messages are flagged `isAutomatic` and hidden from the strip.

## Related Issues

- Closes #1750
- Closes #1751
- Closes #1752

## Video Demo

- 

### Checklist
- [x] I have gone through the [contributing guide](https://github.com/foss42/apidash/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] I am using the latest Flutter stable branch (run `flutter upgrade` and verify)
- [x] I have run the tests (`flutter test`) and all tests are passing

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_

## OS on which you have developed and tested the feature?

- [ ] Windows
- [ ] macOS
- [x] Linux
